### PR TITLE
Fix loggers

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -34,8 +34,14 @@ import com.rarchives.ripme.utils.Utils;
  */
 public class App {
 
-    public static Logger logger;
+    public static final Logger logger;
     private static final History HISTORY = new History();
+
+    static {
+        //initialize logger
+        Utils.configureLogger();
+        logger = Logger.getLogger(App.class);
+    }
 
     public static void main(String[] args) throws MalformedURLException {
         CommandLine cl = getArgs(args);
@@ -44,11 +50,8 @@ public class App {
             System.exit(0);
         }
 
-        //initialize logger
-        Utils.configureLogger();
         System.setProperty("apple.laf.useScreenMenuBar", "true");
         System.setProperty("com.apple.mrj.application.apple.menu.about.name", "RipMe");
-        logger = Logger.getLogger(App.class);
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
 
         if (args.length > 0) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/E621Ripper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/E621Ripper.java
@@ -1,4 +1,3 @@
-
 package com.rarchives.ripme.ripper.rippers;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
@@ -12,19 +11,16 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.log4j.Logger;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
-/**
- *
- * @author
- */
 public class E621Ripper extends AbstractHTMLRipper{
+	private static final Logger logger = Logger.getLogger(E621Ripper.class);
+
 	private static Pattern gidPattern=null;
 	private static Pattern gidPattern2=null;
 	private static Pattern gidPatternPool=null;
@@ -89,7 +85,7 @@ public class E621Ripper extends AbstractHTMLRipper{
 
 					addURLToDownload(new URL(page.getElementById("image").absUrl("src")),Utils.getConfigBoolean("download.save_order",true)?url.getRef()+"-":"");
 				} catch (IOException ex) {
-					Logger.getLogger(E621Ripper.class.getName()).log(Level.SEVERE, null, ex);
+					logger.error(ex);
 				}
 			}
 		}));
@@ -121,7 +117,7 @@ public class E621Ripper extends AbstractHTMLRipper{
 
 			return Utils.filesystemSafe(prefix+new URI(getTerm(url)).getPath());
 		} catch (URISyntaxException ex) {
-			Logger.getLogger(PahealRipper.class.getName()).log(Level.SEVERE, null, ex);
+			logger.error(ex);
 		}
 
 		throw new MalformedURLException("Expected e621.net URL format: e621.net/post/index/1/searchterm - got "+url+" instead");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PahealRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PahealRipper.java
@@ -13,15 +13,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.log4j.Logger;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
 public class PahealRipper extends AbstractHTMLRipper {
+    private static final Logger logger = Logger.getLogger(PahealRipper.class);
+
     private static Map<String, String> cookies = null;
     private static Pattern gidPattern = null;
 
@@ -93,7 +94,7 @@ public class PahealRipper extends AbstractHTMLRipper {
                 + ext);
             addURLToDownload(url, outFile);
         } catch (IOException | URISyntaxException ex) {
-            Logger.getLogger(PahealRipper.class.getName()).log(Level.SEVERE, null, ex);
+            logger.error("Error while downloading URL " + url, ex);
         }
     }
 
@@ -115,7 +116,7 @@ public class PahealRipper extends AbstractHTMLRipper {
         try {
             return Utils.filesystemSafe(new URI(getTerm(url)).getPath());
         } catch (URISyntaxException ex) {
-            Logger.getLogger(PahealRipper.class.getName()).log(Level.SEVERE, null, ex);
+            logger.error(ex);
         }
 
         throw new MalformedURLException("Expected paheal.net URL format: rule34.paheal.net/post/list/searchterm - got " + url + " instead");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XbooruRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XbooruRipper.java
@@ -10,14 +10,15 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.log4j.Logger;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
 public class XbooruRipper extends AbstractHTMLRipper {
+    private static final Logger logger = Logger.getLogger(XbooruRipper.class);
+
     private static Pattern gidPattern = null;
 
     public XbooruRipper(URL url) throws IOException {
@@ -87,7 +88,7 @@ public class XbooruRipper extends AbstractHTMLRipper {
         try {
             return Utils.filesystemSafe(new URI(getTerm(url)).getPath());
         } catch (URISyntaxException ex) {
-            Logger.getLogger(PahealRipper.class.getName()).log(Level.SEVERE, null, ex);
+            logger.error(ex);
         }
 
         throw new MalformedURLException("Expected xbooru.com URL format: xbooru.com/index.php?tags=searchterm - got " + url + " instead");

--- a/src/main/java/com/rarchives/ripme/utils/Http.java
+++ b/src/main/java/com/rarchives/ripme/utils/Http.java
@@ -23,7 +23,7 @@ import com.rarchives.ripme.ripper.AbstractRipper;
 public class Http {
 
     private static final int    TIMEOUT = Utils.getConfigInteger("page.timeout", 5 * 1000);
-    private static final Logger logger  = Logger.getLogger(AbstractRipper.class);
+    private static final Logger logger  = Logger.getLogger(Http.class);
 
     private int retries;
     private String url;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [x] a style change/fix


# Description

Not consistently using log4j and using wrong class names for loggers for some rippers.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change. -- N/A
