### PR TITLE
Pichunter galleries support

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PichunterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PichunterRipper.java
@@ -47,8 +47,23 @@ public class PichunterRipper extends AbstractHTMLRipper {
         if (m.matches()) {
             return m.group(1);
         }
+
+        p = Pattern.compile("https?://www.pichunter.com/gallery/\\d+/([a-zA-Z0-9_-]+)/?");
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
         throw new MalformedURLException("Expected pichunter URL format: " +
                 "pichunter.com/(tags|models|sites)/Name/ - got " + url + " instead");
+    }
+
+    private boolean isPhotoSet(URL url) {
+        Pattern p = Pattern.compile("https?://www.pichunter.com/gallery/\\d+/([a-zA-Z0-9_-]+)/?");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -73,8 +88,14 @@ public class PichunterRipper extends AbstractHTMLRipper {
     @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
-        for (Element el : doc.select("div.thumbtable > a.thumb > img")) {
-            result.add(el.attr("src").replaceAll("_i", "_o"));
+        if (!isPhotoSet(url)) {
+            for (Element el : doc.select("div.thumbtable > a.thumb > img")) {
+                result.add(el.attr("src").replaceAll("_i", "_o"));
+            }
+        } else {
+            for (Element el : doc.select("div.flex-images > figure > a.item > img")) {
+                result.add(el.attr("src").replaceAll("_i", "_o"));
+            }
         }
         return result;
     }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BasicRippersTest.java
@@ -194,8 +194,13 @@ public class BasicRippersTest extends RippersTest {
     }
 
     public void testPichunterRip() throws IOException {
+        // A non-photoset
         AbstractRipper ripper = new PichunterRipper(new URL("https://www.pichunter.com/models/Madison_Ivy"));
         testRipper(ripper);
+        // a photo set
+        ripper = new PichunterRipper(new URL("http://www.pichunter.com/gallery/3270642/Its_not_only_those_who"));
+        testRipper(ripper);
+
     }
 
     public void testMotherlessAlbumRip() throws IOException {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #208 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Added support for pichunter galleries


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [X] I've added a unit test to cover my change.
