### PR TITLE
Minor formatting fix for HentaiCafe ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiCafeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiCafeRipper.java
@@ -19,7 +19,7 @@ import com.rarchives.ripme.utils.Http;
 public class HentaiCafeRipper extends AbstractHTMLRipper {
 
     public HentaiCafeRipper(URL url) throws IOException {
-    super(url);
+        super(url);
     }
 
         @Override


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [X] a style change/fix


# Description

I added a missing indent


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
