### PR TITLE
chanRipper now falls back to  getHost() and getGID(), not page title

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -117,6 +117,12 @@ public class ChanRipper extends AbstractHTMLRipper {
             if (m.matches()) {
                 return m.group(1);
             }
+            // xchan
+            p = Pattern.compile("^.*\\.[a-z]{1,3}/board/[a-zA-Z0-9]+/thread/([0-9]+)/?.*$");
+            m = p.matcher(u);
+            if (m.matches()) {
+                return m.group(1);
+            }
         }
 
         throw new MalformedURLException(

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -70,12 +70,12 @@ public class ChanRipper extends AbstractHTMLRipper {
             } catch (NullPointerException e) {
                 logger.warn("Failed to get thread title from " + url);
             }
-            return doc.select("title").first().text();
         } catch (Exception e) {
             // Fall back to default album naming convention
             logger.warn("Failed to get album title from " + url, e);
         }
-        return super.getAlbumTitle(url);
+        // Fall back on the GID
+        return getHost() + "_" + getGID(url);
     }
 
     @Override
@@ -211,6 +211,6 @@ public class ChanRipper extends AbstractHTMLRipper {
 
     @Override
     public void downloadURL(URL url, int index) {
-        addURLToDownload(url, getPrefix(index), "", this.url.toString(), null);
+        addURLToDownload(url, getPrefix(index));
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #197)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

I changed the album title fall back from the page title, to the hostname and album GID and added a regex to match xchan 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
