### PR TITLE
Pornhub regex fix

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/video/PornhubRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/video/PornhubRipper.java
@@ -1,17 +1,15 @@
 package com.rarchives.ripme.ripper.rippers.video;
 
+import com.rarchives.ripme.ripper.VideoRipper;
+import com.rarchives.ripme.utils.Http;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.jsoup.nodes.Document;
-
-import com.rarchives.ripme.ripper.VideoRipper;
-import com.rarchives.ripme.utils.Http;
 
 public class PornhubRipper extends VideoRipper {
 
@@ -28,7 +26,7 @@ public class PornhubRipper extends VideoRipper {
 
     @Override
     public boolean canRip(URL url) {
-        Pattern p = Pattern.compile("^https?://[wm.]*pornhub\\.com/view_video.php\\?viewkey=[0-9]+.*$");
+        Pattern p = Pattern.compile("^https?://[wm.]*pornhub.com/view_video.php\\?viewkey=[a-z0-9]+");
         Matcher m = p.matcher(url.toExternalForm());
         return m.matches();
     }
@@ -40,7 +38,7 @@ public class PornhubRipper extends VideoRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://[wm.]*pornhub\\.com/view_video.php\\?viewkey=([0-9]+).*$");
+        Pattern p = Pattern.compile("^https?://[wm.]*pornhub.com/view_video.php\\?viewkey=([a-z0-9]+)");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PornhubVideoRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PornhubVideoRipperTest.java
@@ -1,0 +1,35 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import com.rarchives.ripme.ripper.rippers.video.PornhubRipper;
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ *
+ * @author Bob Zhang
+ */
+public class PornhubVideoRipperTest extends RippersTest{
+    
+    public void testCanRipTrue() throws IOException{
+        
+        PornhubRipper ripper = new PornhubRipper(new URL("https://www.pornhub.com/view_video.php?viewkey=ph5a65e6760d7ed"));
+        URL toRip = new URL("https://www.pornhub.com/view_video.php?viewkey=ph5a65e6760d7ed");
+        
+        assertTrue(ripper.canRip(toRip));
+    }
+    
+    public void testCanRipFalse() throws IOException{
+        
+        PornhubRipper ripper = new PornhubRipper(new URL("https://www.pornhub.com/view_video.php?viewkey=ph5a65e6760d7ed"));
+        URL toRip = new URL("https://www.pornhub.com/view_video.php?viewkeysss=ph5a65e6760d7ed");
+        
+        assertFalse(ripper.canRip(toRip));
+    }
+    
+    public void testRip() throws IOException{
+        URL toRip = new URL("https://www.pornhub.com/view_video.php?viewkey=ph5a6d8f368249b");
+        PornhubRipper ripper = new PornhubRipper(toRip);
+        testRipper(ripper);
+    }
+    
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

 Regex for the URL seemed a bit outdated. For the viewkey, it seems like instead of just numbers [0-9] the website updated to lowercase numbers and letters [a-z0-9].

Also added a new test class that includes a few things to check a working regex and a testRip().

# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [X] I've added a unit test to cover my change.
