### PR TITLE
 Remove ripper and tests for gwarchives.com and hushpix.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CheveretoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CheveretoRipper.java
@@ -28,7 +28,7 @@ public class CheveretoRipper extends AbstractHTMLRipper {
         super(url);
     }
 
-    private static List<String> explicit_domains_1 = Arrays.asList("hushpix.com", "tag-fox.com", "gwarchives.com");
+    private static List<String> explicit_domains_1 = Arrays.asList("tag-fox.com");
 
     @Override
     public String getHost() {

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CheveretoRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CheveretoRipperTest.java
@@ -6,18 +6,8 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.CheveretoRipper;
 
 public class CheveretoRipperTest extends RippersTest {
-    public void testHushpix() throws IOException {
-        CheveretoRipper ripper = new CheveretoRipper(new URL("https://hushpix.com/album/gKcu"));
-        testRipper(ripper);
-    }
-
     public void testTagFox() throws IOException {
         CheveretoRipper ripper = new CheveretoRipper(new URL("http://tag-fox.com/album/Thjb"));
-        testRipper(ripper);
-    }
-
-    public void testgwarchives() throws IOException {
-        CheveretoRipper ripper = new CheveretoRipper(new URL("https://gwarchives.com/album/ns4q"));
         testRipper(ripper);
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #414 & Fix #415 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description


Remove ripper and tests for gwarchives.com and hushpix.com


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
