### PR TITLE
Added ripper for theyiffgallery

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TheyiffgalleryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TheyiffgalleryRipper.java
@@ -1,0 +1,75 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class TheyiffgalleryRipper extends AbstractHTMLRipper {
+
+    public TheyiffgalleryRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "theyiffgallery";
+    }
+
+    @Override
+    public String getDomain() {
+        return "theyiffgallery.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https?://theyiffgallery.com/index\\?/category/(\\d+)");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected theyiffgallery URL format: " +
+                "theyiffgallery.com/index?/category/#### - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        String nextPage = doc.select("span.navPrevNext > a").attr("href");
+        if (nextPage != null && !nextPage.isEmpty() && nextPage.contains("start-")) {
+            return Http.url("https://theyiffgallery.com/" + nextPage).get();
+        }
+        throw new IOException("No more pages");
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        for (Element el : doc.select("ul.thumbnails > li.gdthumb")) {
+            String imageSource = el.select("a > img").attr("src");
+            imageSource = imageSource.replaceAll("_data/i", "");
+            imageSource = imageSource.replaceAll("-\\w\\w_\\w\\d+x\\d+", "");
+            result.add("https://theyiffgallery.com" + imageSource);
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
@@ -28,6 +28,7 @@ import com.rarchives.ripme.ripper.rippers.VidbleRipper;
 import com.rarchives.ripme.ripper.rippers.VineRipper;
 import com.rarchives.ripme.ripper.rippers.VkRipper;
 import com.rarchives.ripme.ripper.rippers.XhamsterRipper;
+import com.rarchives.ripme.ripper.rippers.TheyiffgalleryRipper;
 
 /**
  * Simple test cases for various rippers.
@@ -211,6 +212,11 @@ public class BasicRippersTest extends RippersTest {
 
     public void testPornhubRip() throws IOException {
         AbstractRipper ripper = new PornhubRipper(new URL("https://www.pornhub.com/album/15680522"));
+        testRipper(ripper);
+    }
+
+    public void testTheyiffgallery() throws IOException {
+        AbstractRipper ripper = new TheyiffgalleryRipper(new URL("https://theyiffgallery.com/index?/category/4303"));
         testRipper(ripper);
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [X] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

I added a ripper for theyiffgallery


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [X] I've added a unit test to cover my change.
