### PR TITLE
Make webtoons ripper download maximum quality images

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
@@ -71,7 +71,9 @@ public class WebtoonsRipper extends AbstractHTMLRipper {
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<String>();
         for (Element elem : doc.select("div.viewer_img > img")) {
-            result.add(elem.attr("data-url"));
+            String origUrl = elem.attr("data-url");
+            String[] finalUrl = origUrl.split("\\?type");
+            result.add(finalUrl[0]);
         }
         return result;
     }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WebtoonsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WebtoonsRipperTest.java
@@ -10,4 +10,9 @@ public class WebtoonsRipperTest extends RippersTest {
         WebtoonsRipper ripper = new WebtoonsRipper(new URL("http://www.webtoons.com/en/drama/my-boo/ep-33/viewer?title_no=1185&episode_no=33"));
         testRipper(ripper);
     }
+
+    public void testWebtoonsType() throws IOException {
+    	WebtoonsRipper ripper = new WebtoonsRipper(new URL("http://www.webtoons.com/en/drama/lookism/ep-145/viewer?title_no=1049&episode_no=145"));
+    	testRipper(ripper);
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Previously, the webtoons ripper would download links that looked like `http://webtoon.phinf.naver.net/20180103_245/1514974519142IF53B_JPEG/151497451910910491455.jpg?type=q90`
This  change uses regex to remove the part after the extension, thus allowing the ripper to download the original files without any compression

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
