### PR TITLE
[Imagefap] Now adds GID to folder name when using album name as floder name

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImagefapRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImagefapRipper.java
@@ -152,7 +152,7 @@ public class ImagefapRipper extends AbstractHTMLRipper {
             Pattern p = Pattern.compile("^Porn pics of (.*) \\(Page 1\\)$");
             Matcher m = p.matcher(title);
             if (m.matches()) {
-                return getHost() + "_" + m.group(1);
+                return getHost() + "_" + m.group(1) + "_" + getGID(url);
             }
         } catch (IOException e) {
             // Fall back to default album naming convention


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix 
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

This fixes bug #79. This adds the album GID to the folder name so 2 albums with the same name are no long written to the same folder


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
