### PR TITLE
Default config paths added

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -224,12 +224,12 @@ public class App {
     }
 
     private static void loadHistory() {
-        File historyFile = new File("history.json");
+        File historyFile = new File(Utils.getConfigDir() + File.separator + "history.json");
         HISTORY.clear();
         if (historyFile.exists()) {
             try {
-                logger.info("Loading history from history.json");
-                HISTORY.fromFile("history.json");
+                logger.info("Loading history from " + historyFile.getCanonicalPath());
+                HISTORY.fromFile(historyFile.getCanonicalPath());
             } catch (IOException e) {
                 logger.error("Failed to load history from file " + historyFile, e);
                 System.out.println(

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -31,6 +31,9 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
@@ -1001,12 +1004,12 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     }
 
     private void loadHistory() {
-        File historyFile = new File("history.json");
+        File historyFile = new File(Utils.getConfigDir() + File.separator + "history.json");
         HISTORY.clear();
         if (historyFile.exists()) {
             try {
-                logger.info("Loading history from history.json");
-                HISTORY.fromFile("history.json");
+                logger.info("Loading history from " + historyFile.getCanonicalPath());
+                HISTORY.fromFile(historyFile.getCanonicalPath());
             } catch (IOException e) {
                 logger.error("Failed to load history from file " + historyFile, e);
                 JOptionPane.showMessageDialog(null,
@@ -1044,11 +1047,17 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     }
 
     private void saveHistory() {
+        Path historyFile = Paths.get(Utils.getConfigDir() + File.separator + "history.json");
         try {
-            HISTORY.toFile("history.json");
+            if (!Files.exists(historyFile)) {
+                Files.createDirectories(historyFile.getParent());
+                Files.createFile(historyFile);
+            }
+
+            HISTORY.toFile(historyFile.toString());
             Utils.setConfigList("download.history", Collections.emptyList());
         } catch (IOException e) {
-            logger.error("Failed to save history to file history.json", e);
+            logger.error("Failed to save history to file " + historyFile, e);
         }
     }
 

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -36,12 +36,13 @@ import com.rarchives.ripme.ripper.AbstractRipper;
 public class Utils {
     public  static final String RIP_DIRECTORY = "rips";
     private static final String configFile = "rip.properties";
+    private static final String OS = System.getProperty("os.name").toLowerCase();
     private static final Logger logger = Logger.getLogger(Utils.class);
 
     private static PropertiesConfiguration config;
     static {
         try {
-            String configPath = getConfigPath();
+            String configPath = getConfigFilePath();
             File f = new File(configPath);
             if (!f.exists()) {
                 // Use default bundled with .jar
@@ -132,18 +133,52 @@ public class Utils {
 
     public static void saveConfig() {
         try {
-            config.save(getConfigPath());
-            logger.info("Saved configuration to " + getConfigPath());
+            config.save(getConfigFilePath());
+            logger.info("Saved configuration to " + getConfigFilePath());
         } catch (ConfigurationException e) {
             logger.error("Error while saving configuration: ", e);
         }
     }
-    private static String getConfigPath() {
+
+    private static boolean isWindows() {
+        return OS.contains("win");
+    }
+
+    private static boolean isMacOS() {
+        return OS.contains("mac");
+    }
+
+    private static boolean isUnix() {
+        return OS.contains("nix") || OS.contains("nux") || OS.contains("bsd");
+    }
+
+    private static String getWindowsConfigDir() {
+        return System.getenv("LOCALAPPDATA") + File.separator + "ripme";
+    }
+
+    private static String getUnixConfigDir() {
+        return System.getProperty("user.home") + File.separator + ".config" + File.separator + "ripme";
+    }
+
+    private static String getMacOSConfigDir() {
+        return System.getProperty("user.home")
+                + File.separator + "Library" + File.separator + "Application Support" + File.separator + "ripme";
+    }
+
+    public static String getConfigDir() {
+        if (isWindows()) return getWindowsConfigDir();
+        if (isMacOS()) return getMacOSConfigDir();
+        if (isUnix()) return getUnixConfigDir();
+        
         try {
-            return new File(".").getCanonicalPath() + File.separator + configFile;
+            return new File(".").getCanonicalPath();
         } catch (Exception e) {
-            return "." + File.separator + configFile;
+            return ".";
         }
+    }
+
+    private static String getConfigFilePath() {
+        return getConfigDir() + File.separator + configFile;
     }
 
     /**


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [x] a style change/fix issue #76 


# Description

Ripme checks its config and history file in OS default config directory. 
`%LOCALAPPDATA%\ripme` for Windows
`~/Library/Application Support/` for Mac OS
` ~/.config/ripme` for other Unix-like

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).
* [x] I've verified that this change works on Windows 10, Ubuntu 16.04, Mac OS 10.12.6


Optional but recommended:
* [ ] I've added a unit test to cover my change.
