### PR TITLE
Fix #211: Add Utils.filesystemSanitized and apply to filename prefix.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -183,6 +183,7 @@ public abstract class AbstractRipper
             if (!subdirectory.equals("")) {
                 subdirectory = File.separator + subdirectory;
             }
+            prefix = Utils.filesystemSanitized(prefix);
             saveFileAs = new File(
                     workingDir.getCanonicalPath()
                     + subdirectory

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -144,6 +144,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
                 Long epoch = data.getLong("date");
                 Instant instant = Instant.ofEpochSecond(epoch);
                 String image_date = DateTimeFormatter.ofPattern("yyyy_MM_dd_hh:mm_").format(ZonedDateTime.ofInstant(instant, ZoneOffset.UTC));
+
                 try {
                     if (!data.getBoolean("is_video")) {
                         if (imageURLs.size() == 0) {
@@ -158,8 +159,8 @@ public class InstagramRipper extends AbstractHTMLRipper {
                 } catch (MalformedURLException e) {
                     return imageURLs;
                 }
-                nextPageID = data.getString("id");
 
+                nextPageID = data.getString("id");
 
                 if (isThisATest()) {
                     break;

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -355,6 +355,11 @@ public class Utils {
                 + path.substring(path.length() - SHORTENED_PATH_LENGTH);
     }
 
+    public static String filesystemSanitized(String text) {
+        text = text.replaceAll("[^a-zA-Z0-9.-]", "_");
+        return text;
+    }
+
     public static String filesystemSafe(String text) {
         text = text.replaceAll("[^a-zA-Z0-9.-]", "_")
                    .replaceAll("__", "_")


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #211)


# Description

Prefix for file name was not sanitized in any way. Now it is sanitized with `Utils.filesystemSanitized` which converts all unacceptable characters to `_`, but not as extreme as `Utils.filesystemSafe` which also deduplicates `_` and strips them from the end.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
