### PR TITLE
Fixed Hentai2Read folder naming

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
@@ -33,7 +33,7 @@ public class Hentai2readRipper extends AbstractHTMLRipper {
 
         @Override
         public String getGID(URL url) throws MalformedURLException {
-            Pattern p = Pattern.compile("https://hentai2read\\.com/([a-zA-Z0-9_-]*)/?");
+            Pattern p = Pattern.compile("https?://hentai2read\\.com/([a-zA-Z0-9_-]*)/\\d/?");
             Matcher m = p.matcher(url.toExternalForm());
             if (m.matches()) {
                 return m.group(1);
@@ -63,9 +63,7 @@ public class Hentai2readRipper extends AbstractHTMLRipper {
         @Override
         public String getAlbumTitle(URL url) throws MalformedURLException {
             try {
-                Document doc = getFirstPage();
-                String title = doc.select("span[itemprop=title]").text();
-                return getHost() + "_" + title;
+                return getHost() + "_" + getGID(url);
             } catch (Exception e) {
                 // Fall back to default album naming convention
                 logger.warn("Failed to get album title from " + url, e);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #517)


# Description

The ripper now extracts the comic title from the url


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
