### PR TITLE
Close #229: re-enable PhotobucketRipperTest, pages are now loading just fine

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PhotobucketRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PhotobucketRipperTest.java
@@ -6,16 +6,10 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.PhotobucketRipper;
 
 public class PhotobucketRipperTest extends RippersTest {
-    /*
-    // https://github.com/RipMeApp/ripme/issues/229 : Disabled test (temporary) : BasicRippersTest#testPhotobucketRip (timing out)
     public void testPhotobucketRip() throws IOException {
         PhotobucketRipper ripper = new PhotobucketRipper(new URL("http://s844.photobucket.com/user/SpazzySpizzy/library/Album%20Covers?sort=3&page=1"));
         testRipper(ripper);
         deleteSubdirs(ripper.getWorkingDir());
         deleteDir(ripper.getWorkingDir());
     }
-    */
 }
-
-
-


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #229)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Re-enable PhotobucketRipperTest, pages are now loading just fine


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
