### PR TITLE
Added viewcomic ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ViewcomicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ViewcomicRipper.java
@@ -19,7 +19,7 @@ import com.rarchives.ripme.utils.Http;
 public class ViewcomicRipper extends AbstractHTMLRipper {
 
     public ViewcomicRipper(URL url) throws IOException {
-    super(url);
+        super(url);
     }
 
         @Override
@@ -81,6 +81,4 @@ public class ViewcomicRipper extends AbstractHTMLRipper {
         public void downloadURL(URL url, int index) {
             addURLToDownload(url, getPrefix(index));
         }
-
-
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ViewcomicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ViewcomicRipper.java
@@ -1,0 +1,86 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class ViewcomicRipper extends AbstractHTMLRipper {
+
+    public ViewcomicRipper(URL url) throws IOException {
+    super(url);
+    }
+
+        @Override
+        public String getHost() {
+            return "view-comic";
+        }
+
+        @Override
+        public String getDomain() {
+            return "view-comic.com";
+        }
+
+        @Override
+        public String getAlbumTitle(URL url) throws MalformedURLException {
+            try {
+                // Attempt to use album title as GID
+                String titleText = getFirstPage().select("title").first().text();
+                String title = titleText.replace("Viewcomic reading comics online for free", "");
+                title = title.replace("_", "");
+                title = title.replace("|", "");
+                title = title.replace("…", "");
+                title = title.replace(".", "");
+                return getHost() + "_" + title.trim();
+            } catch (IOException e) {
+                // Fall back to default album naming convention
+                logger.info("Unable to find title at " + url);
+            }
+            return super.getAlbumTitle(url);
+        }
+
+
+        @Override
+        public String getGID(URL url) throws MalformedURLException {
+            Pattern p = Pattern.compile("https?://view-comic.com/([a-zA-Z1-9_-]*)/?$");
+            Matcher m = p.matcher(url.toExternalForm());
+            if (m.matches()) {
+                return m.group(1);
+            }
+            throw new MalformedURLException("Expected view-comic URL format: " +
+                            "view-comic.com/COMIC_NAME - got " + url + " instead");
+        }
+
+        @Override
+        public Document getFirstPage() throws IOException {
+            // "url" is an instance field of the superclass
+            return Http.url(url).get();
+        }
+
+        @Override
+        public List<String> getURLsFromPage(Document doc) {
+            List<String> result = new ArrayList<String>();
+                for (Element el : doc.select("div.pinbin-copy > a > img")) {
+                    result.add(el.attr("src"));
+                }
+            return result;
+        }
+
+        @Override
+        public void downloadURL(URL url, int index) {
+            addURLToDownload(url, getPrefix(index));
+        }
+
+
+    }


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [X] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Please add details about your change here.

I added a ripper for the site view-comic.com


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
