### PR TITLE
Added -v, --version flag

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -39,15 +39,23 @@ public class App {
     private static final History HISTORY = new History();
 
     public static void main(String[] args) throws MalformedURLException {
-        Utils.configureLogger();
-        System.setProperty("apple.laf.useScreenMenuBar", "true");
-        System.setProperty("com.apple.mrj.application.apple.menu.about.name", "RipMe");
-        logger = Logger.getLogger(App.class);
-        logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
-
-        if (args.length > 0) {
+        CommandLine cl = getArgs(args);
+        if (args.length > 0 && cl.hasOption('v')) {
+            System.out.println(UpdateUtils.getThisJarVersion());
+            handleArguments(args);
+        } else if (args.length > 0) {
+            Utils.configureLogger();
+            System.setProperty("apple.laf.useScreenMenuBar", "true");
+            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "RipMe");
+            logger = Logger.getLogger(App.class);
+            logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
             handleArguments(args);
         } else {
+            Utils.configureLogger();
+            System.setProperty("apple.laf.useScreenMenuBar", "true");
+            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "RipMe");
+            logger = Logger.getLogger(App.class);
+            logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
             MainWindow mw = new MainWindow();
             SwingUtilities.invokeLater(mw);
         }

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -206,6 +206,7 @@ public class App {
         opts.addOption("l", "ripsdirectory", true, "Rips Directory (Default: ./rips)");
         opts.addOption("n", "no-prop-file", false, "Do not create properties file.");
         opts.addOption("f", "urls-file", true, "Rip URLs from a file.");
+        opts.addOption("v", "version", false, "Show current version");
         return opts;
     }
 

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -40,16 +40,17 @@ public class App {
 
     public static void main(String[] args) throws MalformedURLException {
         CommandLine cl = getArgs(args);
-        if (args.length > 0 && cl.hasOption('v')) {
+        if (args.length > 0){
+          if (cl.hasOption('v')){
             System.out.println(UpdateUtils.getThisJarVersion());
-            handleArguments(args);
-        } else if (args.length > 0) {
+          } else {
             Utils.configureLogger();
             System.setProperty("apple.laf.useScreenMenuBar", "true");
             System.setProperty("com.apple.mrj.application.apple.menu.about.name", "RipMe");
             logger = Logger.getLogger(App.class);
             logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
-            handleArguments(args);
+          }
+          handleArguments(args);
         } else {
             Utils.configureLogger();
             System.setProperty("apple.laf.useScreenMenuBar", "true");

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -40,23 +40,23 @@ public class App {
 
     public static void main(String[] args) throws MalformedURLException {
         CommandLine cl = getArgs(args);
-        if (args.length > 0){
-          if (cl.hasOption('v')){
+        if (args.length > 0 && cl.hasOption('v')){
             System.out.println(UpdateUtils.getThisJarVersion());
-          } else {
-            Utils.configureLogger();
-            System.setProperty("apple.laf.useScreenMenuBar", "true");
-            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "RipMe");
-            logger = Logger.getLogger(App.class);
-            logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
-          }
-          handleArguments(args);
+            System.exit(0);
+        }
+
+        //initialize logger
+        Utils.configureLogger();
+        System.setProperty("apple.laf.useScreenMenuBar", "true");
+        System.setProperty("com.apple.mrj.application.apple.menu.about.name", "RipMe");
+        logger = Logger.getLogger(App.class);
+        logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
+
+        if (args.length > 0) {
+            // CLI Mode
+            handleArguments(args);
         } else {
-            Utils.configureLogger();
-            System.setProperty("apple.laf.useScreenMenuBar", "true");
-            System.setProperty("com.apple.mrj.application.apple.menu.about.name", "RipMe");
-            logger = Logger.getLogger(App.class);
-            logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
+            // GUI Mode
             MainWindow mw = new MainWindow();
             SwingUtilities.invokeLater(mw);
         }


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #49 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Added a -v, --version option for CLI. Relevant with  issue #49  


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
