### PR TITLE
Added hentai.cafe ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiCafeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiCafeRipper.java
@@ -34,7 +34,7 @@ public class HentaiCafeRipper extends AbstractHTMLRipper {
 
         @Override
         public String getGID(URL url) throws MalformedURLException {
-            Pattern p = Pattern.compile("https?://hentai\\.cafe/([a-zA-Z1-9_-]*)/?$");
+            Pattern p = Pattern.compile("https?://hentai\\.cafe/([a-zA-Z1-9_\\-%]*)/?$");
             Matcher m = p.matcher(url.toExternalForm());
             if (m.matches()) {
                 return m.group(1);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiCafeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiCafeRipper.java
@@ -1,0 +1,76 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class HentaiCafeRipper extends AbstractHTMLRipper {
+
+    public HentaiCafeRipper(URL url) throws IOException {
+    super(url);
+    }
+
+        @Override
+        public String getHost() {
+            return "hentai";
+        }
+
+        @Override
+        public String getDomain() {
+            return "hentai.cafe";
+        }
+
+        @Override
+        public String getGID(URL url) throws MalformedURLException {
+            Pattern p = Pattern.compile("https?://hentai\\.cafe/([a-zA-Z1-9_-]*)/?$");
+            Matcher m = p.matcher(url.toExternalForm());
+            if (m.matches()) {
+                return m.group(1);
+            }
+            throw new MalformedURLException("Expected hentai.cafe URL format: " +
+                            "hentai.cafe/COMIC - got " + url + " instead");
+        }
+
+        @Override
+        public Document getFirstPage() throws IOException {
+            // "url" is an instance field of the superclass
+            Document tempDoc = Http.url(url).get();
+            return Http.url(tempDoc.select("div.last > p > a.x-btn").attr("href")).get();
+        }
+
+        @Override
+        public Document getNextPage(Document doc) throws IOException {
+            String nextPageURL = doc.select("div[id=page] > div.inner > a").attr("href");
+            int totalPages = Integer.parseInt(doc.select("div.panel > div.topbar > div > div.topbar_right > div.tbtitle > div.text").text().replace(" ⤵", ""));
+            String[] nextPageURLSplite = nextPageURL.split("/");
+            // This checks if the next page number is greater than the total number of pages
+            if (totalPages >= Integer.parseInt(nextPageURLSplite[nextPageURLSplite.length -1])) {
+                return Http.url(nextPageURL).get();
+            }
+            throw new IOException("No more pages");
+        }
+
+        @Override
+        public List<String> getURLsFromPage(Document doc) {
+            List<String> result = new ArrayList<String>();
+                result.add(doc.select("div[id=page] > div.inner > a > img.open").attr("src"));
+                return result;
+        }
+
+        @Override
+        public void downloadURL(URL url, int index) {
+            addURLToDownload(url, getPrefix(index));
+        }
+    }


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [X] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

A ripper for single comics from hentai.cafe


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.

Test link

https://hentai.cafe/coupe-blue-eyes-and-candied-strawberries/