### PR TITLE
Fixed chan ripper thread title (For real this time)

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -64,9 +64,11 @@ public class ChanRipper extends AbstractHTMLRipper {
         try {
             // Attempt to use album title as GID
             Document doc = getFirstPage();
-            String subject = doc.select(".post.op > .postinfo > .subject").first().text();
-            if (subject != null) {
+            try {
+                String subject = doc.select(".post.op > .postinfo > .subject").first().text();
                 return getHost() + "_" + getGID(url) + "_" + subject;
+            } catch (NullPointerException e) {
+                logger.warn("Failed to get thread title from " + url);
             }
             return doc.select("title").first().text();
         } catch (Exception e) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

The ripper now returns the page title if the thread title is null


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
