### PR TITLE
Hitomi ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HitomiRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HitomiRipper.java
@@ -1,0 +1,73 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class HitomiRipper extends AbstractHTMLRipper {
+
+    String galleryId = "";
+
+    public HitomiRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "hitomi";
+    }
+
+    @Override
+    public String getDomain() {
+        return "hitomi.la";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https://hitomi.la/galleries/([\\d]+).html");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            galleryId = m.group(1);
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected hitomi URL format: " +
+                "https://hitomi.la/galleries/ID.html - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // if we go to /GALLERYID.js we get a nice json array of all images in the gallery
+        return Http.url(new URL(url.toExternalForm().replaceAll(".html", ".js"))).ignoreContentType().get();
+    }
+
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        String json = doc.text().replaceAll("var galleryinfo =", "");
+        logger.info(json);
+        JSONArray json_data = new JSONArray(json);
+        for (int i = 0; i < json_data.length(); i++) {
+            result.add("https://0a.hitomi.la/galleries/" + galleryId + "/" + json_data.getJSONObject(i).getString("name"));
+        }
+
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HitomiRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HitomiRipperTest.java
@@ -9,5 +9,6 @@ public class HitomiRipperTest extends RippersTest {
     public void testRip() throws IOException {
         HitomiRipper ripper = new HitomiRipper(new URL("https://hitomi.la/galleries/975973.html"));
         testRipper(ripper);
+        assertTrue(ripper.getGID(new URL("https://hitomi.la/galleries/975973.html")).equals("975973"));
     }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HitomiRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HitomiRipperTest.java
@@ -1,0 +1,13 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.HitomiRipper;
+
+public class HitomiRipperTest extends RippersTest {
+    public void testRip() throws IOException {
+        HitomiRipper ripper = new HitomiRipper(new URL("https://hitomi.la/galleries/975973.html"));
+        testRipper(ripper);
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a new Ripper



# Description

I added a ripper for Hitomi.la


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [X] I've added a unit test to cover my change.
