### PR TITLE
Minor improvements to Aerisdies folder naming

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/AerisdiesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/AerisdiesRipper.java
@@ -39,26 +39,26 @@ public class AerisdiesRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://www.aerisdies.com/html/lb/([a-z]*_[0-9]*_\\d)\\.html");
+        Pattern p = Pattern.compile("^https?://www.aerisdies.com/html/lb/[a-z]*_(\\d+)_\\d\\.html");
         Matcher m = p.matcher(url.toExternalForm());
         if (!m.matches()) {
             throw new MalformedURLException("Expected URL format: http://www.aerisdies.com/html/lb/albumDIG, got: " + url);
         }
-        return m.group(m.groupCount());
+        return m.group(1);
     }
 
-    @Override
-    public String getAlbumTitle(URL url) throws MalformedURLException {
-        try {
-            // Attempt to use album title as GID
-            String title = getFirstPage().select("title").first().text();
-            return getHost() + "_" + title.trim();
-        } catch (IOException e) {
-            // Fall back to default album naming convention
-            logger.info("Unable to find title at " + url);
-        }
-        return super.getAlbumTitle(url);
-    }
+//    @Override
+//    public String getAlbumTitle(URL url) throws MalformedURLException {
+//        try {
+//            // Attempt to use album title as GID
+//            String title = getFirstPage().select("title").first().text();
+//            return getHost() + "_" + title.trim();
+//        } catch (IOException e) {
+//            // Fall back to default album naming convention
+//            logger.info("Unable to find title at " + url);
+//        }
+//        return super.getAlbumTitle(url);
+//    }
 
     @Override
     public Document getFirstPage() throws IOException {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/AerisdiesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/AerisdiesRipper.java
@@ -47,18 +47,18 @@ public class AerisdiesRipper extends AbstractHTMLRipper {
         return m.group(1);
     }
 
-//    @Override
-//    public String getAlbumTitle(URL url) throws MalformedURLException {
-//        try {
-//            // Attempt to use album title as GID
-//            String title = getFirstPage().select("title").first().text();
-//            return getHost() + "_" + title.trim();
-//        } catch (IOException e) {
-//            // Fall back to default album naming convention
-//            logger.info("Unable to find title at " + url);
-//        }
-//        return super.getAlbumTitle(url);
-//    }
+    @Override
+    public String getAlbumTitle(URL url) throws MalformedURLException {
+        try {
+            // Attempt to use album title as GID
+            String title = getFirstPage().select("div > div > span[id=albumname] > a").first().text();
+            return getHost() + "_" + getGID(url) + "_" + title.trim();
+        } catch (IOException e) {
+            // Fall back to default album naming convention
+            logger.info("Unable to find title at " + url);
+        }
+        return super.getAlbumTitle(url);
+    }
 
     @Override
     public Document getFirstPage() throws IOException {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #258)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

I changed up the GID regex and the getAlbumTitle so it now includes the album title in the folder name

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.

Test link: http://www.aerisdies.com/html/lb/alb_3692_1.html
