### PR TITLE
Added another overload to addURLToDownload which allows the ripper to…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -174,7 +174,7 @@ public abstract class AbstractRipper
      *      URL of the file
      * @param saveAs
      *      Path of the local file to save the content to.
-     * @return True on success, flase on failure.
+     * @return True on success, false on failure.
      */
     public abstract boolean addURLToDownload(URL url, File saveAs);
 
@@ -206,11 +206,13 @@ public abstract class AbstractRipper
      *      The HTTP referrer to use while downloading this file.
      * @param cookies
      *      The cookies to send to the server while downloading this file.
+     * @param fileName
+     *      The name that file will be written to
      * @return 
      *      True if downloaded successfully
      *      False if failed to download
      */
-    protected boolean addURLToDownload(URL url, String prefix, String subdirectory, String referrer, Map<String, String> cookies) {
+    protected boolean addURLToDownload(URL url, String prefix, String subdirectory, String referrer, Map<String, String> cookies, String fileName) {
         // Don't re-add the url if it was downloaded in a previous rip
         if (Utils.getConfigBoolean("remember.url_history", true) && !isThisATest()) {
             if (hasDownloadedURL(url.toExternalForm())) {
@@ -225,9 +227,18 @@ public abstract class AbstractRipper
             logger.debug("Ripper has been stopped");
             return false;
         }
-        logger.debug("url: " + url + ", prefix: " + prefix + ", subdirectory" + subdirectory + ", referrer: " + referrer + ", cookies: " + cookies);
-        String saveAs = url.toExternalForm();
-        saveAs = saveAs.substring(saveAs.lastIndexOf('/')+1);
+        logger.debug("url: " + url + ", prefix: " + prefix + ", subdirectory" + subdirectory + ", referrer: " + referrer + ", cookies: " + cookies + ", fileName: " + fileName);
+        String saveAs;
+        if (fileName != null) {
+            saveAs = fileName;
+            // Get the extension of the file
+            String extension = url.toExternalForm().substring(url.toExternalForm().lastIndexOf(".") + 1);
+            saveAs = saveAs + "." + extension;
+        } else {
+            saveAs = url.toExternalForm();
+            saveAs = saveAs.substring(saveAs.lastIndexOf('/')+1);
+        }
+
         if (saveAs.indexOf('?') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('?')); }
         if (saveAs.indexOf('#') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('#')); }
         if (saveAs.indexOf('&') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('&')); }
@@ -274,7 +285,11 @@ public abstract class AbstractRipper
      * @return True on success, flase on failure.
      */
     protected boolean addURLToDownload(URL url, String prefix, String subdirectory) {
-        return addURLToDownload(url, prefix, subdirectory, null, null);
+        return addURLToDownload(url, prefix, subdirectory, null, null, null);
+    }
+
+    protected boolean addURLToDownload(URL url, String prefix, String subdirectory, String referrer, Map<String, String> cookies) {
+        return addURLToDownload(url, prefix, subdirectory, referrer, cookies, null);
     }
 
     /**
@@ -290,6 +305,8 @@ public abstract class AbstractRipper
         // Use empty subdirectory
         return addURLToDownload(url, prefix, "");
     }
+
+
     /**
      * Waits for downloading threads to complete.
      */

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -125,7 +125,7 @@ public class EightmusesRipper extends AbstractHTMLRipper {
                         logger.info("Retrieving full-size image location from " + imageHref);
                         image = getFullSizeImage(imageHref);
                         URL imageUrl = new URL(image);
-                        addURLToDownload(imageUrl, getPrefix(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies);
+                        addURLToDownload(imageUrl, getPrefix(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies, "");
                         // X is our page index
                         x++;
 
@@ -180,6 +180,6 @@ public class EightmusesRipper extends AbstractHTMLRipper {
 
     @Override
     public String getPrefix(int index) {
-        return String.format("%03d_", index);
+        return String.format("%03d", index);
     }
 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.rarchives.ripme.utils.Utils;
 import org.jsoup.Connection.Response;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -125,7 +126,11 @@ public class EightmusesRipper extends AbstractHTMLRipper {
                         logger.info("Retrieving full-size image location from " + imageHref);
                         image = getFullSizeImage(imageHref);
                         URL imageUrl = new URL(image);
-                        addURLToDownload(imageUrl, getPrefix(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies, "");
+                        if (Utils.getConfigBoolean("8muses.use_short_names", false)) {
+                            addURLToDownload(imageUrl, getPrefixShort(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies, "");
+                        } else {
+                            addURLToDownload(imageUrl, getPrefixLong(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies);
+                        }
                         // X is our page index
                         x++;
 
@@ -178,8 +183,11 @@ public class EightmusesRipper extends AbstractHTMLRipper {
         addURLToDownload(url, getPrefix(index), "", this.url.toExternalForm(), cookies);
     }
 
-    @Override
-    public String getPrefix(int index) {
+    public String getPrefixLong(int index) {
+        return String.format("%03d_", index);
+    }
+
+    public String getPrefixShort(int index) {
         return String.format("%03d", index);
     }
 }


### PR DESCRIPTION
… set the name of the file; Fixed 8muses filename length issue

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #369)


# Description

I Added an overload to addURLToDownload which allows rippers to set the file name and Fixed 8muses filename length issue


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
