### PR TITLE
8muses now supports all page types

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EightmusesRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EightmusesRipperTest.java
@@ -7,7 +7,11 @@ import com.rarchives.ripme.ripper.rippers.EightmusesRipper;
 
 public class EightmusesRipperTest extends RippersTest {
     public void testEightmusesAlbum() throws IOException {
-        EightmusesRipper ripper = new EightmusesRipper(new URL("https://www.8muses.com/album/jab-comics/a-model-life"));
+        // A simple image album
+        EightmusesRipper ripper = new EightmusesRipper(new URL("https://www.8muses.com/comix/album/Affect3D-Comics/TheDude3DX/Lust-Unleashed-The-Urge-To-Explore"));
+        testRipper(ripper);
+        // Test pages with subalbums
+        ripper = new EightmusesRipper(new URL("https://www.8muses.com/comix/album/Blacknwhitecomics_com-Comix/BlacknWhiteComics/The-Mayor"));
         testRipper(ripper);
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #409)


# Description

I rewrote the ripping logic so the ripper now supports ripping pages containing both images and subpages 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
