### PR TITLE
Improved instagram regex and added sanitizeURL

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -44,6 +44,13 @@ public class InstagramRipper extends AbstractHTMLRipper {
     }
 
     @Override
+    public URL sanitizeURL(URL url) throws MalformedURLException {
+       URL san_url = new URL(url.toExternalForm().replaceAll("\\?hl=\\S*", ""));
+       logger.info("sanitized URL is " + san_url.toExternalForm());
+        return san_url;
+    }
+
+    @Override
     public String getGID(URL url) throws MalformedURLException {
         Pattern p = Pattern.compile("^https?://instagram.com/([^/]+)/?");
         Matcher m = p.matcher(url.toExternalForm());
@@ -51,7 +58,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
             return m.group(1);
         }
 
-        p = Pattern.compile("^https?://www.instagram.com/([^/]+)/?");
+        p = Pattern.compile("^https?://www.instagram.com/([^/]+)/?(?:\\?hl=\\S*)?/?");
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #218)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

I improved the regex to allow for /?hl=$LANG to come after the url and added and added a sanitizeURL() func


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
