### PR TITLE
eroshare regex now allows for www to appear before the domain and eroshare ripper no longer adds extra https: to eroshare links

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EroShareRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EroShareRipper.java
@@ -63,13 +63,13 @@ public class EroShareRipper extends AbstractHTMLRipper {
             return true;
         }
 
-        Pattern p_eroshare = Pattern.compile("^https?://eroshare.com/([a-zA-Z0-9\\-_]+)/?$");
+        Pattern p_eroshare = Pattern.compile("^https?://(www[.])?eroshare.com/([a-zA-Z0-9\\-_]+)/?$");
         Matcher m_eroshare = p_eroshare.matcher(url.toExternalForm());
         if (m_eroshare.matches()) {
             return true;
         }
 
-        Pattern p_eroshare_profile = Pattern.compile("^https?://eroshare.com/u/([a-zA-Z0-9\\-_]+)/?$");
+        Pattern p_eroshare_profile = Pattern.compile("^https?://(www[.])?eroshare.com/u/([a-zA-Z0-9\\-_]+)/?$");
         Matcher m_eroshare_profile = p_eroshare_profile.matcher(url.toExternalForm());
         if (m_eroshare_profile.matches()) {
             return true;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EroShareRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EroShareRipper.java
@@ -168,7 +168,9 @@ public class EroShareRipper extends AbstractHTMLRipper {
     @Override
     public Document getFirstPage() throws IOException {
         String urlToDownload = this.url.toExternalForm();
-        Response resp = Http.url(urlToDownload.replace("eroshare.com", "eroshae.com"))
+        urlToDownload = urlToDownload.replace("eroshare.com", "eroshae.com");
+        urlToDownload = urlToDownload.replace("www.", "");
+        Response resp = Http.url(urlToDownload)
                             .ignoreContentType()
                             .response();
 
@@ -185,7 +187,7 @@ public class EroShareRipper extends AbstractHTMLRipper {
             return m.group(1);
         }
 
-        Pattern p_eroshare = Pattern.compile("^https?://eroshare.com/([a-zA-Z0-9\\-_]+)/?$");
+        Pattern p_eroshare = Pattern.compile("^https?://(www[.])?eroshare.com/([a-zA-Z0-9\\-_]+)/?$");
         Matcher m_eroshare = p_eroshare.matcher(url.toExternalForm());
         if (m_eroshare.matches()) {
             return m_eroshare.group(1);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EroShareRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EroShareRipper.java
@@ -128,7 +128,9 @@ public class EroShareRipper extends AbstractHTMLRipper {
         for (Element img : imgs) {
             if (img.hasClass("album-image")) {
                 String imageURL = img.attr("src");
-                imageURL = "https:" + imageURL;
+                if (!imageURL.startsWith("http")) {
+                    imageURL = "https:" + imageURL;
+                }
                 URLs.add(imageURL);
             }
         }
@@ -138,7 +140,10 @@ public class EroShareRipper extends AbstractHTMLRipper {
             if (vid.hasClass("album-video")) {
                 Elements source = vid.getElementsByTag("source");
                 String videoURL = source.first().attr("src");
-                URLs.add("https:" + videoURL);
+                if (!videoURL.startsWith("http")) {
+                    videoURL = "https:" + videoURL;
+                }
+                URLs.add(videoURL);
             }
         }
         // Profile videos
@@ -157,7 +162,10 @@ public class EroShareRipper extends AbstractHTMLRipper {
                 if (vid.hasClass("album-video")) {
                     Elements source = vid.getElementsByTag("source");
                     String videoURL = source.first().attr("src");
-                    URLs.add("https:" + videoURL);
+                    if (!videoURL.startsWith("http")) {
+                        videoURL = "https:" + videoURL;
+                    }
+                    URLs.add(videoURL);
                 }
             }
         }


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #39 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Minor change to the url matching regex


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
