### PR TITLE
SankakuComplexRipper now downloads full sized images

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SankakuComplexRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SankakuComplexRipper.java
@@ -74,7 +74,7 @@ public class SankakuComplexRipper extends AbstractHTMLRipper {
                     // Get the page the full sized image is on
                     Document subPage = Http.url("https://chan.sankakucomplex.com" + postLink).get();
                     logger.info("Checking page " + "https://chan.sankakucomplex.com" + postLink);
-                    imageURLs.add("https:" + subPage.select("div[id=post-content] > a > img").attr("src"));
+                    imageURLs.add("https:" + subPage.select("div[id=stats] > ul > li > a[id=highres]").attr("href"));
                 } catch (IOException e) {
                     logger.warn("Error while loading page " + postLink, e);
                 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #84)


# Description

The ripper now downloads tehe full sized images


# Testing

Required verification:
* [X ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
