### PR TITLE
Close #226: re-enable ImagefapRipperTest

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImagefapRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImagefapRipperTest.java
@@ -8,12 +8,8 @@ import java.util.Map;
 import com.rarchives.ripme.ripper.rippers.ImagefapRipper;
 
 public class ImagefapRipperTest extends RippersTest {
-
     public void testImagefapAlbums() throws IOException {
         Map<URL, String> testURLs = new HashMap<>();
-
-        /*
-        Temporarily disabled test. See issue https://github.com/RipMeApp/ripme/issues/226
 
         // Album with specific title
         testURLs.put(new URL("http://www.imagefap.com/pictures/4649440/Frozen-%28Elsa-and-Anna%29?view=2"),
@@ -22,12 +18,10 @@ public class ImagefapRipperTest extends RippersTest {
         // New URL format
         testURLs.put(new URL("http://www.imagefap.com/gallery.php?pgid=fffd68f659befa5535cf78f014e348f1"),
                              "imagefap_fffd68f659befa5535cf78f014e348f1");
-        */
 
         for (URL url : testURLs.keySet()) {
             ImagefapRipper ripper = new ImagefapRipper(url);
             testRipper(ripper);
         }
     }
-
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #226)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

fap.to is back up and rips are working again: restore unit test


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
