### PR TITLE
Remember downloaded URLs

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -28,7 +28,7 @@ public abstract class AbstractRipper
                 implements RipperInterface, Runnable {
 
     protected static final Logger logger = Logger.getLogger(AbstractRipper.class);
-    private final String URLHistoryFile = Utils.getConfigDir() + File.separator + "url_history.txt";
+    private final String URLHistoryFile = Utils.getURLHistoryFile();
 
     public static final String USER_AGENT =
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:36.0) Gecko/20100101 Firefox/36.0";

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -85,7 +85,7 @@ public abstract class AbstractRipper
         }
     }
 
-    public boolean hasDownloadedURL(String url) {
+    private boolean hasDownloadedURL(String url) {
         File file = new File(URLHistoryFile);
         try {
             Scanner scanner = new Scanner(file);

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -159,9 +159,11 @@ public abstract class AbstractRipper
     protected abstract boolean addURLToDownload(URL url, File saveAs, String referrer, Map<String, String> cookies);
 
     protected boolean addURLToDownload(URL url, String prefix, String subdirectory, String referrer, Map<String, String> cookies) {
-        if (hasDownloadedURL(url.toExternalForm())) {
-            sendUpdate(STATUS.DOWNLOAD_WARN, "Already downloaded " + url.toExternalForm());
-            return false;
+        if (Utils.getConfigBoolean("remember.url_history", true)) {
+            if (hasDownloadedURL(url.toExternalForm())) {
+                sendUpdate(STATUS.DOWNLOAD_WARN, "Already downloaded " + url.toExternalForm());
+                return false;
+            }
         }
         try {
             stopCheck();
@@ -196,10 +198,12 @@ public abstract class AbstractRipper
             logger.info("[+] Creating directory: " + Utils.removeCWD(saveFileAs.getParent()));
             saveFileAs.getParentFile().mkdirs();
         }
-        try {
-            writeDownloadedURL(url.toExternalForm() + "\n");
-        } catch (IOException e) {
+        if (Utils.getConfigBoolean("remember.url_history", true)) {
+            try {
+                writeDownloadedURL(url.toExternalForm() + "\n");
+            } catch (IOException e) {
                 logger.debug("Unable to write URL history file");
+            }
         }
         return addURLToDownload(url, saveFileAs, referrer, cookies);
     }

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -665,6 +665,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             saveHistory();
         });
         historyButtonClear.addActionListener(event -> {
+            Utils.clearURLHistory();
             HISTORY.clear();
             try {
                 historyTableModel.fireTableDataChanged();

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -118,6 +118,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     private static JTextField configRetriesText;
     private static JCheckBox configAutoupdateCheckbox;
     private static JComboBox configLogLevelCombobox;
+    private static JCheckBox configURLHistoryCheckbox;
     private static JCheckBox configPlaySound;
     private static JCheckBox configSaveOrderCheckbox;
     private static JCheckBox configShowPopup;
@@ -191,6 +192,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         Utils.setConfigBoolean("clipboard.autorip", configClipboardAutorip.isSelected());
         Utils.setConfigBoolean("descriptions.save", configSaveDescriptions.isSelected());
         Utils.setConfigBoolean("prefer.mp4", configPreferMp4.isSelected());
+        Utils.setConfigBoolean("remember.url_history", configURLHistoryCheckbox.isSelected());
         saveWindowPosition(mainFrame);
         saveHistory();
         Utils.saveConfig();
@@ -489,6 +491,9 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         configWindowPosition = new JCheckBox("Restore window position", Utils.getConfigBoolean("window.position", true));
         configWindowPosition.setHorizontalAlignment(JCheckBox.RIGHT);
         configWindowPosition.setHorizontalTextPosition(JCheckBox.LEFT);
+        configURLHistoryCheckbox = new JCheckBox("Remember URL history", Utils.getConfigBoolean("remember.url_history", true));
+        configURLHistoryCheckbox.setHorizontalAlignment(JCheckBox.RIGHT);
+        configURLHistoryCheckbox.setHorizontalTextPosition(JCheckBox.LEFT);
         configSaveDirLabel = new JLabel();
         try {
             String workingDir = (Utils.shortenPath(Utils.getWorkingDirectory()));
@@ -520,8 +525,10 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         gbc.gridy = 9; gbc.gridx = 0; configurationPanel.add(configSaveDescriptions, gbc);
                        gbc.gridx = 1; configurationPanel.add(configPreferMp4, gbc);
         gbc.gridy = 10; gbc.gridx = 0; configurationPanel.add(configWindowPosition, gbc);
+                        gbc.gridx = 1; configurationPanel.add(configURLHistoryCheckbox, gbc);
         gbc.gridy = 11; gbc.gridx = 0; configurationPanel.add(configSaveDirLabel, gbc);
                         gbc.gridx = 1; configurationPanel.add(configSaveDirButton, gbc);
+
 
         emptyPanel = new JPanel();
         emptyPanel.setPreferredSize(new Dimension(0, 0));
@@ -742,6 +749,10 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         });
         configSaveURLsOnly.addActionListener(arg0 -> {
             Utils.setConfigBoolean("urls_only.save", configSaveURLsOnly.isSelected());
+            Utils.configureLogger();
+        });
+        configURLHistoryCheckbox.addActionListener(arg0 -> {
+            Utils.setConfigBoolean("remember.url_history", configURLHistoryCheckbox.isSelected());
             Utils.configureLogger();
         });
         configSaveAlbumTitles.addActionListener(arg0 -> {

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -20,7 +20,6 @@ import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.Clip;
 import javax.sound.sampled.Line;
 import javax.sound.sampled.LineEvent;
-import javax.sound.sampled.LineListener;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -175,6 +174,16 @@ public class Utils {
         } catch (Exception e) {
             return ".";
         }
+    }
+    // Delete the url history file
+    public static void clearURLHistory() {
+        File file = new File(getURLHistoryFile());
+        file.delete();
+    }
+
+    // Return the path of the url history file
+    public static String getURLHistoryFile() {
+        return getConfigDir() + File.separator + "url_history.txt";
     }
 
     private static String getConfigFilePath() {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [X] a new feature

# Description

I added the ability for ripme to remember and skip urls that it has downloaded in the past


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
