### PR TITLE
Old Fuskator Test Link Fix

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuskatorRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuskatorRipperTest.java
@@ -7,7 +7,7 @@ import com.rarchives.ripme.ripper.rippers.FuskatorRipper;
 
 public class FuskatorRipperTest extends RippersTest {
     public void testFuskatorAlbum() throws IOException {
-        FuskatorRipper ripper = new FuskatorRipper(new URL("http://fuskator.com/full/emJa1U6cqbi/index.html"));
+        FuskatorRipper ripper = new FuskatorRipper(new URL("https://fuskator.com/thumbs/hqt6pPXAf9z/Shaved-Blonde-Babe-Katerina-Ambre.html"));
         testRipper(ripper);
     }
 }


### PR DESCRIPTION
Would not work, even if human was looking at it.

**This is probably why all travis.cl builds have not been compiling.**

Updated URL to more popular album. Hopefully it will not get deleted in the future.

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #362)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

New Fuskator link for test suite


# Testing
Compile and ran on new test URL.
Nothing else should be affected.


Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
