### PR TITLE
Chan ripper now falls back on page title if thread title can not be …

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -68,8 +68,7 @@ public class ChanRipper extends AbstractHTMLRipper {
             if (subject != null) {
                 return getHost() + "_" + getGID(url) + "_" + subject;
             }
-            subject = doc.select("title").text();
-            return getHost() + "_" + getGID(url) + "_" + subject;
+            return doc.select("title").first().text();
         } catch (Exception e) {
             // Fall back to default album naming convention
             logger.warn("Failed to get album title from " + url, e);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -20,10 +20,8 @@ import com.rarchives.ripme.utils.RipUtils;
 public class ChanRipper extends AbstractHTMLRipper {
     private static List<ChanSite> explicit_domains = Arrays.asList(
         new ChanSite(Arrays.asList("boards.4chan.org"),   Arrays.asList("4cdn.org", "is.4chan.org", "is2.4chan.org")),
-        new ChanSite(Arrays.asList("archive.moe"),        Arrays.asList("data.archive.moe")),
         new ChanSite(Arrays.asList("4archive.org"),       Arrays.asList("imgur.com")),
-        new ChanSite(Arrays.asList("archive.4plebs.org"), Arrays.asList("img.4plebs.org")),
-        new ChanSite(Arrays.asList("fgts.jp"),            Arrays.asList("dat.fgtsi.org"))
+        new ChanSite(Arrays.asList("archive.4plebs.org"), Arrays.asList("img.4plebs.org"))
         );
 
     private static List<String> url_piece_blacklist = Arrays.asList(
@@ -67,6 +65,10 @@ public class ChanRipper extends AbstractHTMLRipper {
             // Attempt to use album title as GID
             Document doc = getFirstPage();
             String subject = doc.select(".post.op > .postinfo > .subject").first().text();
+            if (subject != null) {
+                return getHost() + "_" + getGID(url) + "_" + subject;
+            }
+            subject = doc.select("title").text();
             return getHost() + "_" + getGID(url) + "_" + subject;
         } catch (Exception e) {
             // Fall back to default album naming convention


### PR DESCRIPTION
…found

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

The chanripper will now use the page title as the album title if the thread title can not be found


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
