### PR TITLE
Fixed 8muses ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -84,13 +84,13 @@ public class EightmusesRipper extends AbstractHTMLRipper {
         List<String> imageURLs = new ArrayList<String>();
         // get the first image link on the page and check if the last char in it is a number
         // if it is a number then we're ripping a comic if not it's a subalbum
-        String firstImageLink = page.select(".page-gallery > div > div > div.gallery > a.t-hover").first().attr("href");
+        String firstImageLink = page.select("div.gallery > a.t-hover").first().attr("href");
         Pattern p = Pattern.compile("/comix/([a-zA-Z0-9\\-_/]*/)?\\d+");
         Matcher m = p.matcher(firstImageLink);
         if (!m.matches()) {
             logger.info("Ripping subalbums");
             // Page contains subalbums (not images)
-            Elements albumElements = page.select(".page-gallery > div > div > div.gallery > a.t-hover");
+            Elements albumElements = page.select("div.gallery > a.t-hover");
             List<Element> albumsList = albumElements.subList(0, albumElements.size());
             Collections.reverse(albumsList);
             // Iterate over elements in reverse order
@@ -173,7 +173,7 @@ public class EightmusesRipper extends AbstractHTMLRipper {
         sendUpdate(STATUS.LOADING_RESOURCE, imageUrl);
         Document doc = new Http(imageUrl).get(); // Retrieve the webpage  of the image URL
         Element fullSizeImage = doc.select(".photo").first(); // Select the "photo" element from the page (there should only be 1)
-        String path = "https://cdn.ampproject.org/i/s/www.8muses.com/data/fu/small/" + fullSizeImage.children().select("#imageName").attr("value"); // Append the path to the fullsize image file to the standard prefix
+        String path = "https://cdn.ampproject.org/i/s/www.8muses.com/data/ufu/small/" + fullSizeImage.children().select("#imageName").attr("value"); // Append the path to the fullsize image file to the standard prefix
         return path;
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -100,10 +100,10 @@ public class EightmusesRipper extends AbstractHTMLRipper {
                 if (subUrl != "") {
                     subUrl = subUrl.replaceAll("\\.\\./", "");
                     if (subUrl.startsWith("//")) {
-                        subUrl = "http:";
+                        subUrl = "https:";
                     }
                     else if (!subUrl.startsWith("http://")) {
-                        subUrl = "http://www.8muses.com" + subUrl;
+                        subUrl = "https://www.8muses.com" + subUrl;
                     }
                     try {
                         logger.info("Retrieving " + subUrl);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -173,7 +173,9 @@ public class EightmusesRipper extends AbstractHTMLRipper {
         sendUpdate(STATUS.LOADING_RESOURCE, imageUrl);
         Document doc = new Http(imageUrl).get(); // Retrieve the webpage  of the image URL
         Element fullSizeImage = doc.select(".photo").first(); // Select the "photo" element from the page (there should only be 1)
-        String path = "https://cdn.ampproject.org/i/s/www.8muses.com/data/ufu/small/" + fullSizeImage.children().select("#imageName").attr("value"); // Append the path to the fullsize image file to the standard prefix
+        // subdir is the sub dir the cdn has the image stored in
+        String subdir = doc.select("input#imageDir").first().attr("value");
+        String path = "https://cdn.ampproject.org/i/s/www.8muses.com/" + subdir + "small/" + fullSizeImage.children().select("#imageName").attr("value"); // Append the path to the fullsize image file to the standard prefix
         return path;
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -85,7 +85,7 @@ public class EightmusesRipper extends AbstractHTMLRipper {
         // get the first image link on the page and check if the last char in it is a number
         // if it is a number then we're ripping a comic if not it's a subalbum
         String firstImageLink = page.select(".page-gallery > div > div > div.gallery > a.t-hover").first().attr("href");
-        Pattern p = Pattern.compile("/comix/[a-zA-Z0-9\\-_/]*/\\d+");
+        Pattern p = Pattern.compile("/comix/([a-zA-Z0-9\\-_/]*/)?\\d+");
         Matcher m = p.matcher(firstImageLink);
         if (!m.matches()) {
             logger.info("Ripping subalbums");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -23,7 +23,6 @@ import com.rarchives.ripme.utils.Http;
 public class EightmusesRipper extends AbstractHTMLRipper {
 
     private Document albumDoc = null;
-    private Boolean rippingSubAlbums = false;
     private Map<String,String> cookies = new HashMap<String,String>();
 
     public EightmusesRipper(URL url) throws IOException {
@@ -84,7 +83,6 @@ public class EightmusesRipper extends AbstractHTMLRipper {
         Pattern p = Pattern.compile("/comix/[a-zA-Z0-9\\-_/]*/\\d+");
         Matcher m = p.matcher(firstImageLink);
         if (!m.matches()) {
-            rippingSubAlbums = true;
             logger.info("Ripping subalbums");
             // Page contains subalbums (not images)
             Elements albumElements = page.select(".page-gallery > div > div > div.gallery > a.t-hover");
@@ -127,7 +125,7 @@ public class EightmusesRipper extends AbstractHTMLRipper {
                             x = x + 1;
                         }
                         // This is a hackish workaround so ripme doesn't throw a "no images found at"
-                        imageURLs.add("http://");
+                        imageURLs.add("http://DONTDOWNLOAD");
                     } catch (IOException e) {
                         logger.warn("Error while loading subalbum " + subUrl, e);
                         continue;
@@ -179,7 +177,7 @@ public class EightmusesRipper extends AbstractHTMLRipper {
 
     @Override
     public void downloadURL(URL url, int index) {
-        if (!rippingSubAlbums) {
+        if (!url.equals("http://DONTDOWNLOAD")) {
             addURLToDownload(url, getPrefix(index), "", this.url.toExternalForm(), cookies);
         }
     }


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix #3 

# Description

I updated the cdn url (So downloading images no longer throws 404s) and changed how the ripper tells if it is ripping a album or a series of sub-albums*

* I used a regex to do this, but the regex will fail for comics who titles are all numbers, if anyone can think of a better way to do this please let me know

The regex I used ```/comix/[a-zA-Z0-9\\-_/]*/\\d+```


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.

Test links:

Single album: https://www.8muses.com/comix/album/prismgirls-comics/bikini-space-police

Sub-albums: https://www.8muses.com/comix/album/the-foxxx-comics/the-anal-plumber

~~edit: I found an error, don't merge yet~~

~~Edit_2: I add a hackish workaround for the error I ran into~~

Edit_3: I removed the hack and added a much better solution 