### PR TITLE
Added Hbrowse.com ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HbrowseRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HbrowseRipper.java
@@ -51,6 +51,19 @@ public class HbrowseRipper extends AbstractHTMLRipper {
         }
 
         @Override
+        public String getAlbumTitle(URL url) throws MalformedURLException {
+            try {
+                Document doc = getFirstPage();
+                String title = doc.select("div[id=main] > table.listTable > tbody > tr > td.listLong").first().text();
+                return getHost() + "_" + title + "_" + getGID(url);
+            } catch (Exception e) {
+                // Fall back to default album naming convention
+                logger.warn("Failed to get album title from " + url, e);
+            }
+            return super.getAlbumTitle(url);
+        }
+
+        @Override
         public List<String> getURLsFromPage(Document doc) {
             List<String> result = new ArrayList<String>();
             for (Element el : doc.select("table > tbody > tr > td > a > img")) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HbrowseRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HbrowseRipper.java
@@ -1,0 +1,67 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class HbrowseRipper extends AbstractHTMLRipper {
+
+    public HbrowseRipper(URL url) throws IOException {
+    super(url);
+    }
+
+        @Override
+        public String getHost() {
+            return "hbrowse";
+        }
+
+        @Override
+        public String getDomain() {
+            return "hbrowse.com";
+        }
+
+        @Override
+        public String getGID(URL url) throws MalformedURLException {
+            Pattern p = Pattern.compile("http://www.hbrowse.com/\\d+/([a-zA-Z0-9]*)");
+            Matcher m = p.matcher(url.toExternalForm());
+            if (m.matches()) {
+                return m.group(1);
+            }
+            throw new MalformedURLException("Expected hbrowse.com URL format: " +
+                            "hbrowse.com/ID/COMICID - got " + url + " instead");
+        }
+
+        @Override
+        public Document getFirstPage() throws IOException {
+            // "url" is an instance field of the superclass
+            Document tempDoc = Http.url(url).get();
+            return Http.url(tempDoc.select("td[id=pageTopHome] > a[title=view thumbnails (top)]").attr("href")).get();
+        }
+
+        @Override
+        public List<String> getURLsFromPage(Document doc) {
+            List<String> result = new ArrayList<String>();
+            for (Element el : doc.select("table > tbody > tr > td > a > img")) {
+                String imageURL = el.attr("src").replace("/zzz", "");
+                result.add(imageURL);
+            }
+                return result;
+        }
+
+        @Override
+        public void downloadURL(URL url, int index) {
+            addURLToDownload(url, getPrefix(index));
+        }
+    }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HbrowseRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HbrowseRipper.java
@@ -34,7 +34,7 @@ public class HbrowseRipper extends AbstractHTMLRipper {
 
         @Override
         public String getGID(URL url) throws MalformedURLException {
-            Pattern p = Pattern.compile("http://www.hbrowse.com/\\d+/([a-zA-Z0-9]*)");
+            Pattern p = Pattern.compile("http://www.hbrowse.com/(\\d+)/[a-zA-Z0-9]*");
             Matcher m = p.matcher(url.toExternalForm());
             if (m.matches()) {
                 return m.group(1);


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [X] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

A ripper for Hbrowse.com


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
