### PR TITLE
InstagramRipper getOriginalUrl retrieving cropped images fix

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -111,7 +111,20 @@ public class InstagramRipper extends AbstractJSONRipper {
 
     private String getOriginalUrl(String imageURL) {
         imageURL = imageURL.replaceAll("scontent.cdninstagram.com/hphotos-", "igcdn-photos-d-a.akamaihd.net/hphotos-ak-");
+        imageURL = imageURL.replaceAll("s150x150/", "");
+        imageURL = imageURL.replaceAll("s320x320/", "");
+        imageURL = imageURL.replaceAll("s480x480/", "");
         imageURL = imageURL.replaceAll("s640x640/", "");
+        imageURL = imageURL.replaceAll("s720x720/", "");
+        imageURL = imageURL.replaceAll("s1080x1080/", "");
+        imageURL = imageURL.replaceAll("s2048x2048/", "");
+        imageURL = imageURL.replaceAll("p150x150/", "");
+        imageURL = imageURL.replaceAll("p320x320/", "");
+        imageURL = imageURL.replaceAll("p480x480/", "");
+        imageURL = imageURL.replaceAll("p640x640/", "");
+        imageURL = imageURL.replaceAll("p720x720/", "");
+        imageURL = imageURL.replaceAll("p1080x1080/", "");
+        imageURL = imageURL.replaceAll("p2048x2048/", "");
 
         // Instagram returns cropped images to unauthenticated applications to maintain legacy support. 
         // To retrieve the uncropped image, remove this segment from the URL. 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

* These changes to the getOriginalUrl should make sure that the InstagramRipper stops retrieving the cropped versions of the images.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
* [x] Downloads all relevant content.
* [x] Downloads content from multiple pages (as necessary or appropriate).
* [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).
