### PR TITLE
Improved webtoons folder naming

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
@@ -50,7 +50,7 @@ public class WebtoonsRipper extends AbstractHTMLRipper {
         Pattern pat = Pattern.compile("https?://www.webtoons.com/[a-zA-Z]+/[a-zA-Z]+/([a-zA-Z0-9_-]*)/[a-zA-Z0-9_-]+/\\S*");
         Matcher mat = pat.matcher(url.toExternalForm());
         if (mat.matches()) {
-            return mat.group(1);
+            return getHost() + "_" + mat.group(1);
         }
 
         return super.getAlbumTitle(url);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #262)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

The ripper now includes the site name in the album title


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
