### PR TITLE
Updated issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,3 @@
-<!--
-We've moved! If you are not already, please consider opening your issue at the following link:
-https://github.com/RipMeApp/ripme/issues/new
-
-If this is a bug, please fill out the information below.
-Please include any additional information that would help us fix the bug.
-If this is a feature request or other type of issue, provide whatever information you feel is appropriate.
--->
-
 * Ripme version:
 * Java version: <!-- (output of `java -version`) -->
 * Operating system: <!-- (if Windows, output of `ver` or `winver`) -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,3 @@
-<!--
-We've moved! If you are not already, please consider opening your pull request here:
-https://github.com/RipMeApp/ripme/
-
-To help us verify your change, please fill out the information below.
--->
-
 # Category
 
 This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [x] a style change/fix


# Description

This removes the confusing "We've moved" comments from the PR and Issue templates, since the move is done and it's somewhat confusing for people, as it points to this repository.

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
