### PR TITLE
Change to IG ripper filename format and move from JSON ripper to HTML

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -65,39 +65,6 @@ public class InstagramRipper extends AbstractHTMLRipper {
         throw new MalformedURLException("Unable to find user in " + url);
     }
 
-//    @Override
-//    public URL sanitizeURL(URL url) throws MalformedURLException {
-//        Pattern p = Pattern.compile("^.*instagram\\.com/([a-zA-Z0-9\\-_.]+).*$");
-//        Matcher m = p.matcher(url.toExternalForm());
-//        if (m.matches()) {
-//            return new URL("http://instagram.com/" + m.group(1));
-//        }
-//
-//        throw new MalformedURLException("Expected username in URL (instagram.com/username and not " + url);
-//    }
-
-    private String getUserID(URL url) throws IOException {
-
-        Pattern p = Pattern.compile("^https?://instagram\\.com/([^/]+)");
-        Matcher m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return m.group(1);
-        }
-
-        p = Pattern.compile("^https?://www.instagram.com/([^/]+)/?");
-        m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return m.group(1);
-        }
-        
-        p = Pattern.compile("^https?://(www.)?instagram.com/p/[a-zA-Z0-9_-]+/\\?taken-by=([^/]+)");
-        m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return m.group(1);
-        }
-
-        throw new IOException("Unable to find userID at " + this.url);
-    }
     private JSONObject getJSONFromPage(Document firstPage) throws IOException {
         String jsonText = "";
         try {
@@ -115,7 +82,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
 
     @Override
     public Document getFirstPage() throws IOException {
-        userID = getUserID(url);
+        userID = getGID(url);
         return Http.url(url).get();
     }
 
@@ -131,6 +98,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
 
     private String getOriginalUrl(String imageURL) {
         imageURL = imageURL.replaceAll("scontent.cdninstagram.com/hphotos-", "igcdn-photos-d-a.akamaihd.net/hphotos-ak-");
+        // TODO replace this with a single regex
         imageURL = imageURL.replaceAll("p150x150/", "");
         imageURL = imageURL.replaceAll("p320x320/", "");
         imageURL = imageURL.replaceAll("p480x480/", "");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -3,6 +3,8 @@ package com.rarchives.ripme.ripper.rippers;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -17,6 +19,7 @@ import com.rarchives.ripme.utils.Http;
 
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+
 
 public class InstagramRipper extends AbstractJSONRipper {
 
@@ -137,6 +140,9 @@ public class InstagramRipper extends AbstractJSONRipper {
         JSONArray datas = profilePage.getJSONObject(0).getJSONObject("user").getJSONObject("media").getJSONArray("nodes");
         for (int i = 0; i < datas.length(); i++) {
             JSONObject data = (JSONObject) datas.get(i);
+            Long epoch = data.getLong("date");
+            Instant instant = Instant.ofEpochSecond(epoch);
+            String image_date = DateTimeFormatter.ofPattern("yyyy_MM_dd_hh:mm_").format(ZonedDateTime.ofInstant(instant, ZoneOffset.UTC));
             try {
                 if (!data.getBoolean("is_video")) {
                     if (imageURLs.size() == 0) {
@@ -144,9 +150,9 @@ public class InstagramRipper extends AbstractJSONRipper {
                         // the ripper will error out because we returned an empty array
                         imageURLs.add(data.getString("thumbnail_src"));
                     }
-                    addURLToDownload(new URL(getOriginalUrl(data.getString("thumbnail_src"))));
+                    addURLToDownload(new URL(getOriginalUrl(data.getString("thumbnail_src"))), image_date);
                 } else {
-                    addURLToDownload(new URL(getVideoFromPage(data.getString("code"))));
+                    addURLToDownload(new URL(getVideoFromPage(data.getString("code"))), image_date);
                 }
             } catch (MalformedURLException e) {
                 return  imageURLs;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #138)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

When downloading a file from instagram the ripper ripper now includes the date the image was posted in the file name, I also added support for ripping single posts (Both video and image) and moved from abstractJSONRipper to abstractHTMLRipper because abstractJSONRipper was unable to rip single posts


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
