### PR TITLE
Added basic pornpics.com ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PornpicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PornpicsRipper.java
@@ -1,0 +1,83 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+public class PornpicsRipper extends AbstractHTMLRipper {
+
+    public PornpicsRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "pornpics";
+    }
+
+    @Override
+    public String getDomain() {
+        return "pornpics.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https?://www.pornpics.com/galleries/([a-zA-Z0-9_-]*)/?");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected pornpics URL format: " +
+                "www.pornpics.com/galleries/ID - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+//    @Override
+//    public Document getNextPage(Document doc) throws IOException {
+//        // Find next page
+//        String nextUrl = "";
+//        // We use comic-nav-next to the find the next page
+//        Element elem = doc.select("td > div.next > a").first();
+//        if (elem == null) {
+//            throw new IOException("No more pages");
+//        }
+//        String nextPage = elem.attr("href");
+//        // Some times this returns a empty string
+//        // This for stops that
+//        if (nextPage == "") {
+//            return null;
+//        }
+//        else {
+//            return Http.url("http://cfake.com" + nextPage).get();
+//        }
+//    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        for (Element el : doc.select("a.rel-link")) {
+            result.add(el.attr("href"));
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PornpicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PornpicsRipper.java
@@ -47,26 +47,6 @@ public class PornpicsRipper extends AbstractHTMLRipper {
         return Http.url(url).get();
     }
 
-//    @Override
-//    public Document getNextPage(Document doc) throws IOException {
-//        // Find next page
-//        String nextUrl = "";
-//        // We use comic-nav-next to the find the next page
-//        Element elem = doc.select("td > div.next > a").first();
-//        if (elem == null) {
-//            throw new IOException("No more pages");
-//        }
-//        String nextPage = elem.attr("href");
-//        // Some times this returns a empty string
-//        // This for stops that
-//        if (nextPage == "") {
-//            return null;
-//        }
-//        else {
-//            return Http.url("http://cfake.com" + nextPage).get();
-//        }
-//    }
-
     @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PornpicsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PornpicsRipperTest.java
@@ -1,0 +1,13 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.PornpicsRipper;
+
+public class PornpicsRipperTest extends RippersTest {
+    public void testRip() throws IOException {
+        PornpicsRipper ripper = new PornpicsRipper(new URL("https://www.pornpics.com/galleries/pornstar-dahlia-sky-takes-a-fat-cock-in-her-butthole-wearing-fishnet-stockings/"));
+        testRipper(ripper);
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a new Ripper



# Description

I added a ripper for pornpics.com


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
