### PR TITLE
Updated TravisCI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: java
 jdk:
-  - oraclejdk7
+  - oraclejdk8
+  - openjdk8

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RipMe
 
-[![Build Status](https://travis-ci.org/4pr0n/ripme.svg?branch=master)](https://travis-ci.org/4pr0n/ripme)
+[![Build Status](https://travis-ci.org/RipMeApp/ripme.svg?branch=master)](https://travis-ci.org/4pr0n/ripme)
 [![Join the chat at https://gitter.im/RipMeApp/Lobby](https://badges.gitter.im/RipMeApp/Lobby.svg)](https://gitter.im/RipMeApp/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Album ripper for various websites. Runs on your computer. Requires Java 8.


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Changes the TravisCI configuration to make it work on the current environment and build against OpenJDK8 and Oracle JDK8 (In order to ensure that everyone can use it and to be able to spot JVM-related bugs quicker).

This was tested using my account, you can read the logs there: https://travis-ci.org/MrTimscampi/ripme  
Note that the builds fail due to unit tests failing, but the build completes (which is what is important, at this stage).

A member of the RipMeApp organization should enable Travis (Easy to do, just go login on TravisCI and enable the repo) to complete this PR.

Another change that would be interesting but can only be done by someone from the organization is to enable Travis to deploy releases on GitHub.  
This would enable a contributor to tag a commit with the version number before a push, then Travis would automatically build, test and publish a release on GitHub.  
Instructions can be found here: https://docs.travis-ci.com/user/deployment/releases/

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
