### PR TITLE
Added support for ripping single pages from instagram

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -100,7 +100,19 @@ public class InstagramRipper extends AbstractHTMLRipper {
             return m.group(1);
         }
 
-        p = Pattern.compile("^https?://www.instagram.com/p/([a-zA-Z0-9_-]+)/?(?:\\?taken-by=([^/]+)|\\?hl=\\S*/?)?");
+        p = Pattern.compile("^https?://www.instagram.com/p/([a-zA-Z0-9_-]+)/\\?taken-by=([^/]+)/?");
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(2) + "_" + m.group(1);
+        }
+
+        p = Pattern.compile("^https?://www.instagram.com/p/([a-zA-Z0-9_-]+)/?");
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+
+        p = Pattern.compile("^https?://www.instagram.com/p/([a-zA-Z0-9_-]+)/?(?:\\?hl=\\S*)?/?");
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -58,7 +58,6 @@ public class InstagramRipper extends AbstractHTMLRipper {
             if (json.getJSONObject("entry_data").getJSONArray("PostPage")
                     .getJSONObject(0).getJSONObject("graphql").getJSONObject("shortcode_media")
                     .has("edge_sidecar_to_children")) {
-
                 datas = json.getJSONObject("entry_data").getJSONArray("PostPage")
                         .getJSONObject(0).getJSONObject("graphql").getJSONObject("shortcode_media")
                         .getJSONObject("edge_sidecar_to_children").getJSONArray("edges");
@@ -70,7 +69,6 @@ public class InstagramRipper extends AbstractHTMLRipper {
                     } else {
                         imageURLs.add(data.getString("display_url"));
                     }
-
                 }
             } else {
                 JSONObject data = json.getJSONObject("entry_data").getJSONArray("PostPage")
@@ -80,12 +78,8 @@ public class InstagramRipper extends AbstractHTMLRipper {
                 } else {
                     imageURLs.add(data.getString("display_url"));
                 }
-
-
             }
             return imageURLs;
-
-
         } catch (IOException e) {
             logger.error("Unable to get JSON from page " + url.toExternalForm());
             return null;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/InstagramRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/InstagramRipperTest.java
@@ -29,7 +29,8 @@ public class InstagramRipperTest extends RippersTest {
 
     public void testInstagramAlbums() throws IOException {
         List<URL> contentURLs = new ArrayList<>();
-        contentURLs.add(new URL("https://www.instagram.com/Test_User/"));
+        // This unit test is a bit flaky 
+        //contentURLs.add(new URL("https://www.instagram.com/Test_User/"));
         contentURLs.add(new URL("https://www.instagram.com/p/BZ4egP7njW5/?hl=en"));
         contentURLs.add(new URL("https://www.instagram.com/p/BaNPpaHn2zU/"));
         for (URL url : contentURLs) {

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/InstagramRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/InstagramRipperTest.java
@@ -27,15 +27,14 @@ public class InstagramRipperTest extends RippersTest {
         }
     }
 
-    /*
     public void testInstagramAlbums() throws IOException {
         List<URL> contentURLs = new ArrayList<>();
-        contentURLs.add(new URL("http://instagram.com/anacheri"));
+        contentURLs.add(new URL("https://www.instagram.com/Test_User/"));
+        contentURLs.add(new URL("https://www.instagram.com/p/BZ4egP7njW5/?hl=en"));
+        contentURLs.add(new URL("https://www.instagram.com/p/BaNPpaHn2zU/"));
         for (URL url : contentURLs) {
             InstagramRipper ripper = new InstagramRipper(url);
             testRipper(ripper);
         }
     }
-    */
-
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/InstagramRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/InstagramRipperTest.java
@@ -15,6 +15,10 @@ public class InstagramRipperTest extends RippersTest {
         Map<URL, String> testURLs = new HashMap<>();
         testURLs.put(new URL("http://instagram.com/Test_User"), "Test_User");
         testURLs.put(new URL("http://instagram.com/_test_user_"), "_test_user_");
+        testURLs.put(new URL("https://www.instagram.com/p/BZ4egP7njW5/?hl=en"), "BZ4egP7njW5");
+        testURLs.put(new URL("https://www.instagram.com/p/BZ4egP7njW5"), "BZ4egP7njW5");
+        testURLs.put(new URL("https://www.instagram.com/p/BaNPpaHn2zU/?taken-by=hilaryduff"), "hilaryduff_BaNPpaHn2zU");
+        testURLs.put(new URL("https://www.instagram.com/p/BaNPpaHn2zU/"), "BaNPpaHn2zU");
         for (URL url : testURLs.keySet()) {
             InstagramRipper ripper = new InstagramRipper(url);
             ripper.setup();


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #224)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

I added support for ripping from single pages on instagram (Both single picture/video and slideshows)


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
