### PR TITLE
Added tsuminoRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TsuminoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TsuminoRipper.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.rarchives.ripme.ui.RipStatusMessage;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jsoup.Connection;
@@ -44,6 +45,8 @@ public class TsuminoRipper extends AbstractHTMLRipper {
             return json.getJSONArray("reader_page_urls");
         } catch (IOException e) {
             logger.info(e);
+            sendUpdate(RipStatusMessage.STATUS.DOWNLOAD_ERRORED, "Unable to download album, please compete the captcha at http://www.tsumino.com/Read/Auth/"
+                    + getAlbumID() + " and try again");
             return null;
         }
     }
@@ -82,10 +85,7 @@ public class TsuminoRipper extends AbstractHTMLRipper {
     public Document getFirstPage() throws IOException {
         Connection.Response resp = Http.url(url).response();
         cookies.putAll(resp.cookies());
-        // We need to perform a get on http://www.tsumino.com/Read/View/albumID/1 or else the
-        //www.tsumino.com/Read/Load endpoint 404s
-        resp = Http.url("http://www.tsumino.com/Book/Info/" + getAlbumID()).response();
-        cookies.putAll(resp.cookies());
+        logger.info(resp.parse());
         return resp.parse();
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TsuminoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TsuminoRipper.java
@@ -1,0 +1,108 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class TsuminoRipper extends AbstractHTMLRipper {
+    private Map<String,String> cookies = new HashMap<>();
+
+    public TsuminoRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    private JSONArray getPageUrls() {
+        String postURL = "http://www.tsumino.com/Read/Load";
+        try {
+            // This sessionId will expire and need to be replaced
+            cookies.put("ASP.NET_SessionId","c4rbzccf0dvy3e0cloolmlkq");
+            logger.info(cookies);
+            Document doc = Jsoup.connect(postURL).data("q", getAlbumID()).userAgent(USER_AGENT).cookies(cookies).referrer("http://www.tsumino.com/Read/View/" + getAlbumID()).post();
+            String jsonInfo = doc.html().replaceAll("<html>","").replaceAll("<head></head>", "").replaceAll("<body>", "").replaceAll("</body>", "")
+                    .replaceAll("</html>", "").replaceAll("\n", "");
+            logger.info(jsonInfo);
+            JSONObject json = new JSONObject(jsonInfo);
+            logger.info(json.getJSONArray("reader_page_urls"));
+            return json.getJSONArray("reader_page_urls");
+        } catch (IOException e) {
+            logger.info(e);
+            return null;
+        }
+    }
+
+    @Override
+    public String getHost() {
+        return "tsumino";
+    }
+
+    @Override
+    public String getDomain() {
+        return "tsumino.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https?://www.tsumino.com/Book/Info/([0-9]+)/([a-zA-Z0-9_-]*)");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1) + "_" + m.group(2);
+        }
+        throw new MalformedURLException("Expected tsumino URL format: " +
+                "tsumino.com/Book/Info/ID/TITLE - got " + url + " instead");
+    }
+
+    private String getAlbumID() {
+        Pattern p = Pattern.compile("https?://www.tsumino.com/Book/Info/([0-9]+)/\\S*");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        Connection.Response resp = Http.url(url).response();
+        cookies.putAll(resp.cookies());
+        // We need to perform a get on http://www.tsumino.com/Read/View/albumID/1 or else the
+        //www.tsumino.com/Read/Load endpoint 404s
+        resp = Http.url("http://www.tsumino.com/Book/Info/" + getAlbumID()).response();
+        cookies.putAll(resp.cookies());
+        return resp.parse();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        JSONArray imageIds = getPageUrls();
+        List<String> result = new ArrayList<>();
+        for (int i = 0; i < imageIds.length(); i++) {
+            result.add("http://www.tsumino.com/Image/Object?name=" + URLEncoder.encode(imageIds.getString(i)));
+        }
+
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        sleep(1000);
+        addURLToDownload(url, getPrefix(index));
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a new Ripper



# Description

I added a ripper for tsumino.com


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
