### PR TITLE
Fix case sensitive directories on unix-based systems

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -197,8 +197,11 @@ public abstract class AlbumRipper extends AbstractRipper {
             title = super.getAlbumTitle(this.url);
         }
         logger.debug("Using album title '" + title + "'");
+
         title = Utils.filesystemSafe(title);
-        path += title + File.separator;
+        path += title;
+        path = Utils.getOriginalDirectory(path) + File.separator;   // check for case sensitive (unix only)
+
         this.workingDir = new File(path);
         if (!this.workingDir.exists()) {
             logger.info("[+] Creating directory: " + Utils.removeCWD(this.workingDir));

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -8,11 +8,7 @@ import java.lang.reflect.Constructor;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
@@ -388,22 +384,20 @@ public class Utils {
 
         String original = path;                                         // needs to be checked if lowercase exists
         String lastPart = original.substring(index+1).toLowerCase();    // setting lowercase to check if it exists
-        String lowerCaseOriginal = path.substring(0, index)
-                + File.separator
-                + lastPart;
 
-        if(original.equals(lowerCaseOriginal)) {
-            // same name, nothing to do
-            return original;
+        // Get a List of all Directories and check its lowercase
+        // if file exists return it
+        File f = new File(path.substring(0, index));
+        ArrayList<String> names = new ArrayList<String>(Arrays.asList(f.list()));
+
+        for (String s : names) {
+            if(s.toLowerCase().equals(lastPart)) {
+                // Building Path of existing file
+                return path.substring(0, index) + File.separator + s;
+            }
         }
 
-        // At last, check if the File with the original exists
-        File f = new File(lowerCaseOriginal);
-        if(f.exists()) {
-            return lowerCaseOriginal;
-        } else {
-            return original;
-        }
+        return original;
     }
 
     public static String bytesToHumanReadable(int bytes) {

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -370,6 +370,42 @@ public class Utils {
         return text;
     }
 
+    /**
+     * Checks if given path already exists as lowercase
+     *
+     * @param path - original path entered to be ripped
+     * @return path of existing folder or the original path if not present
+     */
+    public static String getOriginalDirectory(String path) {
+
+        int index;
+        if(isUnix() || isMacOS()) {
+            index = path.lastIndexOf('/');
+        } else {
+            // current OS is windows - nothing to do here
+            return path;
+        }
+
+        String original = path;                                         // needs to be checked if lowercase exists
+        String lastPart = original.substring(index+1).toLowerCase();    // setting lowercase to check if it exists
+        String lowerCaseOriginal = path.substring(0, index)
+                + File.separator
+                + lastPart;
+
+        if(original.equals(lowerCaseOriginal)) {
+            // same name, nothing to do
+            return original;
+        }
+
+        // At last, check if the File with the original exists
+        File f = new File(original);
+        if(f.exists()) {
+            return original;
+        } else {
+            return lowerCaseOriginal;
+        }
+    }
+
     public static String bytesToHumanReadable(int bytes) {
         float fbytes = (float) bytes;
         String[] mags = new String[] {"", "K", "M", "G", "T"};

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -398,11 +398,11 @@ public class Utils {
         }
 
         // At last, check if the File with the original exists
-        File f = new File(original);
+        File f = new File(lowerCaseOriginal);
         if(f.exists()) {
-            return original;
-        } else {
             return lowerCaseOriginal;
+        } else {
+            return original;
         }
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

This bugfix prevents the creation of multiple directories of the same name with different character cases. Only on Unix-based systems #353 

Code description: 
Getting the filelist of the ./rips directory and compare the lowercase version with existing one. If there is an existing directory, the existing name with correct case will be returned.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
