### PR TITLE
Re-enable SankakuComplexRipperTest

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SankakuComplexRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SankakuComplexRipperTest.java
@@ -6,7 +6,6 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.SankakuComplexRipper;
 
 public class SankakuComplexRipperTest extends RippersTest {
-    /*
     public void testSankakuChanRip() throws IOException {
         SankakuComplexRipper ripper = new SankakuComplexRipper(new URL("https://chan.sankakucomplex.com/?tags=cleavage"));
         testRipper(ripper);
@@ -15,5 +14,4 @@ public class SankakuComplexRipperTest extends RippersTest {
         SankakuComplexRipper ripper = new SankakuComplexRipper(new URL("https://idol.sankakucomplex.com/?tags=meme_%28me%21me%21me%21%29_%28cosplay%29"));
         testRipper(ripper);
     }
-    */
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix


# Description

Re-enable SankakuComplexRipperTest. SankakuComplexRipper seems to have been fixed in #99 (@cyian-1756).


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
