### PR TITLE
Improved handling of headless mode & OS-specific config

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FacebookRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FacebookRipper.java
@@ -1,0 +1,4 @@
+package com.rarchives.ripme.ripper.rippers;
+
+public class FacebookRipper {
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FacebookRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FacebookRipper.java
@@ -1,4 +1,0 @@
-package com.rarchives.ripme.ripper.rippers;
-
-public class FacebookRipper {
-}


### PR DESCRIPTION
# Category

This change is exactly one of the following:
* [x] a bug fix (Fix #105 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix

# Description

This adds changes the check for command-lines arguments to avoid throwing an error when no argument is passed on an headless system. It will instead gracefully show the help page to the user.
It also adds a check for the Mac OS-specific properties, to avoid setting them on other systems.
The OS-specific properties and the app initialization have been moved to after the isHeadless check for cleanliness (No need to set GUI properties on an headless app and no need to initialize if we're only going to show an help page).

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
