### PR TITLE
Fixed instagram ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -227,7 +227,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
                 String image_date = DateTimeFormatter.ofPattern("yyyy_MM_dd_hh:mm_").format(ZonedDateTime.ofInstant(instant, ZoneOffset.UTC));
                 if (data.getString("__typename").equals("GraphSidecar")) {
                     try {
-                        Document slideShowDoc = Http.url(new URL ("https://www.instagram.com/p/" + data.getString("shortcode"))).get();
+                        Document slideShowDoc = Http.url(new URL("https://www.instagram.com/p/" + data.getString("shortcode"))).get();
                         List<String> toAdd = getPostsFromSinglePage(slideShowDoc);
                         for (int slideShowInt=0; slideShowInt<toAdd.size(); slideShowInt++) {
                             addURLToDownload(new URL(toAdd.get(slideShowInt)), image_date + data.getString("shortcode"));

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -127,11 +127,11 @@ public class InstagramRipper extends AbstractHTMLRipper {
             return m.group(1);
         }
 
-        p = Pattern.compile("^https?://www.instagram.com/explore/tags/([^/]+)/?");
-        m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return m.group(1);
-        }
+//        p = Pattern.compile("^https?://www.instagram.com/explore/tags/([^/]+)/?");
+//        m = p.matcher(url.toExternalForm());
+//        if (m.matches()) {
+//            return m.group(1);
+//        }
 
         throw new MalformedURLException("Unable to find user in " + url);
     }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #469)

# Description

I updated the ripper to work with IGs new JSON structure 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
