### PR TITLE
Added hentai2read ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
@@ -1,0 +1,115 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class Hentai2readRipper extends AbstractHTMLRipper {
+    String lastPage;
+
+    public Hentai2readRipper(URL url) throws IOException {
+        super(url);
+    }
+
+        @Override
+        public String getHost() {
+            return "hentai2read";
+        }
+
+        @Override
+        public String getDomain() {
+            return "hentai2read.com";
+        }
+
+        @Override
+        public String getGID(URL url) throws MalformedURLException {
+            Pattern p = Pattern.compile("https://hentai2read\\.com/([a-zA-Z0-9_-]*)/?");
+            Matcher m = p.matcher(url.toExternalForm());
+            if (m.matches()) {
+                return m.group(1);
+            }
+            throw new MalformedURLException("Expected hentai2read.com URL format: " +
+                            "hbrowse.com/COMICID - got " + url + " instead");
+        }
+
+        @Override
+        public Document getFirstPage() throws IOException {
+            Document tempDoc;
+            // get the first page of the comic
+            if (url.toExternalForm().substring(url.toExternalForm().length() - 1).equals("/")) {
+                tempDoc = Http.url(url + "1").get();
+            } else {
+                tempDoc = Http.url(url + "/1").get();
+            }
+            for (Element el : tempDoc.select("ul.nav > li > a")) {
+                if (el.attr("href").startsWith("https://hentai2read.com/thumbnails/")) {
+                    // Get the page with the thumbnails
+                    return Http.url(el.attr("href")).get();
+                }
+            }
+            throw new IOException("Unable to get first page");
+        }
+
+        @Override
+        public String getAlbumTitle(URL url) throws MalformedURLException {
+            try {
+                Document doc = getFirstPage();
+                String title = doc.select("span[itemprop=title]").text();
+                return getHost() + "_" + title;
+            } catch (Exception e) {
+                // Fall back to default album naming convention
+                logger.warn("Failed to get album title from " + url, e);
+            }
+            return super.getAlbumTitle(url);
+        }
+
+        @Override
+        public List<String> getURLsFromPage(Document doc) {
+            List<String> result = new ArrayList<String>();
+            for (Element el : doc.select("div.block-content > div > div.img-container > a > img.img-responsive")) {
+                String imageURL = "https:" + el.attr("src");
+                imageURL = imageURL.replace("hentaicdn.com", "static.hentaicdn.com");
+                imageURL = imageURL.replace("thumbnails/", "");
+                imageURL = imageURL.replace("tmb", "");
+                result.add(imageURL);
+            }
+                return result;
+        }
+
+        @Override
+        public Document getNextPage(Document doc) throws IOException {
+            // Find next page
+            String nextUrl = "";
+            Element elem = doc.select("div.bg-white > ul.pagination > li > a").last();
+            if (elem == null) {
+                throw new IOException("No more pages");
+            }
+            nextUrl = elem.attr("href");
+            // We use the global lastPage to check if we've already ripped this page
+            // and is so we quit as there are no more pages
+            if (nextUrl.equals(lastPage)) {
+                throw new IOException("No more pages");
+            }
+            lastPage = nextUrl;
+            // Sleep for half a sec to avoid getting IP banned
+            sleep(500);
+            return Http.url(nextUrl).get();
+            }
+
+        @Override
+        public void downloadURL(URL url, int index) {
+            addURLToDownload(url, getPrefix(index));
+        }
+    }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
@@ -106,7 +106,7 @@ public class Hentai2readRipper extends AbstractHTMLRipper {
             // Sleep for half a sec to avoid getting IP banned
             sleep(500);
             return Http.url(nextUrl).get();
-            }
+        }
 
         @Override
         public void downloadURL(URL url, int index) {


### PR DESCRIPTION
<!--
We've moved! If you are not already, please consider opening your pull request here:
https://github.com/RipMeApp/ripme/

To help us verify your change, please fill out the information below.
-->

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [X] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

A ripper for hentai2read.com


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.

Test links:

https://hentai2read.com/okaasan_boku_onna_ni_natte_mo_ii

https://hentai2read.com/0_distance_love