### PR TITLE
Erome ripper now matchs links without the www

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package com.rarchives.ripme.ripper.rippers;
 
 import java.io.IOException;
@@ -62,6 +57,11 @@ public class EromeRipper extends AbstractHTMLRipper {
             return super.getAlbumTitle(url);
     }
 
+    @Override
+    public URL sanitizeURL(URL url) throws MalformedURLException {
+        return new URL(url.toExternalForm().replaceAll("https?://erome.com", "https://www.erome.com"));
+    }
+
 
     @Override
     public List<String> getURLsFromPage(Document doc) {
@@ -99,7 +99,15 @@ public class EromeRipper extends AbstractHTMLRipper {
         if (m.matches()) {
             return m.group(1);
         }
-        throw new MalformedURLException("erome album not found in " + url + ", expected https://erome.com/album");
+
+        p = Pattern.compile("^https?://erome.com/a/([a-zA-Z0-9]*)/?$");
+        m = p.matcher(url.toExternalForm());
+
+        if (m.matches()) {
+            return m.group(1);
+        }
+
+        throw new MalformedURLException("erome album not found in " + url + ", expected https://www.erome.com/album");
     }
 
     public static List<URL> getURLs(URL url) throws IOException{


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)


# Description

The ripper now allows the user to add urls with out a www., and just adds the www. to the url before downloading


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
