### PR TITLE
Pornhub fix

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/video/PornhubRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/video/PornhubRipper.java
@@ -68,11 +68,11 @@ public class PornhubRipper extends VideoRipper {
                 title = title.replaceAll("\\+", " ");
 
                 vidUrl = null;
-                for (String quality : new String[] {"quality_1080p", "quality_720p", "quality_480p", "quality_240p"}) {
-                    Pattern pv = Pattern.compile("^.*var player_" + quality + " = '([^']*)'.*$", Pattern.DOTALL);
+                for (String quality : new String[] {"1080", "720", "480", "240"}) {
+                    Pattern pv = Pattern.compile("\"quality\":\"" + quality + "\",\"videoUrl\":\"(.*?)\"");
                     Matcher mv = pv.matcher(html);
-                    if (mv.matches()) {
-                        vidUrl = mv.group(1);
+                    if (mv.find()) {
+                        vidUrl = mv.group(1).replace("\\/", "/");
                         break;
                     }
                 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VideoRippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VideoRippersTest.java
@@ -56,8 +56,6 @@ public class VideoRippersTest extends RippersTest {
         }
     }
 
-    // https://github.com/RipMeApp/ripme/issues/187
-    /*
     public void testPornhubRipper() throws IOException {
         List<URL> contentURLs = new ArrayList<>();
         contentURLs.add(new URL("http://www.pornhub.com/view_video.php?viewkey=993166542"));
@@ -66,7 +64,6 @@ public class VideoRippersTest extends RippersTest {
             videoTestHelper(ripper);
         }
     }
-    */
 
     // https://github.com/RipMeApp/ripme/issues/186
     /*


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fixes #289 & Fixes #187 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Fixes Pornhub ripper bug introduced with website change.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
