### PR TITLE
Tumblr API Key Choosing Fix & More Documentation

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -34,23 +34,30 @@ public class TumblrRipper extends AlbumRipper {
     private ALBUM_TYPE albumType;
     private String subdomain, tagName, postNumber;
 
-    private static String TUMBLR_AUTH_CONFIG_KEY = "tumblr.auth";
+    private static final String TUMBLR_AUTH_CONFIG_KEY = "tumblr.auth";
 
     private static boolean useDefaultApiKey = false; // fall-back for bad user-specified key
-    private static final List<String> apiKeys = Arrays.asList("JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX",
-            "FQrwZMCxVnzonv90rgNUJcAk4FpnoS0mYuSuGYqIpM2cFgp9L4",
-            "qpdkY6nMknksfvYAhf2xIHp0iNRLkMlcWShxqzXyFJRxIsZ1Zz");
-    private static final String API_KEY = apiKeys.get(new Random().nextInt(apiKeys.size()));
+    private static final List<String> APIKEYS = Arrays.asList("JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX",
+                                                              "FQrwZMCxVnzonv90rgNUJcAk4FpnoS0mYuSuGYqIpM2cFgp9L4",
+                                                              "qpdkY6nMknksfvYAhf2xIHp0iNRLkMlcWShxqzXyFJRxIsZ1Zz");
+    private static int genNum = new Random().nextInt(APIKEYS.size());
+    private static final String API_KEY = APIKEYS.get(genNum); // Select random API key from APIKEYS
 
-
-    private static String getApiKey() {
+    /**
+     * Gets the API key. 
+     * Chooses between default/included keys & user specified ones (from the config file).
+     * @return Tumblr API key
+     */
+    public static String getApiKey() {
         if (useDefaultApiKey || Utils.getConfigString(TUMBLR_AUTH_CONFIG_KEY, "JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX").equals("JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX")) {
             logger.info("Using api key: " + API_KEY);
             return API_KEY;
         } else {
-            logger.info("Using user tumblr.auth api key");
-            return Utils.getConfigString(TUMBLR_AUTH_CONFIG_KEY, "JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX");
+            String userDefinedAPIKey = Utils.getConfigString(TUMBLR_AUTH_CONFIG_KEY, "JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX");
+            logger.info("Using user tumblr.auth api key: " + userDefinedAPIKey);
+            return userDefinedAPIKey;
         }
+       
     }
 
     public TumblrRipper(URL url) throws IOException {
@@ -64,7 +71,13 @@ public class TumblrRipper extends AlbumRipper {
     public boolean canRip(URL url) {
         return url.getHost().endsWith(DOMAIN);
     }
-
+    
+    /**
+     * Sanitizes URL.
+     * @param url URL to be sanitized.
+     * @return Sanitized URL
+     * @throws MalformedURLException 
+     */
     @Override
     public URL sanitizeURL(URL url) throws MalformedURLException {
         String u = url.toExternalForm();


### PR DESCRIPTION

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #383 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Fixes API choosing. Creates Random objects, generates a number, then feeds
that number to API_KEY.

This is as opposed to the previous way where it created the Random object,
generated a number, then fed it all in a single line.

Also a bit more Documentation.

# Testing

Hand tested - in 10 tries:
 - 3x JFN...
 - 3x qpd...
 - 4x FQr...
So all in all, pretty even distribution

Also tested on my own fork using Travis CI [here](https://travis-ci.org/kevin51jiang/ripme/builds/330163606).

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
