### PR TITLE
Webtoons ripper improved image quality

### DIFF
--- a/cd
+++ b/cd
@@ -1,0 +1,1 @@
+/usr/local/bin/mvn

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <!-- At time of writing: JaCoCo is (allegedly) the only coverage report generator that supports Java 8 -->
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.6.201602180812</version>
+        <version>0.8.0</version>
         <executions>
           <execution>
             <id>prepare-agent</id>

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
@@ -71,7 +71,9 @@ public class WebtoonsRipper extends AbstractHTMLRipper {
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<String>();
         for (Element elem : doc.select("div.viewer_img > img")) {
-            result.add(elem.attr("data-url"));
+            String origUrl = elem.attr("data-url");
+            String[] finalUrl = ogUrl.split("\\?type");
+            result.add(finalUrl[0]);
         }
         return result;
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
@@ -72,7 +72,7 @@ public class WebtoonsRipper extends AbstractHTMLRipper {
         List<String> result = new ArrayList<String>();
         for (Element elem : doc.select("div.viewer_img > img")) {
             String origUrl = elem.attr("data-url");
-            String[] finalUrl = ogUrl.split("\\?type");
+            String[] finalUrl = origUrl.split("\\?type");
             result.add(finalUrl[0]);
         }
         return result;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WebtoonsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WebtoonsRipperTest.java
@@ -10,4 +10,9 @@ public class WebtoonsRipperTest extends RippersTest {
         WebtoonsRipper ripper = new WebtoonsRipper(new URL("http://www.webtoons.com/en/drama/my-boo/ep-33/viewer?title_no=1185&episode_no=33"));
         testRipper(ripper);
     }
+
+    public void testWebtoonsType() throws IOException {
+    	WebtoonsRipper ripper = new WebtoonsRipper(new URL("http://webtoon.phinf.naver.net/20180103_72/1514974518278wi4tU_JPEG/151497451824910491454.jpg?type=q90"));
+    	testRipper(ripper);
+    }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WebtoonsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WebtoonsRipperTest.java
@@ -12,7 +12,7 @@ public class WebtoonsRipperTest extends RippersTest {
     }
 
     public void testWebtoonsType() throws IOException {
-    	WebtoonsRipper ripper = new WebtoonsRipper(new URL("http://webtoon.phinf.naver.net/20180103_72/1514974518278wi4tU_JPEG/151497451824910491454.jpg?type=q90"));
+    	WebtoonsRipper ripper = new WebtoonsRipper(new URL("http://www.webtoons.com/en/drama/lookism/ep-145/viewer?title_no=1049&episode_no=145"));
     	testRipper(ripper);
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Previously, URLs taken from webtoons.com would look like "example.png?type=q90" or something like that. I just removed the end part and realized that the images it downloaded were higher quality

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.

  