### PR TITLE
Hypno hub ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HypnohubRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HypnohubRipper.java
@@ -1,0 +1,91 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+import javax.print.Doc;
+
+public class HypnohubRipper extends AbstractHTMLRipper {
+
+    public HypnohubRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "hypnohub";
+    }
+
+    @Override
+    public String getDomain() {
+        return "hypnohub.net";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https?://hypnohub.net/\\S+/show/([\\d]+)/?$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        p = Pattern.compile("https?://hypnohub.net/\\S+/show/([\\d]+)/([\\S]+)/?$");
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1) + "_" + m.group(2);
+        }
+        throw new MalformedURLException("Expected cfake URL format: " +
+                "hypnohub.net/pool/show/ID - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    private String ripPost(String url) throws IOException {
+        logger.info(url);
+        Document doc = Http.url(url).get();
+        return "https:" +  doc.select("img.image").attr("src");
+
+    }
+
+    private String ripPost(Document doc) {
+        logger.info(url);
+        return "https:" +  doc.select("img.image").attr("src");
+
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        if (url.toExternalForm().contains("/pool")) {
+            for (Element el : doc.select("ul[id=post-list-posts] > li > div > a.thumb")) {
+                try {
+                    result.add(ripPost("https://hypnohub.net" + el.attr("href")));
+                } catch (IOException e) {
+                    return result;
+                }
+            }
+        } else if (url.toExternalForm().contains("/post")) {
+            result.add(ripPost(doc));
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HypnohubRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HypnohubRipperTest.java
@@ -1,0 +1,25 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.HypnohubRipper;
+
+public class HypnohubRipperTest extends RippersTest {
+    public void testRip() throws IOException {
+        URL poolURL = new URL("http://hypnohub.net/pool/show/2303");
+        URL postURL = new URL("http://hypnohub.net/post/show/63464/black_hair-bracelet-collar-corruption-female_only-");
+        HypnohubRipper ripper = new HypnohubRipper(poolURL);
+        testRipper(ripper);
+        ripper = new HypnohubRipper(postURL);
+        testRipper(ripper);
+    }
+    public void testGetGID() throws IOException {
+        URL poolURL = new URL("http://hypnohub.net/pool/show/2303");
+        HypnohubRipper ripper = new HypnohubRipper(poolURL);
+        assertEquals("hypnohub_2303", ripper.getGID(poolURL));
+
+        URL postURL = new URL("http://hypnohub.net/post/show/63464/black_hair-bracelet-collar-corruption-female_only-");
+        assertEquals("hypnohub_63464_black_hair-bracelet-collar-corruption-female_only-", ripper.getGID(postURL));
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a new Ripper



# Description

Added a ripper for hypnohub.net


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
