### PR TITLE
Added portable mode

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -164,7 +164,29 @@ public class Utils {
                 + File.separator + "Library" + File.separator + "Application Support" + File.separator + "ripme";
     }
 
+    private static boolean portableMode() {
+        try {
+            File f = new File(new File(".").getCanonicalPath() + File.separator + configFile);
+            if(f.exists() && !f.isDirectory()) {
+                return true;
+            }
+        } catch (IOException e) {
+            return false;
+        }
+        return false;
+    }
+
+
     public static String getConfigDir() {
+        if (portableMode()) {
+            logger.info("Running in portable mode");
+            try {
+                return new File(".").getCanonicalPath();
+            } catch (Exception e) {
+                return ".";
+            }
+        }
+
         if (isWindows()) return getWindowsConfigDir();
         if (isMacOS()) return getMacOSConfigDir();
         if (isUnix()) return getUnixConfigDir();

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -179,7 +179,6 @@ public class Utils {
 
     public static String getConfigDir() {
         if (portableMode()) {
-            logger.info("Running in portable mode");
             try {
                 return new File(".").getCanonicalPath();
             } catch (Exception e) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Ripme will run in portable mode (It writes all config files to the same dir as the jar) if a file named rip.properties exists in the dir the jar is run from


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
