### PR TITLE
Add WordpressComicRipperTest; remove dead site comics-xxx.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -22,7 +22,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         super(url);
     }
 
-    // Test links:
+    // Test links (see also WordpressComicRipperTest.java)
     // http://www.totempole666.com/comic/first-time-for-everything-00-cover/
     // http://buttsmithy.com/archives/comic/p1
     // http://themonsterunderthebed.net/?comic=test-post

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -30,7 +30,6 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
     // http://www.konradokonski.com/sawdust/
     // http://www.konradokonski.com/wiory/
     // http://freeadultcomix.com/finders-feepaid-in-full-sparrow/
-    // http://comics-xxx.com/republic-rendezvous-palcomix-star-wars-xxx/
     // http://tnbtu.com/comic/01-00/
     // http://shipinbottle.pepsaga.com/?p=281
 
@@ -42,7 +41,6 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         "www.konradokonski.com",
         "freeadultcomix.com",
         "thisis.delvecomic.com",
-        "comics-xxx.com",
         "tnbtu.com",
         "shipinbottle.pepsaga.com"
     );

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -30,6 +30,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
     // http://www.konradokonski.com/sawdust/
     // http://www.konradokonski.com/wiory/
     // http://freeadultcomix.com/finders-feepaid-in-full-sparrow/
+    // http://thisis.delvecomic.com/NewWP/comic/in-too-deep/
     // http://tnbtu.com/comic/01-00/
     // http://shipinbottle.pepsaga.com/?p=281
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
@@ -18,23 +18,32 @@ public class WordpressComicRipperTest extends RippersTest {
     // http://tnbtu.com/comic/01-00/
     // http://shipinbottle.pepsaga.com/?p=281
 
+    /*
+    // https://github.com/RipMeApp/ripme/issues/269 - Disabled test - WordpressRipperTest: various domains flaky in CI
     public void test_totempole666() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://www.totempole666.com/comic/first-time-for-everything-00-cover/"));
         testRipper(ripper);
     }
+    */
 
+    /*
+    // https://github.com/RipMeApp/ripme/issues/269 - Disabled test - WordpressRipperTest: various domains flaky in CI
     public void test_buttsmithy() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://buttsmithy.com/archives/comic/p1"));
         testRipper(ripper);
     }
+    */
 
+    /*
+    // https://github.com/RipMeApp/ripme/issues/269 - Disabled test - WordpressRipperTest: various domains flaky in CI
     public void test_themonsterunderthebed() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://themonsterunderthebed.net/?comic=test-post"));
         testRipper(ripper);
     }
+    */
 
     public void test_prismblush() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
@@ -58,11 +67,14 @@ public class WordpressComicRipperTest extends RippersTest {
     }
     */
 
+    /*
+    // https://github.com/RipMeApp/ripme/issues/269 - Disabled test - WordpressRipperTest: various domains flaky in CI
     public void test_freeadultcomix() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://freeadultcomix.com/finders-feepaid-in-full-sparrow/"));
         testRipper(ripper);
     }
+    */
 
     public void test_delvecomic() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
@@ -14,6 +14,7 @@ public class WordpressComicRipperTest extends RippersTest {
     // http://www.konradokonski.com/sawdust/
     // http://www.konradokonski.com/wiory/
     // http://freeadultcomix.com/finders-feepaid-in-full-sparrow/
+    // http://thisis.delvecomic.com/NewWP/comic/in-too-deep/
     // http://tnbtu.com/comic/01-00/
     // http://shipinbottle.pepsaga.com/?p=281
 
@@ -60,6 +61,12 @@ public class WordpressComicRipperTest extends RippersTest {
     public void test_freeadultcomix() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://freeadultcomix.com/finders-feepaid-in-full-sparrow/"));
+        testRipper(ripper);
+    }
+
+    public void test_delvecomic() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("http://thisis.delvecomic.com/NewWP/comic/in-too-deep/"));
         testRipper(ripper);
     }
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
@@ -1,0 +1,84 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.WordpressComicRipper;
+
+public class WordpressComicRipperTest extends RippersTest {
+    // Test links (see also WordpressComicRipper.java)
+    // http://www.totempole666.com/comic/first-time-for-everything-00-cover/
+    // http://buttsmithy.com/archives/comic/p1
+    // http://themonsterunderthebed.net/?comic=test-post
+    // http://prismblush.com/comic/hella-trap-pg-01/
+    // http://www.konradokonski.com/sawdust/
+    // http://www.konradokonski.com/wiory/
+    // http://freeadultcomix.com/finders-feepaid-in-full-sparrow/
+    // http://comics-xxx.com/republic-rendezvous-palcomix-star-wars-xxx/
+    // http://tnbtu.com/comic/01-00/
+    // http://shipinbottle.pepsaga.com/?p=281
+
+    public void test_totempole666() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("http://www.totempole666.com/comic/first-time-for-everything-00-cover/"));
+        testRipper(ripper);
+    }
+
+    public void test_buttsmithy() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("http://buttsmithy.com/archives/comic/p1"));
+        testRipper(ripper);
+    }
+
+    public void test_themonsterunderthebed() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("http://themonsterunderthebed.net/?comic=test-post"));
+        testRipper(ripper);
+    }
+
+    public void test_prismblush() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("http://prismblush.com/comic/hella-trap-pg-01/"));
+        testRipper(ripper);
+    }
+
+    /*
+    // https://github.com/RipMeApp/ripme/issues/266 - WordpressRipper: konradokonski.com previously supported but now cannot rip
+
+    public void test_konradokonski_1() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("http://www.konradokonski.com/sawdust/"));
+        testRipper(ripper);
+    }
+
+    public void test_konradokonski_2() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("http://www.konradokonski.com/wiory/"));
+        testRipper(ripper);
+    }
+    */
+
+    public void test_freeadultcomix() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("http://freeadultcomix.com/finders-feepaid-in-full-sparrow/"));
+        testRipper(ripper);
+    }
+
+    public void test_comicsxxx() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("http://comics-xxx.com/republic-rendezvous-palcomix-star-wars-xxx/"));
+        testRipper(ripper);
+    }
+
+    public void test_tnbtu() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("http://tnbtu.com/comic/01-00/"));
+        testRipper(ripper);
+    }
+
+    public void test_pepsaga() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("http://shipinbottle.pepsaga.com/?p=281"));
+        testRipper(ripper);
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
@@ -14,7 +14,6 @@ public class WordpressComicRipperTest extends RippersTest {
     // http://www.konradokonski.com/sawdust/
     // http://www.konradokonski.com/wiory/
     // http://freeadultcomix.com/finders-feepaid-in-full-sparrow/
-    // http://comics-xxx.com/republic-rendezvous-palcomix-star-wars-xxx/
     // http://tnbtu.com/comic/01-00/
     // http://shipinbottle.pepsaga.com/?p=281
 
@@ -61,12 +60,6 @@ public class WordpressComicRipperTest extends RippersTest {
     public void test_freeadultcomix() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://freeadultcomix.com/finders-feepaid-in-full-sparrow/"));
-        testRipper(ripper);
-    }
-
-    public void test_comicsxxx() throws IOException {
-        WordpressComicRipper ripper = new WordpressComicRipper(
-                new URL("http://comics-xxx.com/republic-rendezvous-palcomix-star-wars-xxx/"));
         testRipper(ripper);
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix


# Description

Add WordpressComicRipperTest, fix and clean up issues it revealed.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
