### PR TITLE
Added direct link ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DirectlinksRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DirectlinksRipper.java
@@ -1,0 +1,65 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class DirectlinksRipper extends AbstractHTMLRipper {
+
+    public DirectlinksRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        String host = url.toExternalForm().split("/")[2];
+        return host;
+    }
+
+    @Override
+    public String getDomain() {
+        String host = url.toExternalForm().split("/")[2];
+        return host;
+    }
+
+    @Override
+    public boolean canRip(URL url) {
+        Pattern pat = Pattern.compile("https?://[www\\.]?\\S+\\.(mp4|gif|png|jpg|jpeg|webm)/?$");
+        Matcher mat = pat.matcher(url.toExternalForm());
+
+        return mat.matches();
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        return url.toExternalForm();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<String>();
+            result.add(url.toExternalForm());
+            return result;
+        }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        return Http.url(url).ignoreContentType().get();
+    }
+}


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [X] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

A ripper for direct links (mp4|gif|png|jpg|jpeg|webm at this point)


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.

I've not done much testing and this probably interferes with other rippers that allow for direct link ripping. Also the current folder name output is terrible (it's the url that was ripped)