### PR TITLE
Added support for ripping from IG tags

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -186,7 +186,12 @@ public class InstagramRipper extends AbstractHTMLRipper {
                     try {
                         // Sleep for a while to avoid a ban
                         sleep(2500);
-                        getURLsFromPage(Http.url(url.toExternalForm() + "?max_id=" + nextPageID).get());
+                        if (url.toExternalForm().substring(url.toExternalForm().length() - 1).equals("/")) {
+                            getURLsFromPage(Http.url(url.toExternalForm() + "?max_id=" + nextPageID).get());
+                        } else {
+                            getURLsFromPage(Http.url(url.toExternalForm() + "/?max_id=" + nextPageID).get());
+                        }
+
                     } catch (IOException e) {
                         return imageURLs;
                     }
@@ -199,6 +204,8 @@ public class InstagramRipper extends AbstractHTMLRipper {
                 } catch (IOException e) {
                     return imageURLs;
                 }
+            } else {
+                logger.warn("Can't get net page");
             }
         } else { // We're ripping from a single page
             logger.info("Ripping from single page");


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

I added the ability to rip from instagram hashtags


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
