### PR TITLE
Wordpress 8muses.download

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -44,7 +44,8 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         "freeadultcomix.com",
         "thisis.delvecomic.com",
         "tnbtu.com",
-        "shipinbottle.pepsaga.com"
+        "shipinbottle.pepsaga.com",
+            "8muses.download"
     );
 
     @Override
@@ -135,6 +136,12 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             if (shipinbottleMat.matches()) {
                 return true;
             }
+
+            Pattern eight_musesPat = Pattern.compile("https?://8muses.download/([a-zA-Z0-9_-]+)/?$");
+            Matcher eight_musesMat = eight_musesPat.matcher(url.toExternalForm());
+            if (eight_musesMat.matches()) {
+                return true;
+            }
         }
 
 
@@ -209,6 +216,11 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             return getHost() + "_" + "Ship_in_bottle";
         }
 
+        Pattern eight_musesPat = Pattern.compile("https?://8muses.download/([a-zA-Z0-9_-]+)/?$");
+        Matcher eight_musesMat = eight_musesPat.matcher(url.toExternalForm());
+        if (eight_musesMat.matches()) {
+            return getHost() + "_" + eight_musesMat.group(1);
+        }
         return super.getAlbumTitle(url);
     }
 
@@ -312,6 +324,12 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         if (url.toExternalForm().contains("shipinbottle.pepsaga.com")) {
             for (Element elem : doc.select("div#comic > div.comicpane > a > img")) {
                 result.add(elem.attr("src"));
+            }
+        }
+
+        if (url.toExternalForm().contains("8muses.download")) {
+            for (Element elem : doc.select("div.popup-gallery > figure > a")) {
+                result.add(elem.attr("href"));
             }
         }
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
@@ -83,6 +83,12 @@ public class WordpressComicRipperTest extends RippersTest {
                 new URL("http://tnbtu.com/comic/01-00/"));
         testRipper(ripper);
     }
+
+    public void test_Eightmuses_download() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("https://8muses.download/lustomic-playkittens-josh-samuel-porn-comics-8-muses/"));
+        testRipper(ripper);
+    }
     // https://github.com/RipMeApp/ripme/issues/269 - Disabled test - WordpressRipperTest: various domains flaky in CI
 //    public void test_pepsaga() throws IOException {
 //        WordpressComicRipper ripper = new WordpressComicRipper(


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a new Ripper



# Description

I addded a ripper for 8muses.download


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [X] I've added a unit test to cover my change.
