### PR TITLE
Socks proxy imrpovements

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -7,9 +7,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.FileNotFoundException;
 
-import java.net.Authenticator;
 import java.net.MalformedURLException;
-import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
@@ -43,6 +41,12 @@ public class App {
 
     public static void main(String[] args) throws MalformedURLException {
         CommandLine cl = getArgs(args);
+
+        // Check if there is a proxy setting in the config dir and use it only if the user
+        // hasn't passed -s
+        if (!Utils.getConfigString("socks.proxy", "").equals("") && !cl.hasOption('s')) {
+            Utils.setProxy(Utils.getConfigString("socks.proxy", ""));
+        }
 
         if (args.length > 0 && cl.hasOption('v')){
             logger.info(UpdateUtils.getThisJarVersion());
@@ -98,27 +102,7 @@ public class App {
         }
         
         if (cl.hasOption('s')) {
-            String sservfull = cl.getOptionValue('s').trim();
-            if (sservfull.lastIndexOf("@") != -1) {
-                int sservli = sservfull.lastIndexOf("@");
-                String userpw = sservfull.substring(0, sservli);
-                String[] usersplit = userpw.split(":");
-                String user = usersplit[0];
-                String password = usersplit[1];
-                Authenticator.setDefault(new Authenticator(){
-                    protected  PasswordAuthentication  getPasswordAuthentication(){
-                        PasswordAuthentication p = new PasswordAuthentication(user, password.toCharArray());
-                        return p;
-                    }
-                });
-                
-                sservfull = sservfull.substring(sservli + 1);
-            }
-            String[] servsplit = sservfull.split(":");
-            if (servsplit.length == 2) {
-                System.setProperty("socksProxyPort", servsplit[1]);
-            }
-            System.setProperty("socksProxyHost", servsplit[0]);
+            Utils.setProxy(cl.getOptionValue('s'));
         }
 
         if (cl.hasOption('t')) {

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -5,9 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLDecoder;
+import java.net.*;
 import java.util.*;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -90,6 +88,34 @@ public class Utils {
             workingDir.mkdirs();
         }
         return workingDir;
+    }
+
+    /**
+     * Set the socks proxy to use
+     * @param proxyString proxy to use in format [user:password]@host[:port]
+     */
+    public static void setProxy(String proxyString) {
+        String sservfull = proxyString.trim();
+        if (sservfull.lastIndexOf("@") != -1) {
+            int sservli = sservfull.lastIndexOf("@");
+            String userpw = sservfull.substring(0, sservli);
+            String[] usersplit = userpw.split(":");
+            String user = usersplit[0];
+            String password = usersplit[1];
+            Authenticator.setDefault(new Authenticator(){
+                protected PasswordAuthentication getPasswordAuthentication(){
+                    PasswordAuthentication p = new PasswordAuthentication(user, password.toCharArray());
+                    return p;
+                }
+            });
+
+            sservfull = sservfull.substring(sservli + 1);
+        }
+        String[] servsplit = sservfull.split(":");
+        if (servsplit.length == 2) {
+            System.setProperty("socksProxyPort", servsplit[1]);
+        }
+        System.setProperty("socksProxyHost", servsplit[0]);
     }
 
     public static String getConfigString(String key, String defaultValue) {

--- a/src/test/java/com/rarchives/ripme/tst/proxyTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/proxyTest.java
@@ -1,0 +1,4 @@
+package com.rarchives.ripme.tst;
+
+public class proxyTest {
+}

--- a/src/test/java/com/rarchives/ripme/tst/proxyTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/proxyTest.java
@@ -1,4 +1,26 @@
 package com.rarchives.ripme.tst;
 
-public class proxyTest {
+import java.io.IOException;
+import java.net.URL;
+import com.rarchives.ripme.utils.Utils;
+import junit.framework.TestCase;
+import com.rarchives.ripme.utils.Http;
+
+
+public class proxyTest  extends TestCase {
+    // This test will only run on machines where the user has added a entry for socks.proxy
+    public void testSocksProxy() throws IOException {
+        URL url = new URL("https://icanhazip.com");
+        String proxyConfig = Utils.getConfigString("socks.proxy", "");
+        if (!proxyConfig.equals("")) {
+            String ip1 = Http.url(url).ignoreContentType().get().text();
+            Utils.setProxy(Utils.getConfigString("socks.proxy", ""));
+            String ip2 = Http.url(url).ignoreContentType().get().text();
+            assertFalse(ip1.equals(ip2));
+        } else {
+            System.out.println("SKipping proxyTest");
+            assert(true);
+        }
+    }
+
 }


### PR DESCRIPTION
# Category


# Description

The proxy is now set via the setProxy func in Utils.java. I added a config option for the proxy and added a unit test


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
