### PR TITLE
Added Porncomix.info ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PorncomixRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PorncomixRipper.java
@@ -1,0 +1,69 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class PorncomixRipper extends AbstractHTMLRipper {
+
+    public PorncomixRipper(URL url) throws IOException {
+    super(url);
+    }
+
+        @Override
+        public String getHost() {
+            return "porncomix";
+        }
+
+        @Override
+        public String getDomain() {
+            return "porncomix.info";
+        }
+
+        @Override
+        public String getGID(URL url) throws MalformedURLException {
+            Pattern p = Pattern.compile("https?://www.porncomix.info/([a-zA-Z1-9_-]*)/?$");
+            Matcher m = p.matcher(url.toExternalForm());
+            if (m.matches()) {
+                return m.group(1);
+            }
+            throw new MalformedURLException("Expected proncomix URL format: " +
+                            "porncomix.info/comic - got " + url + " instead");
+        }
+
+        @Override
+        public Document getFirstPage() throws IOException {
+            // "url" is an instance field of the superclass
+            return Http.url(url).get();
+        }
+
+        @Override
+        public List<String> getURLsFromPage(Document doc) {
+            List<String> result = new ArrayList<>();
+                for (Element el : doc.select("div.single-post > div.gallery > dl > dt > a > img")) {
+                    String imageSource = el.attr("data-lazy-src");
+                    // We remove the .md from images so we download the full size image
+                    // not the thumbnail ones
+                        imageSource = imageSource.replaceAll("-\\d\\d\\dx\\d\\d\\d", "");
+                        result.add(imageSource);
+                    }
+                return result;
+        }
+
+        @Override
+        public void downloadURL(URL url, int index) {
+            addURLToDownload(url, getPrefix(index));
+        }
+    }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PorncomixRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PorncomixRipper.java
@@ -34,7 +34,7 @@ public class PorncomixRipper extends AbstractHTMLRipper {
 
         @Override
         public String getGID(URL url) throws MalformedURLException {
-            Pattern p = Pattern.compile("https?://www.porncomix.info/([a-zA-Z1-9_-]*)/?$");
+            Pattern p = Pattern.compile("https?://www.porncomix.info/([a-zA-Z0-9_\\-]*)/?$");
             Matcher m = p.matcher(url.toExternalForm());
             if (m.matches()) {
                 return m.group(1);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [X] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

A ripper for porncomix.info


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.

Test link: http://www.porncomix.info/edge-of-humanity-01-zzz/
