### PR TITLE
Fix usage of command-line on non-headless systems

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -47,7 +47,7 @@ public class App {
             System.exit(0);
         }
 
-        if (GraphicsEnvironment.isHeadless()) {
+        if (GraphicsEnvironment.isHeadless() || args.length > 0) {
             handleArguments(args);
         } else {
             if (SystemUtils.IS_OS_MAC_OSX) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #497 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Fixes the case of using command-line on a non-headless system, where the GUI would open anyway.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
