### PR TITLE
Gfycat url fix

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/video/GfycatRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/video/GfycatRipper.java
@@ -30,8 +30,17 @@ public class GfycatRipper extends VideoRipper {
         return url.getHost().endsWith(HOST);
     }
 
+    /**
+     * Sanitizes URL, fix for issue #356
+     * @param url
+     * @return Sanitized URL
+     * @throws MalformedURLException 
+     */
     @Override
     public URL sanitizeURL(URL url) throws MalformedURLException {
+        if(url.toString().contains("/gifs/detail/")){
+            url = new URL(url.toString().replace("/gifs/detail/", "/"));//Remove /gifs/detail from URL
+        }
         return url;
     }
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/GfycatRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/GfycatRipperTest.java
@@ -1,0 +1,39 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.rarchives.ripme.tst.ripper.rippers;
+
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.video.GfycatRipper;
+
+/**
+ *
+ * @author Bob Zhang
+ */
+public class GfycatRipperTest extends RippersTest{
+    
+
+    /**
+     * What normal people would try to rip.
+     * @throws IOException 
+     */
+    public void testGfycatNormal() throws IOException {
+        GfycatRipper ripper = new GfycatRipper(new URL("https://gfycat.com/TemptingExcellentIchthyosaurs"));
+        testRipper(ripper);
+    }
+    
+     /**
+     * For the kind of people who insist on putting "/gifs/detail/" in the URL
+     * @throws IOException 
+     */
+    public void testGfycatExtendedURL() throws IOException {
+        GfycatRipper ripper = new GfycatRipper(new URL("https://gfycat.com/gifs/detail/TemptingExcellentIchthyosaurs"));
+        testRipper(ripper);
+    }
+}
+


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #356 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description
In sanitizeURL() method to remove "/gifs/detail/" and replace it with "/".
Added JUnit test for Gfycat (both normal and extended links)

# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [X] I've added a unit test to cover my change.
