### PR TITLE
TsuminoRipper now adds .png to filenames; Removed unneeded debug stat…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TsuminoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TsuminoRipper.java
@@ -17,7 +17,6 @@ import org.json.JSONObject;
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
@@ -35,13 +34,10 @@ public class TsuminoRipper extends AbstractHTMLRipper {
         try {
             // This sessionId will expire and need to be replaced
             cookies.put("ASP.NET_SessionId","c4rbzccf0dvy3e0cloolmlkq");
-            logger.info(cookies);
             Document doc = Jsoup.connect(postURL).data("q", getAlbumID()).userAgent(USER_AGENT).cookies(cookies).referrer("http://www.tsumino.com/Read/View/" + getAlbumID()).post();
             String jsonInfo = doc.html().replaceAll("<html>","").replaceAll("<head></head>", "").replaceAll("<body>", "").replaceAll("</body>", "")
                     .replaceAll("</html>", "").replaceAll("\n", "");
-            logger.info(jsonInfo);
             JSONObject json = new JSONObject(jsonInfo);
-            logger.info(json.getJSONArray("reader_page_urls"));
             return json.getJSONArray("reader_page_urls");
         } catch (IOException e) {
             logger.info(e);
@@ -85,7 +81,6 @@ public class TsuminoRipper extends AbstractHTMLRipper {
     public Document getFirstPage() throws IOException {
         Connection.Response resp = Http.url(url).response();
         cookies.putAll(resp.cookies());
-        logger.info(resp.parse());
         return resp.parse();
     }
 
@@ -103,6 +98,6 @@ public class TsuminoRipper extends AbstractHTMLRipper {
     @Override
     public void downloadURL(URL url, int index) {
         sleep(1000);
-        addURLToDownload(url, getPrefix(index));
+        addURLToDownload(url, getPrefix(index), "", null, null, null, "png");
     }
 }


### PR DESCRIPTION
…ment

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)


# Description

The ripper now adds ".png" to downloaded files


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
