### PR TITLE
[hentaifoundry] set content filter

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jsoup.Connection.Method;
 import org.jsoup.Connection.Response;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -49,15 +50,57 @@ public class HentaifoundryRipper extends AbstractHTMLRipper {
 
     @Override
     public Document getFirstPage() throws IOException {
-        Response resp = Http.url("http://www.hentai-foundry.com/").response();
-        cookies = resp.cookies();
+        Response resp;
+        Document doc;
+
         resp = Http.url("http://www.hentai-foundry.com/?enterAgree=1&size=1500")
                 .referrer("http://www.hentai-foundry.com/")
                 .cookies(cookies)
                 .response();
         // The only cookie that seems to matter in getting around the age wall is the phpsession cookie
         cookies.putAll(resp.cookies());
-        sleep(500);
+
+        doc = resp.parse();
+        String csrf_token = doc.select("input[name=YII_CSRF_TOKEN]")
+                               .first().attr("value");
+        if (csrf_token != null) {
+            Map<String,String> data = new HashMap<>();
+            data.put("YII_CSRF_TOKEN"  , csrf_token);
+            data.put("rating_nudity"   , "3");
+            data.put("rating_violence" , "3");
+            data.put("rating_profanity", "3");
+            data.put("rating_racism"   , "3");
+            data.put("rating_sex"      , "3");
+            data.put("rating_spoilers" , "3");
+            data.put("rating_yaoi"     , "1");
+            data.put("rating_yuri"     , "1");
+            data.put("rating_teen"     , "1");
+            data.put("rating_guro"     , "1");
+            data.put("rating_furry"    , "1");
+            data.put("rating_beast"    , "1");
+            data.put("rating_male"     , "1");
+            data.put("rating_female"   , "1");
+            data.put("rating_futa"     , "1");
+            data.put("rating_other"    , "1");
+            data.put("rating_scat"     , "1");
+            data.put("rating_incest"   , "1");
+            data.put("rating_rape"     , "1");
+            data.put("filter_media"    , "A");
+            data.put("filter_order"    , "date_new");
+            data.put("filter_type"     , "0");
+
+            resp = Http.url("http://www.hentai-foundry.com/site/filters")
+                       .referrer("http://www.hentai-foundry.com/")
+                       .cookies(cookies)
+                       .data(data)
+                       .method(Method.POST)
+                       .response();
+            cookies.putAll(resp.cookies());
+        }
+        else {
+            logger.info("unable to find csrf_token and set filter");
+        }
+
         resp = Http.url(url)
                 .referrer("http://www.hentai-foundry.com/")
                 .cookies(cookies)


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #373, maybe #53 as well) 
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Hentai-Foundry, by default, filters quite a few images when looking at a user's gallery, but you can click the "Filters" button in the top-left of the page and adjust your filter settings.

This commit fills out and submits the filter settings form, allowing all content to be shown, before fetching the first page.

For comparison, the same thing is also implemented in my own project: https://github.com/mikf/gallery-dl/blob/a2020c736e8f947a7f44a5daf4cdfd598a29e17b/gallery_dl/extractor/hentaifoundry.py#L115-L145
As you can see, it is possible to get the YII_CSRF_TOKEN from your own cookies, but I didn't want to deal with string operations in Java ...

On another note: The very first request to just "http://www.hentai-foundry.com/" and the `sleep(500);` call are unnecessary. Everything works fine without (and my own stuff doesn't use them either), so I removed them.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
