### PR TITLE
Update size abbreviations e.g. from kb, mb, to KiB, MiB

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -367,13 +367,13 @@ public class Utils {
 
     public static String bytesToHumanReadable(int bytes) {
         float fbytes = (float) bytes;
-        String[] mags = new String[] {"", "k", "m", "g", "t"};
+        String[] mags = new String[] {"", "K", "M", "G", "T"};
         int magIndex = 0;
         while (fbytes >= 1024) {
             fbytes /= 1024;
             magIndex++;
         }
-        return String.format("%.2f%sb", fbytes, mags[magIndex]);
+        return String.format("%.2f%siB", fbytes, mags[magIndex]);
     }
 
     public static List<String> getListOfAlbumRippers() throws Exception {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [x] a style change/fix


# Description

For example, kb is incorrect because lowercase k is not a correct abbreviation of kilo- and lowercase b means bits not Bytes. Correct abbreviation would be KB (if dividing by 1000 at each magnitude) or KiB (if dividing by 1024 at each magnitude). Since we are using the latter, update display to be e.g. KiB, MiB instead of kb, mb.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
