### PR TITLE
Fix #206: Re-enable XhamsterRipperTest

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XhamsterRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XhamsterRipperTest.java
@@ -6,9 +6,13 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.XhamsterRipper;
 
 public class XhamsterRipperTest extends RippersTest {
-    // https://github.com/RipMeApp/ripme/issues/206 : Disabled test : BasicRippersTest#testXhamsterAlbums -- fix and re-enable
-    // public void testXhamsterAlbums() throws IOException {
-    //     XhamsterRipper ripper = new XhamsterRipper(new URL("https://xhamster.com/photos/gallery/sexy-preggo-girls-9026608"));
-    //     testRipper(ripper);
-    // }
+    public void testXhamsterAlbum1() throws IOException {
+        XhamsterRipper ripper = new XhamsterRipper(new URL("https://xhamster.com/photos/gallery/sexy-preggo-girls-9026608"));
+        testRipper(ripper);
+    }
+
+    public void testXhamsterAlbum2() throws IOException {
+        XhamsterRipper ripper = new XhamsterRipper(new URL("https://xhamster.com/photos/gallery/japanese-dolls-4-asahi-mizuno-7254664"));
+        testRipper(ripper);
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #206)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Fix #206: Re-enable XhamsterRipperTest


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
