### PR TITLE
Added ripper for erome.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
@@ -1,0 +1,140 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.Connection.Response;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.jsoup.Connection.Method;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.ui.RipStatusMessage.STATUS;
+import com.rarchives.ripme.utils.Http;
+
+/**
+ *
+ * @author losipher
+ */
+public class EromeRipper extends AbstractHTMLRipper {
+
+
+    public EromeRipper (URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getDomain() {
+            return "erome.com";
+    }
+
+    @Override
+    public String getHost() {
+            return "erome";
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+
+    @Override
+    public String getAlbumTitle(URL url) throws MalformedURLException {
+            try {
+                // Attempt to use album title as GID
+                Element titleElement = getFirstPage().select("meta[property=og:title]").first();
+                String title = titleElement.attr("content");
+                title = title.substring(title.lastIndexOf('/') + 1);
+                return getHost() + "_" + getGID(url) + "_" + title.trim();
+            } catch (IOException e) {
+                // Fall back to default album naming convention
+                logger.info("Unable to find title at " + url);
+            }
+            return super.getAlbumTitle(url);
+    }
+
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> URLs = new ArrayList<String>();
+        //Pictures
+        Elements imgs = doc.select("div.img > img.img-front");
+        for (Element img : imgs) {
+            String imageURL = img.attr("src");
+            imageURL = "https:" + imageURL;
+            URLs.add(imageURL);
+        }
+        //Videos
+        Elements vids = doc.select("div.video > video > source");
+        for (Element vid : vids) {
+            String videoURL = vid.attr("src");
+            URLs.add("https:" + videoURL);
+        }
+
+        return URLs;
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        Response resp = Http.url(this.url)
+                            .ignoreContentType()
+                            .response();
+
+        Document doc = resp.parse();
+
+        return doc;
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https?://www.erome.com/a/([a-zA-Z0-9]*)/?$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("erome album not found in " + url + ", expected https://erome.com/album");
+    }
+
+    public static List<URL> getURLs(URL url) throws IOException{
+
+        Response resp = Http.url(url)
+                            .ignoreContentType()
+                            .response();
+
+        Document doc = resp.parse();
+
+        List<URL> URLs = new ArrayList<URL>();
+        //Pictures
+        Elements imgs = doc.getElementsByTag("img");
+        for (Element img : imgs) {
+            if (img.hasClass("album-image")) {
+                String imageURL = img.attr("src");
+                imageURL = "https:" + imageURL;
+                URLs.add(new URL(imageURL));
+            }
+        }
+        //Videos
+        Elements vids = doc.getElementsByTag("video");
+        for (Element vid : vids) {
+            if (vid.hasClass("album-video")) {
+                Elements source = vid.getElementsByTag("source");
+                String videoURL = source.first().attr("src");
+                URLs.add(new URL(videoURL));
+            }
+        }
+
+        return URLs;
+    }
+}


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [X] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

A ripper for erome that supports pictures and videos. It closes #36 


# Testing

Test links:
https://www.erome.com/a/ixVfLNtQ - album of videos
https://www.erome.com/a/n3d8WIxW - album with a single video
https://www.erome.com/a/8g2TCiPp - album mixed
https://www.erome.com/a/gEgcLsOG - album of pictures

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
