### PR TITLE
Fixed imgbox ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgboxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgboxRipper.java
@@ -48,7 +48,7 @@ public class ImgboxRipper extends AbstractHTMLRipper {
     public List<String> getURLsFromPage(Document doc) {
         List<String> imageURLs = new ArrayList<>();
         for (Element thumb : doc.select("div.boxed-content > a > img")) {
-            String image = thumb.attr("src").replaceAll("thumbs.imgbox.com", "images.imgbox.com");
+            String image = thumb.attr("src").replaceAll("thumbs", "images");
             image = image.replace("_b", "_o");
             imageURLs.add(image);
         }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #114 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Now handles the different subdomains domains


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
