### PR TITLE
Oglaf ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/OglafRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/OglafRipper.java
@@ -1,0 +1,82 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class OglafRipper extends AbstractHTMLRipper {
+
+    public OglafRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "oglaf";
+    }
+
+    @Override
+    public String getDomain() {
+        return "oglaf.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("http://oglaf\\.com/([a-zA-Z1-9_-]*)/?");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected oglaf URL format: " +
+                "oglaf.com/NAME - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        if (doc.select("div#nav > a > div#nx").first() == null) {
+            throw new IOException("No more pages");
+        }
+        Element elem = doc.select("div#nav > a > div#nx").first().parent();
+        String nextPage = elem.attr("href");
+        // Some times this returns a empty string
+        // This for stops that
+        if (nextPage.equals("")) {
+            throw new IOException("No more pages");
+        }
+        else {
+            sleep(1000);
+            return Http.url("http://oglaf.com" + nextPage).get();
+        }
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        for (Element el : doc.select("b > img#strip")) {
+                String imageSource = el.select("img").attr("src");
+                result.add(imageSource);
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/OglafRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/OglafRipper.java
@@ -42,6 +42,11 @@ public class OglafRipper extends AbstractHTMLRipper {
     }
 
     @Override
+    public String getAlbumTitle(URL url) throws MalformedURLException {
+        return getDomain();
+    }
+
+    @Override
     public Document getFirstPage() throws IOException {
         // "url" is an instance field of the superclass
         return Http.url(url).get();

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/OglafRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/OglafRipperTest.java
@@ -1,4 +1,13 @@
 package com.rarchives.ripme.tst.ripper.rippers;
 
-public class OglafRipperTest {
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.OglafRipper;
+
+public class OglafRipperTest extends RippersTest {
+    public void testRip() throws IOException {
+        OglafRipper ripper = new OglafRipper(new URL("http://oglaf.com/plumes/"));
+        testRipper(ripper);
+    }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/OglafRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/OglafRipperTest.java
@@ -1,0 +1,4 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+public class OglafRipperTest {
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a new Ripper


# Description

A ripper for oglaf.com


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [X] I've added a unit test to cover my change.
