### PR TITLE
fixed Imgbox ripper; removed unti test for site that doesn't exist anymore

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImgboxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImgboxRipper.java
@@ -50,6 +50,7 @@ public class ImgboxRipper extends AbstractHTMLRipper {
         for (Element thumb : doc.select("div.boxed-content > a > img")) {
             String image = thumb.attr("src").replaceAll("thumbs", "images");
             image = image.replace("_b", "_o");
+            image = image.replaceAll("\\d-s", "i");
             imageURLs.add(image);
         }
         return imageURLs;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
@@ -8,7 +8,6 @@ import com.rarchives.ripme.ripper.rippers.DeviantartRipper;
 import com.rarchives.ripme.ripper.rippers.EightmusesRipper;
 import com.rarchives.ripme.ripper.rippers.FivehundredpxRipper;
 import com.rarchives.ripme.ripper.rippers.FuraffinityRipper;
-import com.rarchives.ripme.ripper.rippers.GifyoRipper;
 import com.rarchives.ripme.ripper.rippers.GirlsOfDesireRipper;
 import com.rarchives.ripme.ripper.rippers.HentaifoundryRipper;
 import com.rarchives.ripme.ripper.rippers.ImagearnRipper;
@@ -130,12 +129,7 @@ public class BasicRippersTest extends RippersTest {
         testRipper(ripper);
     }
     */
-
-    public void testGifyoAlbum() throws IOException {
-        GifyoRipper ripper = new GifyoRipper(new URL("http://gifyo.com/PieSecrets/"));
-        testRipper(ripper);
-    }
-
+    
     public void testGirlsofdesireAlbum() throws IOException {
         GirlsOfDesireRipper ripper = new GirlsOfDesireRipper(new URL("http://www.girlsofdesire.org/galleries/krillia/"));
         testRipper(ripper);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #114 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

fixed imgbox ripper; removed unit test for site that doesn't exist anymore


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
