### PR TITLE
Fix #266: Enable WordpressComicRipper konradokonski.com tests with updated URLs.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -27,8 +27,8 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
     // http://buttsmithy.com/archives/comic/p1
     // http://themonsterunderthebed.net/?comic=test-post
     // http://prismblush.com/comic/hella-trap-pg-01/
-    // http://www.konradokonski.com/sawdust/
-    // http://www.konradokonski.com/wiory/
+    // http://www.konradokonski.com/sawdust/comic/get-up/
+    // http://www.konradokonski.com/wiory/comic/08182008/
     // http://freeadultcomix.com/finders-feepaid-in-full-sparrow/
     // http://thisis.delvecomic.com/NewWP/comic/in-too-deep/
     // http://tnbtu.com/comic/01-00/
@@ -67,9 +67,15 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
                 return true;
             }
 
-            Pattern konradokonskiPat = Pattern.compile("https?://www.konradokonski.com/sawdust/comic/([a-zA-Z0-9_-]*)/?$");
-            Matcher konradokonskiMat = konradokonskiPat.matcher(url.toExternalForm());
-            if (konradokonskiMat.matches()) {
+            Pattern konradokonskiSawdustPat = Pattern.compile("http://www.konradokonski.com/sawdust/comic/([a-zA-Z0-9_-]*)/?$");
+            Matcher konradokonskiSawdustMat = konradokonskiSawdustPat.matcher(url.toExternalForm());
+            if (konradokonskiSawdustMat.matches()) {
+                return true;
+            }
+
+            Pattern konradokonskiWioryPat = Pattern.compile("http://www.konradokonski.com/wiory/comic/([a-zA-Z0-9_-]*)/?$");
+            Matcher konradokonskiWioryMat = konradokonskiWioryPat.matcher(url.toExternalForm());
+            if (konradokonskiWioryMat.matches()) {
                 return true;
             }
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
@@ -11,8 +11,8 @@ public class WordpressComicRipperTest extends RippersTest {
     // http://buttsmithy.com/archives/comic/p1
     // http://themonsterunderthebed.net/?comic=test-post
     // http://prismblush.com/comic/hella-trap-pg-01/
-    // http://www.konradokonski.com/sawdust/
-    // http://www.konradokonski.com/wiory/
+    // http://www.konradokonski.com/sawdust/comic/get-up/
+    // http://www.konradokonski.com/wiory/comic/08182008/
     // http://freeadultcomix.com/finders-feepaid-in-full-sparrow/
     // http://thisis.delvecomic.com/NewWP/comic/in-too-deep/
     // http://tnbtu.com/comic/01-00/
@@ -51,21 +51,17 @@ public class WordpressComicRipperTest extends RippersTest {
         testRipper(ripper);
     }
 
-    /*
-    // https://github.com/RipMeApp/ripme/issues/266 - WordpressRipper: konradokonski.com previously supported but now cannot rip
-
     public void test_konradokonski_1() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
-                new URL("http://www.konradokonski.com/sawdust/"));
+                new URL("http://www.konradokonski.com/sawdust/comic/get-up/"));
         testRipper(ripper);
     }
 
     public void test_konradokonski_2() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
-                new URL("http://www.konradokonski.com/wiory/"));
+                new URL("http://www.konradokonski.com/wiory/comic/08182008/"));
         testRipper(ripper);
     }
-    */
 
     /*
     // https://github.com/RipMeApp/ripme/issues/269 - Disabled test - WordpressRipperTest: various domains flaky in CI


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #266)


# Description

Enable WordpressComicRipper konradokonski.com tests with updated URLs as discussed in #266.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
