### PR TITLE
Fix furaffinity

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuraffinityRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuraffinityRipperTest.java
@@ -6,11 +6,8 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.FuraffinityRipper;
 
 public class FuraffinityRipperTest extends RippersTest {
-    // https://github.com/RipMeApp/ripme/issues/183
-    /*
     public void testFuraffinityAlbum() throws IOException {
         FuraffinityRipper ripper = new FuraffinityRipper(new URL("https://www.furaffinity.net/gallery/mustardgas/"));
         testRipper(ripper);
     }
-    */
 }


### PR DESCRIPTION
Replaces #176 by @cyian-1756

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #183)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

I removed all the code for logging in (Which ripme was not able to go anymore due to a change in the login system) so the ripper can now rip all public albums.


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
