### PR TITLE
Twitch ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/video/TwitchVideoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/video/TwitchVideoRipper.java
@@ -1,0 +1,80 @@
+package com.rarchives.ripme.ripper.rippers.video;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+
+import com.rarchives.ripme.ripper.VideoRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class TwitchVideoRipper extends VideoRipper {
+
+    private static final String HOST = "twitch";
+
+    public TwitchVideoRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return HOST;
+    }
+
+    @Override
+    public boolean canRip(URL url) {
+        Pattern p = Pattern.compile("^https://clips\\.twitch\\.tv/.*$");
+        Matcher m = p.matcher(url.toExternalForm());
+        return m.matches();
+    }
+
+    @Override
+    public URL sanitizeURL(URL url) throws MalformedURLException {
+        return url;
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https://clips\\.twitch\\.tv/(.*)$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(m.groupCount());
+        }
+
+        throw new MalformedURLException(
+                "Expected Twitch.tv format:"
+                        + "https://clips.twitch.tv/####"
+                        + " Got: " + url);
+    }
+
+    @Override
+    public void rip() throws IOException {
+        logger.info("Retrieving " + this.url);
+        Document doc = Http.url(url).get();
+        
+        //Get user friendly filename from page title
+        String title = doc.title();
+        
+        Elements script = doc.select("script");
+        if (script.size() == 0) {
+            throw new IOException("Could not find script code at " + url);
+        }
+        //Regex assumes highest quality source is listed first
+        Pattern p = Pattern.compile("\"source\":\"(.*?)\"");
+        
+        for (Element element : script) {
+            Matcher m = p.matcher(element.data());
+            if (m.find()){
+                String vidUrl = m.group(1);
+                addURLToDownload(new URL(vidUrl), HOST + "_" + title);
+            }
+        }
+        waitForThreads();
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VideoRippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VideoRippersTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import com.rarchives.ripme.ripper.VideoRipper;
 import com.rarchives.ripme.ripper.rippers.video.PornhubRipper;
+import com.rarchives.ripme.ripper.rippers.video.TwitchVideoRipper;
 import com.rarchives.ripme.ripper.rippers.video.VineRipper;
 import com.rarchives.ripme.ripper.rippers.video.XvideosRipper;
 import com.rarchives.ripme.ripper.rippers.video.YoupornRipper;
@@ -35,6 +36,15 @@ public class VideoRippersTest extends RippersTest {
         }
     }
 
+    public void testTwitchVideoRipper() throws IOException {
+        List<URL> contentURLs = new ArrayList<>();
+        contentURLs.add(new URL("https://clips.twitch.tv/FaithfulIncredulousPotTBCheesePull"));
+        for (URL url : contentURLs) {
+            TwitchVideoRipper ripper = new TwitchVideoRipper(url);
+            videoTestHelper(ripper);
+        }
+    }
+    
     public void testXvideosRipper() throws IOException {
         List<URL> contentURLs = new ArrayList<>();
         contentURLs.add(new URL("https://www.xvideos.com/video19719109/ziggy_star_ultra_hard_anal_pounding"));


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Add Twitch.tv video ripper requested in #38 by @painerp


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
