### PR TITLE
Added Webtoons ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
@@ -1,0 +1,91 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import java.util.Map;
+import java.util.HashMap;
+import org.jsoup.Connection.Response;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class WebtoonsRipper extends AbstractHTMLRipper {
+    private Map<String,String> cookies = new HashMap<String,String>();
+
+    public WebtoonsRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "webtoons";
+    }
+
+    @Override
+    public String getDomain() {
+        return "www.webtoons.com";
+    }
+
+    @Override
+    public boolean canRip(URL url) {
+        Pattern pat = Pattern.compile("https?://www\\.webtoons\\.com/[a-zA-Z]+/[a-zA-Z]+/([a-zA-Z0-9_-]*)/ep-\\d+/\\S*");
+        Matcher mat = pat.matcher(url.toExternalForm());
+        if (mat.matches()) {
+            return true;
+        }
+        return false;
+    }
+
+
+    @Override
+    public String getAlbumTitle(URL url) throws MalformedURLException {
+        Pattern pat = Pattern.compile("https?://www\\.webtoons\\.com/[a-zA-Z]+/[a-zA-Z]+/([a-zA-Z0-9_-]*)/ep-\\d+/\\S*");
+        Matcher mat = pat.matcher(url.toExternalForm());
+        if (mat.matches()) {
+            return mat.group(1);
+        }
+
+        return super.getAlbumTitle(url);
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern pat = Pattern.compile("https?://www\\.webtoons\\.com/[a-zA-Z]+/[a-zA-Z]+/([a-zA-Z0-9_-]*)/ep-\\d+/\\S*");
+        Matcher mat = pat.matcher(url.toExternalForm());
+        if (mat.matches()) {
+            return mat.group(1);
+        }
+        throw new MalformedURLException("You should never see this error message");
+    }
+
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<String>();
+        for (Element elem : doc.select("div.viewer_img > img")) {
+            result.add(elem.attr("data-url"));
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index), "", this.url.toExternalForm(), cookies);
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        Response resp = Http.url(url).response();
+        cookies = resp.cookies();
+        return Http.url(url).get();
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
@@ -37,7 +37,7 @@ public class WebtoonsRipper extends AbstractHTMLRipper {
 
     @Override
     public boolean canRip(URL url) {
-        Pattern pat = Pattern.compile("https?://www\\.webtoons\\.com/[a-zA-Z]+/[a-zA-Z]+/([a-zA-Z0-9_-]*)/ep-\\d+/\\S*");
+        Pattern pat = Pattern.compile("https?://www.webtoons.com/[a-zA-Z]+/[a-zA-Z]+/([a-zA-Z0-9_-]*)/[a-zA-Z0-9_-]+/\\S*");
         Matcher mat = pat.matcher(url.toExternalForm());
         if (mat.matches()) {
             return true;
@@ -48,7 +48,7 @@ public class WebtoonsRipper extends AbstractHTMLRipper {
 
     @Override
     public String getAlbumTitle(URL url) throws MalformedURLException {
-        Pattern pat = Pattern.compile("https?://www\\.webtoons\\.com/[a-zA-Z]+/[a-zA-Z]+/([a-zA-Z0-9_-]*)/ep-\\d+/\\S*");
+        Pattern pat = Pattern.compile("https?://www.webtoons.com/[a-zA-Z]+/[a-zA-Z]+/([a-zA-Z0-9_-]*)/[a-zA-Z0-9_-]+/\\S*");
         Matcher mat = pat.matcher(url.toExternalForm());
         if (mat.matches()) {
             return mat.group(1);
@@ -59,7 +59,7 @@ public class WebtoonsRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern pat = Pattern.compile("https?://www\\.webtoons\\.com/[a-zA-Z]+/[a-zA-Z]+/([a-zA-Z0-9_-]*)/ep-\\d+/\\S*");
+        Pattern pat = Pattern.compile("https?://www.webtoons.com/[a-zA-Z]+/[a-zA-Z]+/([a-zA-Z0-9_-]*)/[a-zA-Z0-9_-]+/\\S*");
         Matcher mat = pat.matcher(url.toExternalForm());
         if (mat.matches()) {
             return mat.group(1);
@@ -95,7 +95,7 @@ public class WebtoonsRipper extends AbstractHTMLRipper {
         String nextUrl = "";
         Element elem = doc.select("a.pg_next").first();
             nextUrl = elem.attr("href");
-            if (nextUrl == "") {
+            if (nextUrl.equals("") || nextUrl.equals("#")) {
                 throw new IOException("No more pages");
             }
             return Http.url(nextUrl).get();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
@@ -88,4 +88,16 @@ public class WebtoonsRipper extends AbstractHTMLRipper {
         cookies = resp.cookies();
         return Http.url(url).get();
     }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        // Find next page
+        String nextUrl = "";
+        Element elem = doc.select("a.pg_next").first();
+            nextUrl = elem.attr("href");
+            if (nextUrl == "") {
+                throw new IOException("No more pages");
+            }
+            return Http.url(nextUrl).get();
+        }
 }


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [X] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

A ripper for the site webtoons.com


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.

Test link: http://www.webtoons.com/en/fantasy/the-gamer/ep-1/viewer?title_no=88&episode_no=1
