### PR TITLE
Some automated code cleanup

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.Objects;
 
 import org.jsoup.nodes.Document;
 
@@ -142,7 +143,7 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
     }
     private String fileNameFromURL(URL url) {
         String saveAs = url.toExternalForm();
-        if (saveAs.substring(saveAs.length() - 1) == "/") { saveAs = saveAs.substring(0,saveAs.length() - 1) ;}
+        if (Objects.equals(saveAs.substring(saveAs.length() - 1), "/")) { saveAs = saveAs.substring(0,saveAs.length() - 1) ;}
         saveAs = saveAs.substring(saveAs.lastIndexOf('/')+1);
         if (saveAs.indexOf('?') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('?')); }
         if (saveAs.indexOf('#') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('#')); }

--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -15,9 +15,9 @@ import com.rarchives.ripme.utils.Utils;
 
 public abstract class AlbumRipper extends AbstractRipper {
 
-    private Map<URL, File> itemsPending = Collections.synchronizedMap(new HashMap<URL, File>());
-    private Map<URL, File> itemsCompleted = Collections.synchronizedMap(new HashMap<URL, File>());
-    private Map<URL, String> itemsErrored = Collections.synchronizedMap(new HashMap<URL, String>());
+    private final Map<URL, File> itemsPending = Collections.synchronizedMap(new HashMap<URL, File>());
+    private final Map<URL, File> itemsCompleted = Collections.synchronizedMap(new HashMap<URL, File>());
+    private final Map<URL, String> itemsErrored = Collections.synchronizedMap(new HashMap<URL, String>());
 
     protected AlbumRipper(URL url) throws IOException {
         super(url);

--- a/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
@@ -31,11 +31,11 @@ class DownloadFileThread extends Thread {
     private String referrer = "";
     private Map<String,String> cookies = new HashMap<>();
 
-    private URL url;
-    private File saveAs;
-    private String prettySaveAs;
-    private AbstractRipper observer;
-    private int retries;
+    private final URL url;
+    private final File saveAs;
+    private final String prettySaveAs;
+    private final AbstractRipper observer;
+    private final int retries;
 
     private final int TIMEOUT;
 

--- a/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
@@ -163,10 +163,10 @@ class DownloadFileThread extends Thread {
                 // Close any open streams
                 try {
                     if (bis != null) { bis.close(); }
-                } catch (IOException e) { }
+                } catch (IOException ignored) { }
                 try {
                     if (fos != null) { fos.close(); }
-                } catch (IOException e) { }
+                } catch (IOException ignored) { }
             }
             if (tries > this.retries) {
                 logger.error("[!] Exceeded maximum retries (" + this.retries + ") for URL " + url);

--- a/src/main/java/com/rarchives/ripme/ripper/DownloadVideoThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadVideoThread.java
@@ -24,11 +24,11 @@ class DownloadVideoThread extends Thread {
 
     private static final Logger logger = Logger.getLogger(DownloadVideoThread.class);
 
-    private URL url;
-    private File saveAs;
-    private String prettySaveAs;
-    private AbstractRipper observer;
-    private int retries;
+    private final URL url;
+    private final File saveAs;
+    private final String prettySaveAs;
+    private final AbstractRipper observer;
+    private final int retries;
 
     public DownloadVideoThread(URL url, File saveAs, AbstractRipper observer) {
         super();

--- a/src/main/java/com/rarchives/ripme/ripper/DownloadVideoThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadVideoThread.java
@@ -121,10 +121,10 @@ class DownloadVideoThread extends Thread {
                 // Close any open streams
                 try {
                     if (bis != null) { bis.close(); }
-                } catch (IOException e) { }
+                } catch (IOException ignored) { }
                 try {
                     if (fos != null) { fos.close(); }
-                } catch (IOException e) { }
+                } catch (IOException ignored) { }
             }
             if (tries > this.retries) {
                 logger.error("[!] Exceeded maximum retries (" + this.retries + ") for URL " + url);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/AerisdiesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/AerisdiesRipper.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 public class AerisdiesRipper extends AbstractHTMLRipper {
 
     private Document albumDoc = null;
-    private Map<String,String> cookies = new HashMap<>();
+    private final Map<String,String> cookies = new HashMap<>();
 
 
     public AerisdiesRipper(URL url) throws IOException {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CfakeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CfakeRipper.java
@@ -5,6 +5,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -59,7 +60,7 @@ public class CfakeRipper extends AbstractHTMLRipper {
                 String nextPage = elem.attr("href");
                 // Some times this returns a empty string
                 // This for stops that
-                if (nextPage == "") {
+                if (Objects.equals(nextPage, "")) {
                     return null;
                 }
                 else {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -18,7 +18,7 @@ import com.rarchives.ripme.utils.Http;
 import com.rarchives.ripme.utils.RipUtils;
 
 public class ChanRipper extends AbstractHTMLRipper {
-    private static List<ChanSite> explicit_domains = Arrays.asList(
+    private static final List<ChanSite> explicit_domains = Arrays.asList(
         new ChanSite(Arrays.asList("boards.4chan.org"),   Arrays.asList("4cdn.org", "is.4chan.org", "is2.4chan.org")),
         new ChanSite(Arrays.asList("archive.moe"),        Arrays.asList("data.archive.moe")),
         new ChanSite(Arrays.asList("4archive.org"),       Arrays.asList("imgur.com")),
@@ -26,7 +26,7 @@ public class ChanRipper extends AbstractHTMLRipper {
         new ChanSite(Arrays.asList("fgts.jp"),            Arrays.asList("dat.fgtsi.org"))
         );
 
-    private static List<String> url_piece_blacklist = Arrays.asList(
+    private static final List<String> url_piece_blacklist = Arrays.asList(
         "=http",
         "http://imgops.com/",
         "iqdb.org",

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CheebyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CheebyRipper.java
@@ -21,7 +21,7 @@ import com.rarchives.ripme.utils.Http;
 public class CheebyRipper extends AbstractHTMLRipper {
 
     private int offset = 0;
-    private Map<String, Integer> albumSets = new HashMap<>();
+    private final Map<String, Integer> albumSets = new HashMap<>();
 
     public CheebyRipper(URL url) throws IOException {
         super(url);
@@ -169,8 +169,9 @@ public class CheebyRipper extends AbstractHTMLRipper {
     }
 
     private class Image {
-        String url, prefix;
-        int index;
+        final String url;
+        final String prefix;
+        final int index;
         Image(String url, String prefix, int index) {
             this.url = url;
             this.prefix = prefix;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CheveretoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CheveretoRipper.java
@@ -21,7 +21,7 @@ public class CheveretoRipper extends AbstractHTMLRipper {
     super(url);
     }
 
-    private static List<String> explicit_domains_1 = Arrays.asList("hushpix.com", "tag-fox.com");
+    private static final List<String> explicit_domains_1 = Arrays.asList("hushpix.com", "tag-fox.com");
         @Override
         public String getHost() {
             return url.toExternalForm().split("/")[2];

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CheveretoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CheveretoRipper.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -90,7 +91,7 @@ public class CheveretoRipper extends AbstractHTMLRipper {
                 String nextPage = elem.attr("href");
                 // Some times this returns a empty string
                 // This for stops that
-                if (nextPage == "") {
+                if (Objects.equals(nextPage, "")) {
                     return null;
                 }
                 else {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
@@ -33,7 +33,7 @@ public class DeviantartRipper extends AbstractHTMLRipper {
                              IMAGE_SLEEP_TIME = 2000;
 
     private Map<String,String> cookies = new HashMap<>();
-    private Set<String> triedURLs = new HashSet<>();
+    private final Set<String> triedURLs = new HashSet<>();
 
     public DeviantartRipper(URL url) throws IOException {
         super(url);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/E621Ripper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/E621Ripper.java
@@ -29,7 +29,7 @@ public class E621Ripper extends AbstractHTMLRipper{
 	private static Pattern gidPattern2=null;
 	private static Pattern gidPatternPool=null;
 
-	private DownloadThreadPool e621ThreadPool=new DownloadThreadPool("e621");
+	private final DownloadThreadPool e621ThreadPool=new DownloadThreadPool("e621");
 
 	public E621Ripper(URL url) throws IOException {
 		super(url);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EHentaiRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EHentaiRipper.java
@@ -30,7 +30,7 @@ public class EHentaiRipper extends AbstractHTMLRipper {
     private String lastURL = null;
 
     // Thread pool for finding direct image links from "image" pages (html)
-    private DownloadThreadPool ehentaiThreadPool = new DownloadThreadPool("ehentai");
+    private final DownloadThreadPool ehentaiThreadPool = new DownloadThreadPool("ehentai");
     @Override
     public DownloadThreadPool getThreadPool() {
         return ehentaiThreadPool;
@@ -189,9 +189,9 @@ public class EHentaiRipper extends AbstractHTMLRipper {
      * Handles case when site has IP-banned the user.
      */
     private class EHentaiImageThread extends Thread {
-        private URL url;
-        private int index;
-        private File workingDir;
+        private final URL url;
+        private final int index;
+        private final File workingDir;
 
         EHentaiImageThread(URL url, int index, File workingDir) {
             super();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -3,11 +3,7 @@ package com.rarchives.ripme.ripper.rippers;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -97,7 +93,7 @@ public class EightmusesRipper extends AbstractHTMLRipper {
             for (Element subalbum : albumsList) {
                 String subUrl = subalbum.attr("href");
                 // This if is to skip ads which don't have a href
-                if (subUrl != "") {
+                if (!Objects.equals(subUrl, "")) {
                     subUrl = subUrl.replaceAll("\\.\\./", "");
                     if (subUrl.startsWith("//")) {
                         subUrl = "https:";

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -24,8 +24,6 @@ public class EightmusesRipper extends AbstractHTMLRipper {
     // the map for storing the title of each album when downloading sub albums
     private Map<URL,String> urlTitles = new HashMap<>();
 
-    private Boolean rippingSubalbums = false;
-
     public EightmusesRipper(URL url) throws IOException {
         super(url);
     }
@@ -128,7 +126,6 @@ public class EightmusesRipper extends AbstractHTMLRipper {
                             addURLToDownload(imageUrl, getPrefix(prefix), albumTitle, this.url.toExternalForm(), cookies);
                             prefix = prefix + 1;
                         }
-                        rippingSubalbums = true;
                         imageURLs.addAll(subalbumImages);
                     } catch (IOException e) {
                         logger.warn("Error while loading subalbum " + subUrl, e);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -23,7 +23,7 @@ import com.rarchives.ripme.utils.Http;
 public class EightmusesRipper extends AbstractHTMLRipper {
 
     private Document albumDoc = null;
-    private Map<String,String> cookies = new HashMap<>();
+    private final Map<String,String> cookies = new HashMap<>();
     // TODO put up a wiki page on using maps to store titles
     // the map for storing the title of each album when downloading sub albums
     private Map<URL,String> urlTitles = new HashMap<>();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EroShareRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EroShareRipper.java
@@ -10,6 +10,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -86,7 +87,7 @@ public class EroShareRipper extends AbstractHTMLRipper {
             throw new IOException("No more pages");
         }
             nextUrl = elem.attr("href");
-            if (nextUrl == "") {
+            if (Objects.equals(nextUrl, "")) {
                 throw new IOException("No more pages");
             }
             return Http.url("eroshae.com" + nextUrl).get();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FlickrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FlickrRipper.java
@@ -28,7 +28,7 @@ import com.rarchives.ripme.utils.Utils;
 public class FlickrRipper extends AbstractHTMLRipper {
 
     private int page = 1;
-    private Set<String> attempted = new HashSet<>();
+    private final Set<String> attempted = new HashSet<>();
     private Document albumDoc = null;
     private final DownloadThreadPool flickrThreadPool;
     @Override
@@ -236,8 +236,8 @@ public class FlickrRipper extends AbstractHTMLRipper {
      * Helper class to find and download images found on "image" pages
      */
     private class FlickrImageThread extends Thread {
-        private URL    url;
-        private int    index;
+        private final URL    url;
+        private final int    index;
 
         FlickrImageThread(URL url, int index) {
             super();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
@@ -32,7 +32,7 @@ public class FuraffinityRipper extends AbstractHTMLRipper {
     private static final String urlBase = "https://www.furaffinity.net";
 
     // Thread pool for finding direct image links from "image" pages (html)
-    private DownloadThreadPool furaffinityThreadPool
+    private final DownloadThreadPool furaffinityThreadPool
                                = new DownloadThreadPool( "furaffinity");
 
     @Override
@@ -228,7 +228,7 @@ public class FuraffinityRipper extends AbstractHTMLRipper {
     }
 
     private class FuraffinityDocumentThread extends Thread {
-        private URL url;
+        private final URL url;
 
         FuraffinityDocumentThread(URL url) {
             super();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImagebamRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImagebamRipper.java
@@ -23,7 +23,7 @@ public class ImagebamRipper extends AbstractHTMLRipper {
     private Document albumDoc = null;
 
     // Thread pool for finding direct image links from "image" pages (html)
-    private DownloadThreadPool imagebamThreadPool = new DownloadThreadPool("imagebam");
+    private final DownloadThreadPool imagebamThreadPool = new DownloadThreadPool("imagebam");
     @Override
     public DownloadThreadPool getThreadPool() {
         return imagebamThreadPool;
@@ -121,8 +121,8 @@ public class ImagebamRipper extends AbstractHTMLRipper {
      * Handles case when site has IP-banned the user.
      */
     private class ImagebamImageThread extends Thread {
-        private URL url;
-        private int index;
+        private final URL url;
+        private final int index;
 
         ImagebamImageThread(URL url, int index) {
             super();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImagevenueRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImagevenueRipper.java
@@ -20,7 +20,7 @@ import com.rarchives.ripme.utils.Utils;
 public class ImagevenueRipper extends AbstractHTMLRipper {
 
     // Thread pool for finding direct image links from "image" pages (html)
-    private DownloadThreadPool imagevenueThreadPool = new DownloadThreadPool("imagevenue");
+    private final DownloadThreadPool imagevenueThreadPool = new DownloadThreadPool("imagevenue");
     @Override
     public DownloadThreadPool getThreadPool() {
         return imagevenueThreadPool;
@@ -80,8 +80,8 @@ public class ImagevenueRipper extends AbstractHTMLRipper {
      * Handles case when site has IP-banned the user.
      */
     private class ImagevenueImageThread extends Thread {
-        private URL url;
-        private int index;
+        private final URL url;
+        private final int index;
 
         ImagevenueImageThread(URL url, int index) {
             super();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/LusciousRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/LusciousRipper.java
@@ -5,6 +5,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,7 +51,7 @@ public class LusciousRipper extends AbstractHTMLRipper {
         // This is here for pages with mp4s instead of images
         String video_image = "";
         video_image = page.select("div > video > source").attr("src");
-        if (video_image != "") {
+        if (!Objects.equals(video_image, "")) {
             urls.add(video_image);
         }
         return urls;
@@ -61,7 +62,7 @@ public class LusciousRipper extends AbstractHTMLRipper {
         // Find next page
         String nextPageUrl = "https://luscious.net" + doc.select("a.image_link[rel=next]").attr("href");
         // The more_like_this is here so we don't try to download the page that comes after the end of an album
-        if (nextPageUrl == "https://luscious.net" ||
+        if (Objects.equals(nextPageUrl, "https://luscious.net") ||
         nextPageUrl.contains("more_like_this")) {
             throw new IOException("No more pages");
         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MediacrushRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MediacrushRipper.java
@@ -102,7 +102,7 @@ public class MediacrushRipper extends AbstractJSONRipper {
                 URL javaUrl = new URL("https://www.java.com/en/download/");
                 try {
                     Desktop.getDesktop().browse(javaUrl.toURI());
-                } catch (URISyntaxException use) { }
+                } catch (URISyntaxException ignored) { }
             }
             throw new IOException("Cannot rip due to limitations in Java installation, consider upgrading Java", re.getCause());
         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MotherlessRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MotherlessRipper.java
@@ -123,8 +123,8 @@ public class MotherlessRipper extends AlbumRipper {
      * Helper class to find and download images found on "image" pages
      */
     private class MotherlessImageThread extends Thread {
-        private URL url;
-        private int index;
+        private final URL url;
+        private final int index;
 
         MotherlessImageThread(URL url, int index) {
             super();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -7,6 +7,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jsoup.nodes.Document;
@@ -73,7 +74,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
             if (m.matches()) {
                 nextUrl = "http://myhentaicomics.com" + m.group(0);
                 }
-            if (nextUrl == "") {
+            if (Objects.equals(nextUrl, "")) {
                 throw new IOException("No more pages");
             }
             // Sleep for half a sec to avoid getting IP banned
@@ -100,7 +101,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
                 Element elem = nextAlbumPage.select("a.ui-icon-right").first();
                 String nextPage = elem.attr("href");
                 pageNumber = pageNumber + 1;
-                if (nextPage == "") {
+                if (Objects.equals(nextPage, "")) {
                     logger.info("Got " + pageNumber + " pages");
                     break;
                 }
@@ -220,7 +221,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
         // If true the page is a page of albums
         if (doc.toString().contains("class=\"g-item g-album\"")) {
             // This if checks that there is more than 1 page
-            if (doc.select("a.ui-icon-right").last().attr("href") != "") {
+            if (!Objects.equals(doc.select("a.ui-icon-right").last().attr("href"), "")) {
                 // There is more than one page so we call getListOfPages
                 List<String> pagesToRip = getListOfPages(doc);
                 logger.debug("Pages to rip = " + pagesToRip);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NfsfwRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NfsfwRipper.java
@@ -149,9 +149,9 @@ public class NfsfwRipper extends AlbumRipper {
      * Helper class to find and download images found on "image" pages
      */
     private class NfsfwImageThread extends Thread {
-        private URL url;
-        private String subdir;
-        private int index;
+        private final URL url;
+        private final String subdir;
+        private final int index;
 
         NfsfwImageThread(URL url, String subdir, int index) {
             super();
@@ -187,8 +187,8 @@ public class NfsfwRipper extends AlbumRipper {
     }
 
     private class Pair {
-        String first;
-        String second;
+        final String first;
+        final String second;
         Pair(String first, String second) {
             this.first = first;
             this.second = second;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NhentaiRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NhentaiRipper.java
@@ -26,7 +26,7 @@ public class NhentaiRipper extends AbstractHTMLRipper {
     private Document firstPage;
 
     // Thread pool for finding direct image links from "image" pages (html)
-    private DownloadThreadPool nhentaiThreadPool = new DownloadThreadPool("nhentai");
+    private final DownloadThreadPool nhentaiThreadPool = new DownloadThreadPool("nhentai");
 
     @Override
     public DownloadThreadPool getThreadPool() {
@@ -109,9 +109,9 @@ public class NhentaiRipper extends AbstractHTMLRipper {
 
     private class NHentaiImageThread extends Thread {
 
-        private URL url;
-        private int index;
-        private File workingDir;
+        private final URL url;
+        private final int index;
+        private final File workingDir;
 
         NHentaiImageThread(URL url, int index, File workingDir) {
             super();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PornhubRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PornhubRipper.java
@@ -24,7 +24,7 @@ public class PornhubRipper extends AlbumRipper {
     private static final String DOMAIN = "pornhub.com", HOST = "Pornhub";
 
     // Thread pool for finding direct image links from "image" pages (html)
-    private DownloadThreadPool pornhubThreadPool = new DownloadThreadPool("pornhub");
+    private final DownloadThreadPool pornhubThreadPool = new DownloadThreadPool("pornhub");
 
     // Current HTML document
     private Document albumDoc = null;
@@ -131,8 +131,8 @@ public class PornhubRipper extends AlbumRipper {
      * Handles case when site has IP-banned the user.
      */
     private class PornhubImageThread extends Thread {
-        private URL url;
-        private int index;
+        private final URL url;
+        private final int index;
 
         PornhubImageThread(URL url, int index, File workingDir) {
             super();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SankakuComplexRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SankakuComplexRipper.java
@@ -21,7 +21,7 @@ import com.rarchives.ripme.utils.Http;
 
 public class SankakuComplexRipper extends AbstractHTMLRipper {
     private Document albumDoc = null;
-    private Map<String,String> cookies = new HashMap<>();
+    private final Map<String,String> cookies = new HashMap<>();
 
     public SankakuComplexRipper(URL url) throws IOException {
         super(url);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TapasticRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TapasticRipper.java
@@ -18,8 +18,8 @@ import com.rarchives.ripme.utils.Http;
 import com.rarchives.ripme.utils.Utils;
 
 class TapasticEpisode {
-    int id;
-    String filename;
+    final int id;
+    final String filename;
     public TapasticEpisode(int index, int id, String title) {
         int index1 = index;
         this.id    = id;
@@ -30,7 +30,7 @@ class TapasticEpisode {
 
 public class TapasticRipper extends AbstractHTMLRipper {
 
-    private List<TapasticEpisode> episodes= new ArrayList<>();
+    private final List<TapasticEpisode> episodes= new ArrayList<>();
 
     public TapasticRipper(URL url) throws IOException {
         super(url);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -31,7 +31,7 @@ public class TumblrRipper extends AlbumRipper {
     private ALBUM_TYPE albumType;
     private String subdomain, tagName, postNumber;
 
-    private static String TUMBLR_AUTH_CONFIG_KEY = "tumblr.auth";
+    private static final String TUMBLR_AUTH_CONFIG_KEY = "tumblr.auth";
 
     private static boolean useDefaultApiKey = false; // fall-back for bad user-specified key
     private static final String DEFAULT_API_KEY = "JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX";

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -226,7 +227,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             nextPage = elem.attr("href");
         }
 
-        if (nextPage == "") {
+        if (Objects.equals(nextPage, "")) {
             throw new IOException("No more pages");
         } else {
             return Http.url(nextPage).get();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -34,7 +34,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
     // http://tnbtu.com/comic/01-00/
     // http://shipinbottle.pepsaga.com/?p=281
 
-    private static List<String> explicit_domains = Arrays.asList(
+    private static final List<String> explicit_domains = Arrays.asList(
         "www.totempole666.com",
         "buttsmithy.com",
         "themonsterunderthebed.net",

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ZizkiRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ZizkiRipper.java
@@ -20,7 +20,7 @@ import com.rarchives.ripme.utils.Http;
 public class ZizkiRipper extends AbstractHTMLRipper {
 
     private Document albumDoc = null;
-    private Map<String,String> cookies = new HashMap<>();
+    private final Map<String,String> cookies = new HashMap<>();
 
     public ZizkiRipper(URL url) throws IOException {
         super(url);

--- a/src/main/java/com/rarchives/ripme/ui/ClipboardUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/ClipboardUtils.java
@@ -47,7 +47,7 @@ class ClipboardUtils {
 
 class AutoripThread extends Thread {
     volatile boolean isRunning = false;
-    private Set<String> rippedURLs = new HashSet<>();
+    private final Set<String> rippedURLs = new HashSet<>();
 
     public void run() {
         isRunning = true;

--- a/src/main/java/com/rarchives/ripme/ui/ContextMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/ContextMenuMouseListener.java
@@ -18,13 +18,13 @@ import javax.swing.text.JTextComponent;
  * @author Bozhidar Batsov
  */
 public class ContextMenuMouseListener extends MouseAdapter {
-    private JPopupMenu popup = new JPopupMenu();
+    private final JPopupMenu popup = new JPopupMenu();
 
-    private Action cutAction;
-    private Action copyAction;
-    private Action pasteAction;
-    private Action undoAction;
-    private Action selectAllAction;
+    private final Action cutAction;
+    private final Action copyAction;
+    private final Action pasteAction;
+    private final Action undoAction;
+    private final Action selectAllAction;
 
     private JTextComponent textComponent;
     private String savedString = "";

--- a/src/main/java/com/rarchives/ripme/ui/HistoryMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/HistoryMenuMouseListener.java
@@ -11,7 +11,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JTable;
 
 class HistoryMenuMouseListener extends MouseAdapter {
-    private JPopupMenu popup = new JPopupMenu();
+    private final JPopupMenu popup = new JPopupMenu();
     private JTable tableComponent;
 
     @SuppressWarnings("serial")

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -234,7 +234,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         //If creating the tray icon fails, ignore it.
         try {
             setupTrayIcon();
-        } catch (Exception e) { }
+        } catch (Exception ignored) { }
 
         EmptyBorder emptyBorder = new EmptyBorder(5, 5, 5, 5);
         GridBagConstraints gbc = new GridBagConstraints();
@@ -310,7 +310,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             optionQueue.setIcon(new ImageIcon(icon));
             icon = ImageIO.read(getClass().getClassLoader().getResource("gear.png"));
             optionConfiguration.setIcon(new ImageIcon(icon));
-        } catch (Exception e) { }
+        } catch (Exception ignored) { }
         gbc.gridx = 0; optionsPanel.add(optionLog, gbc);
         gbc.gridx = 1; optionsPanel.add(optionHistory, gbc);
         gbc.gridx = 2; optionsPanel.add(optionQueue, gbc);
@@ -500,7 +500,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             configSaveDirLabel.setText(workingDir);
             configSaveDirLabel.setForeground(Color.BLUE);
             configSaveDirLabel.setCursor(new Cursor(Cursor.HAND_CURSOR));
-        } catch (Exception e) { }
+        } catch (Exception ignored) { }
         configSaveDirLabel.setToolTipText(configSaveDirLabel.getText());
         configSaveDirLabel.setHorizontalAlignment(JLabel.RIGHT);
         configSaveDirButton = new JButton("Select Save Directory...");
@@ -668,7 +668,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             }
             try {
                 historyTableModel.fireTableDataChanged();
-            } catch (Exception e) { }
+            } catch (Exception ignored) { }
             saveHistory();
         });
         historyButtonClear.addActionListener(event -> {
@@ -676,7 +676,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             HISTORY.clear();
             try {
                 historyTableModel.fireTableDataChanged();
-            } catch (Exception e) { }
+            } catch (Exception ignored) { }
             saveHistory();
         });
 
@@ -719,7 +719,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 Desktop desktop = Desktop.getDesktop();
                 try {
                     desktop.open(file);
-                } catch (Exception e1) { }
+                } catch (Exception ignored) { }
             }
         });
         configSaveDirButton.addActionListener(arg0 -> {
@@ -859,7 +859,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                     about.append("</li>");
                 }
                 about.append("</ul>");
-            } catch (Exception e) { }
+            } catch (Exception ignored) { }
            about.append("<br>And download videos from video sites:");
             try {
                 List<String> rippers = Utils.getListOfVideoRippers();
@@ -874,7 +874,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                     about.append("</li>");
                 }
                 about.append("</ul>");
-            } catch (Exception e) { }
+            } catch (Exception ignored) { }
 
             about.append("Do you want to visit the project homepage on Github?");
             about.append("</html>");
@@ -951,7 +951,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             synchronized (this) {
                 sd.insertString(sd.getLength(), text + "\n", sas);
             }
-        } catch (BadLocationException e) { }
+        } catch (BadLocationException ignored) { }
 
         logText.setCaretPosition(sd.getLength());
     }
@@ -1185,7 +1185,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 entry.count = rsc.count;
                 try {
                     entry.title = ripper.getAlbumTitle(ripper.getURL());
-                } catch (MalformedURLException e) { }
+                } catch (MalformedURLException ignored) { }
                 HISTORY.add(entry);
                 historyTableModel.fireTableDataChanged();
             }
@@ -1204,7 +1204,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             try {
                 Image folderIcon = ImageIO.read(getClass().getClassLoader().getResource("folder.png"));
                 openButton.setIcon(new ImageIcon(folderIcon));
-            } catch (Exception e) { }
+            } catch (Exception ignored) { }
             appendLog("Rip complete, saved to " + f.getAbsolutePath(), Color.GREEN);
             openButton.setActionCommand(f.toString());
             openButton.addActionListener(event -> {

--- a/src/main/java/com/rarchives/ripme/ui/QueueMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/QueueMenuMouseListener.java
@@ -15,7 +15,7 @@ import javax.swing.JPopupMenu;
 import com.rarchives.ripme.utils.Utils;
 
 class QueueMenuMouseListener extends MouseAdapter {
-    private JPopupMenu popup = new JPopupMenu();
+    private final JPopupMenu popup = new JPopupMenu();
     private JList queueList;
     private DefaultListModel queueListModel;
 

--- a/src/main/java/com/rarchives/ripme/ui/RipStatusMessage.java
+++ b/src/main/java/com/rarchives/ripme/ui/RipStatusMessage.java
@@ -16,14 +16,14 @@ public class RipStatusMessage {
         COMPLETED_BYTES("Completed bytes"),
         RIP_ERRORED("Rip Errored");
 
-        String value;
+        final String value;
         STATUS(String value) {
             this.value = value;
         }
     }
 
-    private STATUS status;
-    private Object object;
+    private final STATUS status;
+    private final Object object;
 
     public RipStatusMessage(STATUS status, Object object) {
         this.status = status;

--- a/src/main/java/com/rarchives/ripme/utils/Base64.java
+++ b/src/main/java/com/rarchives/ripme/utils/Base64.java
@@ -8,7 +8,7 @@ public class Base64 {
 
     private final static char[] ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".toCharArray();
 
-    private static int[] toInt = new int[128];
+    private static final int[] toInt = new int[128];
 
     static {
         for (int i = 0; i < ALPHABET.length; i++) {

--- a/src/main/java/com/rarchives/ripme/utils/Http.java
+++ b/src/main/java/com/rarchives/ripme/utils/Http.java
@@ -26,7 +26,7 @@ public class Http {
     private static final Logger logger  = Logger.getLogger(AbstractRipper.class);
 
     private int retries;
-    private String url;
+    private final String url;
     private Connection connection;
 
     // Constructors

--- a/src/main/java/com/rarchives/ripme/utils/RipUtils.java
+++ b/src/main/java/com/rarchives/ripme/utils/RipUtils.java
@@ -98,7 +98,7 @@ public class RipUtils {
             String u = url.toExternalForm().replaceAll("&amp;", "&");
             try {
                 result.add(new URL(u));
-            } catch (MalformedURLException e) {
+            } catch (MalformedURLException ignored) {
             }
             return result;
         }

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -407,7 +407,7 @@ public class Utils {
         logger.info("Loaded " + logFile);
         try {
             stream.close();
-        } catch (IOException e) { }
+        } catch (IOException ignored) { }
     }
 
     /**


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [X] a refactoring
* [ ] a style change/fix


# Description

I ran IdeaC code analyst tool on ripme and let it auto fix a bunch of simple errors, as with any automated code cleanup this should be tested pretty heavily before being merged.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
