### PR TITLE
Fixes #410 Imgur - Cannot download albums with a single image in

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImgurRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImgurRipperTest.java
@@ -1,12 +1,12 @@
 package com.rarchives.ripme.tst.ripper.rippers;
 
+import com.rarchives.ripme.ripper.rippers.ImgurRipper;
+import com.rarchives.ripme.ripper.rippers.ImgurRipper.ImgurAlbum;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-
-import com.rarchives.ripme.ripper.rippers.ImgurRipper;
-import com.rarchives.ripme.ripper.rippers.ImgurRipper.ImgurAlbum;
 
 public class ImgurRipperTest extends RippersTest {
 
@@ -17,7 +17,6 @@ public class ImgurRipperTest extends RippersTest {
         failURLs.add(new URL("http://imgur.com/"));
         failURLs.add(new URL("http://i.imgur.com"));
         failURLs.add(new URL("http://i.imgur.com/"));
-        failURLs.add(new URL("http://imgur.com/image"));
         failURLs.add(new URL("http://imgur.com/image.jpg"));
         failURLs.add(new URL("http://i.imgur.com/image.jpg"));
         for (URL url : failURLs) {
@@ -50,6 +49,15 @@ public class ImgurRipperTest extends RippersTest {
         }
     }
 
+    public void testImgurSingleImage() throws IOException {
+        List<URL> contentURLs = new ArrayList<>();
+        contentURLs.add(new URL("http://imgur.com/qbfcLyG")); // Single image URL
+        contentURLs.add(new URL("https://imgur.com/KexUO")); // Single image URL
+        for (URL url : contentURLs) {
+            ImgurRipper ripper = new ImgurRipper(url);
+            testRipper(ripper);
+        }
+    }
 
     public void testImgurAlbumWithMoreThan20Pictures() throws IOException {
         ImgurAlbum album = ImgurRipper.getImgurAlbum(new URL("http://imgur.com/a/HUMsq"));


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #410 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

The issue was caused by recognizing the link as SERIES_OF_IMAGES and failing to find comma in the link which resulted in throwing MalformedUrlException. At first I tried to tackle the problem by treating single image as an album with single image and trying to reuse ripAlbum method, however, I would need to add additional complexity by another if conditions in getImgurAlbum method, which I didn't like. I decided to  fix this issue by introducing new SINGLE__IMAGE type recognizable by another regex expression. and pass the logic to dedicated ripSingleImage method.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
