### PR TITLE
Abstract ripper fixes

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -212,7 +212,7 @@ public abstract class AbstractRipper
      *      True if downloaded successfully
      *      False if failed to download
      */
-    protected boolean addURLToDownload(URL url, String prefix, String subdirectory, String referrer, Map<String, String> cookies, String fileName) {
+    protected boolean addURLToDownload(URL url, String prefix, String subdirectory, String referrer, Map<String, String> cookies, String fileName, String extension) {
         // Don't re-add the url if it was downloaded in a previous rip
         if (Utils.getConfigBoolean("remember.url_history", true) && !isThisATest()) {
             if (hasDownloadedURL(url.toExternalForm())) {
@@ -228,21 +228,7 @@ public abstract class AbstractRipper
             return false;
         }
         logger.debug("url: " + url + ", prefix: " + prefix + ", subdirectory" + subdirectory + ", referrer: " + referrer + ", cookies: " + cookies + ", fileName: " + fileName);
-        String saveAs;
-        if (fileName != null) {
-            saveAs = fileName;
-            // Get the extension of the file
-            String extension = url.toExternalForm().substring(url.toExternalForm().lastIndexOf(".") + 1);
-            saveAs = saveAs + "." + extension;
-        } else {
-            saveAs = url.toExternalForm();
-            saveAs = saveAs.substring(saveAs.lastIndexOf('/')+1);
-        }
-
-        if (saveAs.indexOf('?') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('?')); }
-        if (saveAs.indexOf('#') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('#')); }
-        if (saveAs.indexOf('&') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('&')); }
-        if (saveAs.indexOf(':') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf(':')); }
+        String saveAs = getFileName(url, fileName, extension);
         File saveFileAs;
         try {
             if (!subdirectory.equals("")) {
@@ -272,6 +258,10 @@ public abstract class AbstractRipper
             }
         }
         return addURLToDownload(url, saveFileAs, referrer, cookies);
+    }
+
+    protected boolean addURLToDownload(URL url, String prefix, String subdirectory, String referrer, Map<String, String> cookies, String fileName) {
+        return addURLToDownload(url, prefix, subdirectory, referrer, cookies, fileName, null);
     }
 
     /**
@@ -304,6 +294,35 @@ public abstract class AbstractRipper
     protected boolean addURLToDownload(URL url, String prefix) {
         // Use empty subdirectory
         return addURLToDownload(url, prefix, "");
+    }
+
+    public static String getFileName(URL url, String fileName, String extension) {
+        String saveAs;
+        if (fileName != null) {
+            saveAs = fileName;
+        } else {
+            saveAs = url.toExternalForm();
+            saveAs = saveAs.substring(saveAs.lastIndexOf('/')+1);
+        }
+        if (extension == null) {
+            // Get the extension of the file
+            String[] lastBitOfURL = url.toExternalForm().split("/");
+
+            String[] lastBit = lastBitOfURL[lastBitOfURL.length - 1].split(".");
+            if (lastBit.length != 0) {
+                extension = lastBit[lastBit.length - 1];
+                saveAs = saveAs + "." + extension;
+            }
+        }
+
+        if (saveAs.indexOf('?') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('?')); }
+        if (saveAs.indexOf('#') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('#')); }
+        if (saveAs.indexOf('&') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf('&')); }
+        if (saveAs.indexOf(':') >= 0) { saveAs = saveAs.substring(0, saveAs.indexOf(':')); }
+        if (extension != null) {
+            saveAs = saveAs + "." + extension;
+        }
+        return saveAs;
     }
 
 

--- a/src/test/java/com/rarchives/ripme/tst/AbstractRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/AbstractRipperTest.java
@@ -1,0 +1,4 @@
+package com.rarchives.ripme.tst;
+
+public class AbstractRipperTest {
+}

--- a/src/test/java/com/rarchives/ripme/tst/AbstractRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/AbstractRipperTest.java
@@ -1,4 +1,30 @@
 package com.rarchives.ripme.tst;
 
-public class AbstractRipperTest {
+import com.rarchives.ripme.ripper.AbstractRipper;
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.net.URL;
+
+
+
+public class AbstractRipperTest extends TestCase {
+
+    public void testGetFileName() throws IOException {
+       String fileName = AbstractRipper.getFileName(new URL("http://www.tsumino.com/Image/Object?name=U1EieteEGwm6N1dGszqCpA%3D%3D"), "test", "test");
+       assertEquals("test.test", fileName);
+
+       fileName = AbstractRipper.getFileName(new URL("http://www.tsumino.com/Image/Object?name=U1EieteEGwm6N1dGszqCpA%3D%3D"), "test", null);
+       assertEquals("test", fileName);
+
+       fileName = AbstractRipper.getFileName(new URL("http://www.tsumino.com/Image/Object?name=U1EieteEGwm6N1dGszqCpA%3D%3D"), null, null);
+       assertEquals("Object", fileName);
+
+       fileName = AbstractRipper.getFileName(new URL("http://www.test.com/file.png"), null, null);
+       assertEquals("file.png", fileName);
+
+       fileName = AbstractRipper.getFileName(new URL("http://www.test.com/file."), null, null);
+       assertEquals("file.", fileName);
+    }
+
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #540)


# Description

addURLToDownload no longer erroneously creates sub dirs if it can't get the extension of a file 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
