### PR TITLE
Hentaifoundry ripper no long throws a null error when getting the nex…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
@@ -101,13 +101,6 @@ public class HentaifoundryRipper extends AbstractHTMLRipper {
             }
             Document imagePage;
             try {
-                Response resp = Http.url("http://www.hentai-foundry.com/").response();
-                cookies = resp.cookies();
-                resp = Http.url("http://www.hentai-foundry.com/?enterAgree=1&size=1500")
-                        .referrer("http://www.hentai-foundry.com/")
-                        .cookies(cookies)
-                        .response();
-                cookies.putAll(resp.cookies());
 
                 logger.info("grabbing " + "http://www.hentai-foundry.com" + thumb.attr("href"));
                 imagePage = Http.url("http://www.hentai-foundry.com" + thumb.attr("href")).cookies(cookies).get();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
@@ -52,16 +52,16 @@ public class HentaifoundryRipper extends AbstractHTMLRipper {
         Response resp = Http.url("http://www.hentai-foundry.com/").response();
         cookies = resp.cookies();
         resp = Http.url("http://www.hentai-foundry.com/?enterAgree=1&size=1500")
-                   .referrer("http://www.hentai-foundry.com/")
-                   .cookies(cookies)
-                   .response();
+                .referrer("http://www.hentai-foundry.com/")
+                .cookies(cookies)
+                .response();
         // The only cookie that seems to matter in getting around the age wall is the phpsession cookie
         cookies.putAll(resp.cookies());
         sleep(500);
         resp = Http.url(url)
-                   .referrer("http://www.hentai-foundry.com/")
-                   .cookies(cookies)
-                   .response();
+                .referrer("http://www.hentai-foundry.com/")
+                .cookies(cookies)
+                .response();
         cookies.putAll(resp.cookies());
         return resp.parse();
     }
@@ -74,12 +74,16 @@ public class HentaifoundryRipper extends AbstractHTMLRipper {
         }
         Elements els = doc.select("li.next > a");
         Element first = els.first();
-        String nextURL = first.attr("href");
-        nextURL = "http://www.hentai-foundry.com" + nextURL;
-        return Http.url(nextURL)
-                   .referrer(url)
-                   .cookies(cookies)
-                   .get();
+        try {
+            String nextURL = first.attr("href");
+            nextURL = "http://www.hentai-foundry.com" + nextURL;
+            return Http.url(nextURL)
+                    .referrer(url)
+                    .cookies(cookies)
+                    .get();
+        } catch (NullPointerException e) {
+            throw new IOException("No more pages");
+        }
     }
 
     @Override
@@ -100,9 +104,9 @@ public class HentaifoundryRipper extends AbstractHTMLRipper {
                 Response resp = Http.url("http://www.hentai-foundry.com/").response();
                 cookies = resp.cookies();
                 resp = Http.url("http://www.hentai-foundry.com/?enterAgree=1&size=1500")
-                           .referrer("http://www.hentai-foundry.com/")
-                           .cookies(cookies)
-                           .response();
+                        .referrer("http://www.hentai-foundry.com/")
+                        .cookies(cookies)
+                        .response();
                 cookies.putAll(resp.cookies());
 
                 logger.info("grabbing " + "http://www.hentai-foundry.com" + thumb.attr("href"));


### PR DESCRIPTION
…t page; No longer makes unneeded requests

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #406)


# Description

I removed code that was making an unneeded request and made getNextPage thrown an IOException if it can't get the next page


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
