### PR TITLE
8muses ripper now works with latest site update

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -178,10 +178,8 @@ public class EightmusesRipper extends AbstractHTMLRipper {
         sendUpdate(STATUS.LOADING_RESOURCE, imageUrl);
         logger.info("Getting full sized image from " + imageUrl);
         Document doc = new Http(imageUrl).get(); // Retrieve the webpage  of the image URL
-        Element fullSizeImage = doc.select(".photo").first(); // Select the "photo" element from the page (there should only be 1)
-        // subdir is the sub dir the cdn has the image stored in
-        String subdir = doc.select("input#imageDir").first().attr("value");
-        return "https://cdn.ampproject.org/i/s/www.8muses.com/" + subdir + "small/" + fullSizeImage.children().select("#imageName").attr("value");
+        String imageName = doc.select("input[id=imageName]").attr("value"); // Select the "input" element from the page
+        return "https://www.8muses.com/image/fm/" + imageName;
     }
 
     @Override

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
@@ -47,9 +47,7 @@ public class BasicRippersTest extends RippersTest {
     }
 
     public void testEightmusesAlbum() throws IOException {
-        EightmusesRipper ripper = new EightmusesRipper(new URL("http://www.8muses.com/index/category/jab-hotassneighbor7"));
-        testRipper(ripper);
-        ripper = new EightmusesRipper(new URL("https://www.8muses.com/album/jab-comics/a-model-life"));
+        EightmusesRipper ripper = new EightmusesRipper(new URL("https://www.8muses.com/album/jab-comics/a-model-life"));
         testRipper(ripper);
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #148 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

I changed the ripper gets the full sized image url


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
