### PR TITLE
Added basic support for aerisdies.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/AerisdiesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/AerisdiesRipper.java
@@ -1,0 +1,98 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.Connection.Response;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.ui.RipStatusMessage.STATUS;
+import com.rarchives.ripme.utils.Http;
+import java.util.HashMap;
+
+public class AerisdiesRipper extends AbstractHTMLRipper {
+
+    private Document albumDoc = null;
+    private Map<String,String> cookies = new HashMap<String,String>();
+
+
+    public AerisdiesRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "aerisdies";
+    }
+    @Override
+    public String getDomain() {
+        return "aerisdies.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https?://www.aerisdies.com/html/lb/([a-z]*_[0-9]*_\\d)\\.html");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (!m.matches()) {
+            throw new MalformedURLException("Expected URL format: http://www.aerisdies.com/html/lb/albumDIG, got: " + url);
+        }
+        return m.group(m.groupCount());
+    }
+
+    @Override
+    public String getAlbumTitle(URL url) throws MalformedURLException {
+        try {
+            // Attempt to use album title as GID
+            String title = getFirstPage().select("title").first().text();
+            return getHost() + "_" + title.trim();
+        } catch (IOException e) {
+            // Fall back to default album naming convention
+            logger.info("Unable to find title at " + url);
+        }
+        return super.getAlbumTitle(url);
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        if (albumDoc == null) {
+            Response resp = Http.url(url).response();
+            cookies.putAll(resp.cookies());
+            albumDoc = resp.parse();
+        }
+        return albumDoc;
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document page) {
+        List<String> imageURLs = new ArrayList<String>();
+        Elements albumElements = page.select("div.imgbox > a > img");
+            for (Element imageBox : albumElements) {
+                String imageUrl = imageBox.attr("src");
+                imageUrl = imageUrl.replaceAll("thumbnails", "images");
+                imageUrl = imageUrl.replaceAll("../../", "");
+                imageUrl = imageUrl.replaceAll("gif", "jpg");
+                imageURLs.add("http://www.aerisdies.com/" + imageUrl);
+            }
+        return imageURLs;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index), "", this.url.toExternalForm(), cookies);
+    }
+
+    @Override
+    public String getPrefix(int index) {
+        return String.format("%03d_", index);
+    }
+}


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix -- which issue? #...
* [X] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

A ripper for aerisdies.com.

Test link: http://www.aerisdies.com/html/lb/douj_11369_1.html


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
