### PR TITLE
Fix WordpressComicRipper's ripper for freeadultcomix.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -275,9 +275,10 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         }
 
         // freeadultcomix gets it own if because it needs to add http://freeadultcomix.com to the start of each link
+        // TODO review the above comment which no longer applies -- see if there's a refactoring we should do here.
         if (url.toExternalForm().contains("freeadultcomix.com")) {
             for (Element elem : doc.select("div.single-post > p > img.aligncenter")) {
-                result.add("http://freeadultcomix.com" + elem.attr("src"));
+                result.add(elem.attr("src"));
             }
         }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

freeadultcomix.com no longer needs to add domain to image links (and in fact was broken because it did)


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change. (See other PR)
