### PR TITLE
Make expanded window resizable

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -261,14 +261,16 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         JPanel ripPanel = new JPanel(new GridBagLayout());
         ripPanel.setBorder(emptyBorder);
 
+        gbc.fill = GridBagConstraints.BOTH;
         gbc.weightx = 0;
         gbc.gridx = 0; ripPanel.add(new JLabel("URL:", JLabel.RIGHT), gbc);
         gbc.weightx = 1;
+        gbc.weighty = 1;
         gbc.gridx = 1; ripPanel.add(ripTextfield, gbc);
+        gbc.weighty = 0;
         gbc.weightx = 0;
         gbc.gridx = 2; ripPanel.add(ripButton, gbc);
         gbc.gridx = 3; ripPanel.add(stopButton, gbc);
-        gbc.fill = GridBagConstraints.BOTH;
         gbc.weightx = 1;
 
         statusLabel = new JLabel("Inactive");

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -524,6 +524,12 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         gbc.gridy = 11; gbc.gridx = 0; configurationPanel.add(configSaveDirLabel, gbc);
                         gbc.gridx = 1; configurationPanel.add(configSaveDirButton, gbc);
 
+        // Sometimes on Linux Java has trouble setting window size when also changing setResizable
+        // Put an empty JPanel on the bottom of the window to keep components anchored to the top
+        JPanel emptyPanel = new JPanel();
+        emptyPanel.setPreferredSize(new Dimension(0, 0));
+        emptyPanel.setSize(0, 0);
+
         gbc.anchor = GridBagConstraints.PAGE_START;
         gbc.gridy = 0; pane.add(ripPanel, gbc);
         gbc.gridy = 1; pane.add(statusPanel, gbc);
@@ -535,6 +541,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         gbc.gridy = 5; pane.add(historyPanel, gbc);
         gbc.gridy = 5; pane.add(queuePanel, gbc);
         gbc.gridy = 5; pane.add(configurationPanel, gbc);
+        gbc.gridy = 6; pane.add(emptyPanel, gbc);
         gbc.weighty = 0;
         gbc.fill = GridBagConstraints.HORIZONTAL;
     }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix


# Description

The log, history, and queue are hard to read with a small unresizable window. This makes the window resizable when the lower panes are not visible.


# Testing
All the tests that fail also fail on the current main master branch. The failures are not related to these changes.

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
