### PR TITLE
Instagram ripper no longer 403s on certain images

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -161,6 +161,8 @@ public class InstagramRipper extends AbstractHTMLRipper {
     }
 
     private String getOriginalUrl(String imageURL) {
+        // Without this regex most images will return a 403 error
+        imageURL = imageURL.replaceAll("vp/[a-zA-Z0-9]*/", "");
         imageURL = imageURL.replaceAll("scontent.cdninstagram.com/hphotos-", "igcdn-photos-d-a.akamaihd.net/hphotos-ak-");
         // TODO replace this with a single regex
         imageURL = imageURL.replaceAll("p150x150/", "");
@@ -177,6 +179,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
         imageURL = imageURL.replaceAll("s720x720/", "");
         imageURL = imageURL.replaceAll("s1080x1080/", "");
         imageURL = imageURL.replaceAll("s2048x2048/", "");
+
         
         // Instagram returns cropped images to unauthenticated applications to maintain legacy support. 
         // To retrieve the uncropped image, remove this segment from the URL. 
@@ -232,7 +235,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
                         if (imageURLs.size() == 0) {
                             // We add this one item to the array because either wise
                             // the ripper will error out because we returned an empty array
-                            imageURLs.add(data.getString("thumbnail_src"));
+                            imageURLs.add(getOriginalUrl(data.getString("thumbnail_src")));
                         }
                         addURLToDownload(new URL(getOriginalUrl(data.getString("thumbnail_src"))), image_date);
                     } else {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #384)


# Description

The ripper now removes any string matching vp/[a-zA-Z0-9]*/ before downloading an image


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
