### PR TITLE
Added hasASAPRipping(), which if returns true allows a ripper to not …

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -53,7 +53,6 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
     protected boolean hasDescriptionSupport() {
         return false;
     }
-    public boolean hasASAPRipping() { return false; }
     protected String[] getDescription(String url, Document page) throws IOException {
         throw new IOException("getDescription not implemented"); // Do I do this or make an abstract function?
     }

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -53,7 +53,7 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
     protected boolean hasDescriptionSupport() {
         return false;
     }
-    public boolean hasASAPRipping() {return false;}
+    public boolean hasASAPRipping() { return false; }
     protected String[] getDescription(String url, Document page) throws IOException {
         throw new IOException("getDescription not implemented"); // Do I do this or make an abstract function?
     }
@@ -69,9 +69,8 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
         Document doc = getFirstPage();
 
         while (doc != null) {
-            List<String> imageURLs;
+            List<String> imageURLs = getURLsFromPage(doc);
             if (!hasASAPRipping()) {
-                imageURLs = getURLsFromPage(doc);
                 // Remove all but 1 image
                 if (isThisATest()) {
                     while (imageURLs.size() > 1) {

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -53,6 +53,7 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
     protected boolean hasDescriptionSupport() {
         return false;
     }
+    public boolean hasASAPRipping() {return false;}
     protected String[] getDescription(String url, Document page) throws IOException {
         throw new IOException("getDescription not implemented"); // Do I do this or make an abstract function?
     }
@@ -68,24 +69,27 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
         Document doc = getFirstPage();
 
         while (doc != null) {
-            List<String> imageURLs = getURLsFromPage(doc);
-            // Remove all but 1 image
-            if (isThisATest()) {
-                while (imageURLs.size() > 1) {
-                    imageURLs.remove(1);
+            List<String> imageURLs;
+            if (!hasASAPRipping()) {
+                imageURLs = getURLsFromPage(doc);
+                // Remove all but 1 image
+                if (isThisATest()) {
+                    while (imageURLs.size() > 1) {
+                        imageURLs.remove(1);
+                    }
                 }
-            }
 
-            if (imageURLs.size() == 0) {
-                throw new IOException("No images found at " + doc.location());
-            }
+                if (imageURLs.size() == 0) {
+                    throw new IOException("No images found at " + doc.location());
+                }
 
-            for (String imageURL : imageURLs) {
-                index += 1;
-                logger.debug("Found image url #" + index + ": " + imageURL);
-                downloadURL(new URL(imageURL), index);
-                if (isStopped()) {
-                    break;
+                for (String imageURL : imageURLs) {
+                    index += 1;
+                    logger.debug("Found image url #" + index + ": " + imageURL);
+                    downloadURL(new URL(imageURL), index);
+                    if (isStopped()) {
+                        break;
+                    }
                 }
             }
             if (hasDescriptionSupport() && Utils.getConfigBoolean("descriptions.save", false)) {

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -43,6 +43,7 @@ public abstract class AbstractRipper
     public abstract void rip() throws IOException;
     public abstract String getHost();
     public abstract String getGID(URL url) throws MalformedURLException;
+    public boolean hasASAPRipping() { return false; }
 
     private boolean shouldStop = false;
     private boolean thisIsATest = false;


### PR DESCRIPTION
…return anything from getURLsFromPage()

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] A api change


# Description

This allows rippers to implement asap ripping (Ripping from getURLsFromPage) without having to return anything. This should help with avoiding any hackish work arounds.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
