### PR TITLE
[tumblr] avoid 'httpss' in image URLs

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -44,7 +44,7 @@ public class TumblrRipper extends AlbumRipper {
     private static final String API_KEY = APIKEYS.get(genNum); // Select random API key from APIKEYS
 
     /**
-     * Gets the API key. 
+     * Gets the API key.
      * Chooses between default/included keys & user specified ones (from the config file).
      * @return Tumblr API key
      */
@@ -57,7 +57,7 @@ public class TumblrRipper extends AlbumRipper {
             logger.info("Using user tumblr.auth api key: " + userDefinedAPIKey);
             return userDefinedAPIKey;
         }
-       
+
     }
 
     public TumblrRipper(URL url) throws IOException {
@@ -71,12 +71,12 @@ public class TumblrRipper extends AlbumRipper {
     public boolean canRip(URL url) {
         return url.getHost().endsWith(DOMAIN);
     }
-    
+
     /**
      * Sanitizes URL.
      * @param url URL to be sanitized.
      * @return Sanitized URL
-     * @throws MalformedURLException 
+     * @throws MalformedURLException
      */
     @Override
     public URL sanitizeURL(URL url) throws MalformedURLException {
@@ -230,7 +230,7 @@ public class TumblrRipper extends AlbumRipper {
                             urlString = urlString.replaceAll("_\\d+\\.", "_raw.");
                             fileURL = new URL(urlString);
                         } else {
-                            fileURL = new URL(photo.getJSONObject("original_size").getString("url").replaceAll("http", "https"));
+                            fileURL = new URL(photo.getJSONObject("original_size").getString("url").replaceAll("http:", "https:"));
                         }
                         m = p.matcher(fileURL.toString());
                         if (m.matches()) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #523)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Replacing `http` with `https` in an URL already starting with
`https://...` changes its scheme/protocol to `httpss`.

I've simply added a `:` to the replacement strings to prevent this from happening.

(My editor also removed some spaces from the end of some lines)

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
