### PR TITLE
Ripme now supports clipboard ripping for .cafe domains

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/ClipboardUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/ClipboardUtils.java
@@ -57,10 +57,11 @@ class AutoripThread extends Thread {
                 String clipboard = ClipboardUtils.getClipboardString();
                 if (clipboard != null) {
                     Pattern p = Pattern.compile(
+                            // TODO: This regex is a monster and doesn't match all links; It needs to be rewritten
                             "\\b(((ht|f)tp(s?)://|~/|/)|www.)" +
                             "(\\w+:\\w+@)?(([-\\w]+\\.)+(com|org|net|gov" +
                             "|mil|biz|info|mobi|name|aero|jobs|museum" +
-                            "|travel|[a-z]{2}))(:[\\d]{1,5})?" +
+                            "|travel|cafe|[a-z]{2}))(:[\\d]{1,5})?" +
                             "(((/([-\\w~!$+|.,=]|%[a-f\\d]{2})+)+|/)+|\\?|#)?" +
                             "((\\?([-\\w~!$+|.,*:]|%[a-f\\d{2}])+=?" +
                             "([-\\w~!$+|.,*:=]|%[a-f\\d]{2})*)" +


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #380)

# Description

I changed the regex in com/rarchives/ripme/ui/ClipboardUtils.java to include domains ending in .cafe


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
