### PR TITLE
Added ripper and unit test for dynasty-scans.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DynastyscansRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DynastyscansRipper.java
@@ -1,0 +1,84 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.json.JSONArray;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class DynastyscansRipper extends AbstractHTMLRipper {
+
+    public DynastyscansRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "dynasty-scans";
+    }
+
+    @Override
+    public String getDomain() {
+        return "dynasty-scans.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https?://dynasty-scans.com/chapters/([\\S]+)/?$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected dynasty-scans URL format: " +
+                "dynasty-scans.com/chapters/ID - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        Element elem = doc.select("a[id=next_link]").first();
+        if (elem == null || elem.attr("href").equals("#")) {
+            throw new IOException("No more pages");
+        }
+        return Http.url("https://dynasty-scans.com" + elem.attr("href")).get();
+
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        String jsonText = null;
+        for (Element script : doc.select("script")) {
+            if (script.data().contains("var pages")) {
+                jsonText = script.data().replaceAll("var pages = ", "");
+                jsonText = jsonText.replaceAll("//<!\\[CDATA\\[", "");
+                jsonText = jsonText.replaceAll("//]]>", "");
+            }
+        }
+        JSONArray imageArray = new JSONArray(jsonText);
+        for (int i = 0; i < imageArray.length(); i++) {
+            result.add("https://dynasty-scans.com" + imageArray.getJSONObject(i).getString("image"));
+        }
+
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DynastyscansRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DynastyscansRipperTest.java
@@ -1,0 +1,18 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.DynastyscansRipper;
+
+public class DynastyscansRipperTest extends RippersTest {
+    public void testRip() throws IOException {
+        DynastyscansRipper ripper = new DynastyscansRipper(new URL("https://dynasty-scans.com/chapters/under_one_roof_ch01"));
+        testRipper(ripper);
+    }
+
+    public void testGetGID() throws IOException {
+        DynastyscansRipper ripper = new DynastyscansRipper(new URL("https://dynasty-scans.com/chapters/under_one_roof_ch01"));
+        assertEquals("under_one_roof_ch01", ripper.getGID(new URL("https://dynasty-scans.com/chapters/under_one_roof_ch01")));
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a new Ripper


# Description

I added a ripper for dynasty-scans.com


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
