### PR TITLE
Added dribbble.com ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DribbbleRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DribbbleRipper.java
@@ -1,0 +1,74 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class DribbbleRipper extends AbstractHTMLRipper {
+
+    public DribbbleRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "dribbble";
+    }
+    @Override
+    public String getDomain() {
+        return "dribbble.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https?://[wm.]*dribbble\\.com/([a-zA-Z0-9]+).*$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected dribbble.com URL format: " +
+                "dribbble.com/albumid - got " + url + "instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        return Http.url(url).get();
+    }
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        // Find next page
+        Elements hrefs = doc.select("a.next_page");
+        if (hrefs.size() == 0) {
+            throw new IOException("No more pages");
+        }
+        String nextUrl = "https://www.dribbble.com" + hrefs.first().attr("href");
+        sleep(500);
+        return Http.url(nextUrl).get();
+    }
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> imageURLs = new ArrayList<>();
+        for (Element thumb : doc.select("a.dribbble-link > picture > source")) {
+            // nl skips thumbnails
+            if ( thumb.attr("srcset").contains("teaser")) continue;
+            String image = thumb.attr("srcset").replace("_1x", "");
+            imageURLs.add(image);
+        }
+        return imageURLs;
+    }
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DribbbleRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DribbbleRipperTest.java
@@ -1,0 +1,13 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.DribbbleRipper;
+
+public class DribbbleRipperTest extends RippersTest {
+    public void testDribbbleRip() throws IOException {
+        DribbbleRipper ripper = new DribbbleRipper(new URL("https://dribbble.com/typogriff"));
+        testRipper(ripper);
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper #320 
* [ ] a refactoring
* [ ] a style change/fix


# Description

Dribbble.com ripper


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
