### PR TITLE
Forced https for tumblr image links

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -192,7 +192,7 @@ public class TumblrRipper extends AlbumRipper {
                 for (int j = 0; j < photos.length(); j++) {
                     photo = photos.getJSONObject(j);
                     try {
-                        fileURL = new URL(photo.getJSONObject("original_size").getString("url"));
+                        fileURL = new URL(photo.getJSONObject("original_size").getString("url").replaceAll("http", "https"));
                         m = p.matcher(fileURL.toString());
                         if (m.matches()) {
                             addURLToDownload(fileURL);
@@ -206,7 +206,7 @@ public class TumblrRipper extends AlbumRipper {
                 }
             } else if (post.has("video_url")) {
                 try {
-                    fileURL = new URL(post.getString("video_url"));
+                    fileURL = new URL(post.getString("video_url").replaceAll("http", "https"));
                     addURLToDownload(fileURL);
                 } catch (Exception e) {
                         logger.error("[!] Error while parsing video in " + post, e);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #336 )


# Description

The ripper now replaces http with https in all links before downloading them, this seems to fix the issue where all tumblr links were throwing 400 errors


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
