### PR TITLE
Added support for incase.buttsimthy.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -37,6 +37,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
     private static List<String> explicit_domains = Arrays.asList(
         "www.totempole666.com",
         "buttsmithy.com",
+        "incase.buttsmithy.com",
         "themonsterunderthebed.net",
         "prismblush.com",
         "www.konradokonski.com",
@@ -84,6 +85,12 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             Pattern buttsmithyPat = Pattern.compile("https?://buttsmithy.com/archives/comic/([a-zA-Z0-9_-]*)/?$");
             Matcher buttsmithyMat = buttsmithyPat.matcher(url.toExternalForm());
             if (buttsmithyMat.matches()) {
+                return true;
+            }
+
+            Pattern buttsmithyIncasePat = Pattern.compile("https?://incase.buttsmithy.com/comic/([a-zA-Z0-9_-]*)/?$");
+            Matcher buttsmithyIncaseMat = buttsmithyIncasePat.matcher(url.toExternalForm());
+            if (buttsmithyIncaseMat.matches()) {
                 return true;
             }
 
@@ -176,6 +183,12 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         Matcher prismblushMat = prismblushPat.matcher(url.toExternalForm());
         if (prismblushMat.matches()) {
             return getHost() + "_" + prismblushMat.group(1);
+        }
+
+        Pattern buttsmithyIncasePat = Pattern.compile("https?://incase.buttsmithy.com/comic/([a-zA-Z0-9_-]*)/?$");
+        Matcher buttsmithyIncaseMat = buttsmithyIncasePat.matcher(url.toExternalForm());
+        if (buttsmithyIncaseMat.matches()) {
+            return getHost() + "_" + buttsmithyIncaseMat.group(1).replaceAll("-page-\\d", "").replaceAll("-pg-\\d", "");
         }
 
         Pattern comicsxxxPat = Pattern.compile("https?://comics-xxx.com/([a-zA-Z0-9_\\-]*)/?$");


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a new Ripper


# Description

I added support for incase.buttsimthy.com


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
