### PR TITLE
Fixed sankakucomplex ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SankakuComplexRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SankakuComplexRipper.java
@@ -69,25 +69,23 @@ public class SankakuComplexRipper extends AbstractHTMLRipper {
         // Image URLs are basically thumbnail URLs with a different domain, a simple
         // path replacement, and a ?xxxxxx post ID at the end (obtainable from the href)
         for (Element thumbSpan : doc.select("div.content > div > span.thumb > a")) {
-
             String postLink = thumbSpan.attr("href");
-            try {
-                // Get the page the full sized image is on
-                Document subPage = Http.url("https://chan.sankakucomplex.com" + postLink).get();
-                imageURLs.add("https:" + subPage.select("div[id=post-content] > a.sample > img").attr("src"));
-            } catch (IOException e) {
-                logger.warn("Error while loading page " + postLink, e);
-                continue;
-            }
-
+                try {
+                    // Get the page the full sized image is on
+                    Document subPage = Http.url("https://chan.sankakucomplex.com" + postLink).get();
+                    logger.info("Checking page " + "https://chan.sankakucomplex.com" + postLink);
+                    imageURLs.add("https:" + subPage.select("div[id=post-content] > a > img").attr("src"));
+                } catch (IOException e) {
+                    logger.warn("Error while loading page " + postLink, e);
+                    continue;
+                }
         }
         return imageURLs;
     }
 
     @Override
     public void downloadURL(URL url, int index) {
-        // Mock up the URL of the post page based on the post ID at the end of the URL.
-        sleep(10000);
+        sleep(8000);
         addURLToDownload(url, getPrefix(index));
     }
 
@@ -95,9 +93,14 @@ public class SankakuComplexRipper extends AbstractHTMLRipper {
     public Document getNextPage(Document doc) throws IOException {
         Element pagination = doc.select("div.pagination").first();
         if (pagination.hasAttr("next-page-url")) {
-            return Http.url(pagination.attr("abs:next-page-url")).cookies(cookies).get();
-        } else {
-            return null;
+            String nextPage = pagination.attr("abs:next-page-url");
+            // Only logged in users can see past page 25
+            // Trying to rip page 26 will throw a no images found error
+            if (nextPage.contains("page=26") == false) {
+                logger.info("Getting next page: " + pagination.attr("abs:next-page-url"));
+                return Http.url(pagination.attr("abs:next-page-url")).cookies(cookies).get();
+            }
         }
+        throw new IOException("No more pages");
     }
 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SankakuComplexRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SankakuComplexRipper.java
@@ -43,7 +43,7 @@ public class SankakuComplexRipper extends AbstractHTMLRipper {
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             try {
-                return URLDecoder.decode(m.group(1), "UTF-8");
+                return URLDecoder.decode(m.group(2), "UTF-8");
             } catch (UnsupportedEncodingException e) {
                 throw new MalformedURLException("Cannot decode tag name '" + m.group(1) + "'");
             }


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

A fix for sankakucomplex (It now downloads full sized images)


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.

