### PR TITLE
Instagram ripper now downloads slide shows when ripping user profiles

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -212,7 +212,19 @@ public class InstagramRipper extends AbstractHTMLRipper {
                 Long epoch = data.getLong("date");
                 Instant instant = Instant.ofEpochSecond(epoch);
                 String image_date = DateTimeFormatter.ofPattern("yyyy_MM_dd_hh:mm_").format(ZonedDateTime.ofInstant(instant, ZoneOffset.UTC));
-
+                if (data.getString("__typename").equals("GraphSidecar")) {
+                    try {
+                        Document slideShowDoc = Http.url(new URL ("https://www.instagram.com/p/" + data.getString("code"))).get();
+                        List<String> toAdd = getPostsFromSinglePage(slideShowDoc);
+                        for (int slideShowInt=0; slideShowInt<toAdd.size(); slideShowInt++) {
+                            addURLToDownload(new URL(toAdd.get(slideShowInt)));
+                        }
+                    } catch (MalformedURLException e) {
+                        logger.error("Unable to download slide show, URL was malformed");
+                    } catch (IOException e) {
+                        logger.error("Unable to download slide show");
+                    }
+                }
                 try {
                     if (!data.getBoolean("is_video")) {
                         if (imageURLs.size() == 0) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -217,7 +217,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
                         Document slideShowDoc = Http.url(new URL ("https://www.instagram.com/p/" + data.getString("code"))).get();
                         List<String> toAdd = getPostsFromSinglePage(slideShowDoc);
                         for (int slideShowInt=0; slideShowInt<toAdd.size(); slideShowInt++) {
-                            addURLToDownload(new URL(toAdd.get(slideShowInt)));
+                            addURLToDownload(new URL(toAdd.get(slideShowInt)), image_date + data.getString("code"));
                         }
                     } catch (MalformedURLException e) {
                         logger.error("Unable to download slide show, URL was malformed");


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #273 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

The ripper now downloads all images in slide shows when ripping entire user profiles


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.

Test link: https://www.instagram.com/hilaryduff/

After the first 48 or so images (as of 22/11/2017) you should see images from the slide show https://www.instagram.com/p/BZ4egP7njW5/ start appearing with the name format of $Date_$postCode_$imageName
