### PR TITLE
Fix gfycat parser

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/video/GfycatRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/video/GfycatRipper.java
@@ -65,9 +65,9 @@ public class GfycatRipper extends VideoRipper {
     public static String getVideoURL(URL url) throws IOException {
         logger.info("Retrieving " + url.toExternalForm());
         Document doc = Http.url(url).get();
-        Elements videos = doc.select("source#mp4Source");
+        Elements videos = doc.select("source[type='video/mp4']");
         if (videos.size() == 0) {
-            throw new IOException("Could not find source#mp4source at " + url);
+            throw new IOException("Could not find source[type='video/mp4'] at " + url);
         }
         String vidUrl = videos.first().attr("src");
         if (vidUrl.startsWith("//")) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #233)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Works for both old and new gfycat links


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
