### PR TITLE
Added canRip for rule34.xxx

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Rule34Ripper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Rule34Ripper.java
@@ -34,6 +34,16 @@ public class Rule34Ripper extends AbstractHTMLRipper {
     }
 
     @Override
+    public boolean canRip(URL url){
+        Pattern p = Pattern.compile("https?://rule34.xxx/index.php\\?page=post&s=list&tags=([\\S]+)");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
     public String getGID(URL url) throws MalformedURLException {
         Pattern p = Pattern.compile("https?://rule34.xxx/index.php\\?page=post&s=list&tags=([\\S]+)");
         Matcher m = p.matcher(url.toExternalForm());
@@ -41,7 +51,7 @@ public class Rule34Ripper extends AbstractHTMLRipper {
             return m.group(1);
         }
         throw new MalformedURLException("Expected rule34.xxx URL format: " +
-                "rule34.xxx/index.php\\?page=post&s=list&tags=TAG - got " + url + " instead");
+                "rule34.xxx/index.php?page=post&s=list&tags=TAG - got " + url + " instead");
     }
 
     public URL getAPIUrl() throws MalformedURLException {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #546)


# Description

I added a canRip func


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
