### PR TITLE
Fixes RipMeApp/ripme#57

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/video/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/video/XhamsterRipper.java
@@ -27,7 +27,7 @@ public class XhamsterRipper extends VideoRipper {
 
     @Override
     public boolean canRip(URL url) {
-        Pattern p = Pattern.compile("^https?://.*xhamster\\.com/movies/[0-9]+.*$");
+        Pattern p = Pattern.compile("^https?://.*xhamster\\.com/(movies|videos)/.*$");
         Matcher m = p.matcher(url.toExternalForm());
         return m.matches();
     }
@@ -39,7 +39,7 @@ public class XhamsterRipper extends VideoRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://.*xhamster\\.com/movies/([0-9]+).*$");
+        Pattern p = Pattern.compile("^https?://.*xhamster\\.com/(movies|videos)/.*$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);
@@ -47,7 +47,8 @@ public class XhamsterRipper extends VideoRipper {
 
         throw new MalformedURLException(
                 "Expected xhamster format:"
-                        + "xhamster.com/movies/####"
+                        + "xhamster.com/movies/#### or"
+                        + "xhamster.com/videos/####"
                         + " Got: " + url);
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #57 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

I've modified the regex to account for either a /movies or /videos subdir.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
