### PR TITLE
Added support for spyingwithlana.com; added some more unittests for t…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -45,7 +45,19 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         "thisis.delvecomic.com",
         "tnbtu.com",
         "shipinbottle.pepsaga.com",
-            "8muses.download"
+        "8muses.download",
+        "spyingwithlana.com"
+    );
+
+    private static List<String> theme1 = Arrays.asList(
+            "www.totempole666.com",
+            "buttsmithy.com",
+            "themonsterunderthebed.net",
+            "prismblush.com",
+            "www.konradokonski.com",
+            "thisis.delvecomic.com",
+            "tnbtu.com",
+            "spyingwithlana.com"
     );
 
     @Override
@@ -142,6 +154,12 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             if (eight_musesMat.matches()) {
                 return true;
             }
+
+            Pattern spyingwithlanaPat = Pattern.compile("https?://spyingwithlana.com/comic/([a-zA-Z0-9_-]+)/?$");
+            Matcher spyingwithlanaMat = spyingwithlanaPat.matcher(url.toExternalForm());
+            if (spyingwithlanaMat.matches()) {
+                return true;
+            }
         }
 
 
@@ -221,6 +239,13 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         if (eight_musesMat.matches()) {
             return getHost() + "_" + eight_musesMat.group(1);
         }
+
+        Pattern spyingwithlanaPat = Pattern.compile("https?://spyingwithlana.com/comic/([a-zA-Z0-9_-]+)/?$");
+        Matcher spyingwithlanaMat = spyingwithlanaPat.matcher(url.toExternalForm());
+        if (spyingwithlanaMat.matches()) {
+            return "spyingwithlana_" + spyingwithlanaMat.group(1).replaceAll("-page-\\d", "");
+        }
+
         return super.getAlbumTitle(url);
     }
 
@@ -239,13 +264,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         // Find next page
         String nextPage = "";
         Element elem = null;
-        if (getHost().contains("www.totempole666.com")
-                || getHost().contains("buttsmithy.com")
-                || getHost().contains("themonsterunderthebed.net")
-                || getHost().contains("prismblush.com")
-                || getHost().contains("www.konradokonski.com")
-                || getHost().contains("thisis.delvecomic.com")
-                || getHost().contains("tnbtu.com")) {
+        if (theme1.contains(getHost())) {
             elem = doc.select("a.comic-nav-next").first();
             if (elem == null) {
                 throw new IOException("No more pages");
@@ -269,13 +288,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
     @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
-        if (getHost().contains("www.totempole666.com")
-                || getHost().contains("buttsmithy.com")
-                || getHost().contains("themonsterunderthebed.net")
-                || getHost().contains("prismblush.com")
-                || getHost().contains("www.konradokonski.com")
-                || getHost().contains("thisis.delvecomic.com")
-                || getHost().contains("tnbtu.com")) {
+        if (theme1.contains(getHost())) {
             Element elem = doc.select("div.comic-table > div#comic > a > img").first();
             // If doc is the last page in the comic then elem.attr("src") returns null
             // because there is no link <a> to the next page

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
@@ -55,12 +55,20 @@ public class WordpressComicRipperTest extends RippersTest {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://www.konradokonski.com/sawdust/comic/get-up/"));
         testRipper(ripper);
+
     }
 
     public void test_konradokonski_2() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://www.konradokonski.com/wiory/comic/08182008/"));
         testRipper(ripper);
+    }
+
+    public void test_konradokonski_getAlbumTitle() throws IOException {
+        URL url = new URL("http://www.konradokonski.com/sawdust/comic/get-up/");
+        WordpressComicRipper ripper = new WordpressComicRipper(url);
+        assertEquals("konradokonski.com_sawdust", ripper.getAlbumTitle(url));
+
     }
 
     /*
@@ -89,6 +97,26 @@ public class WordpressComicRipperTest extends RippersTest {
                 new URL("https://8muses.download/lustomic-playkittens-josh-samuel-porn-comics-8-muses/"));
         testRipper(ripper);
     }
+
+    public void test_Eightmuses_getAlbumTitle() throws IOException {
+        URL url = new URL("https://8muses.download/lustomic-playkittens-josh-samuel-porn-comics-8-muses/");
+        WordpressComicRipper ripper = new WordpressComicRipper(url);
+        assertEquals("8muses.download_lustomic-playkittens-josh-samuel-porn-comics-8-muses",
+                ripper.getAlbumTitle(url));
+    }
+
+    public void test_spyingwithlana_download() throws IOException {
+        WordpressComicRipper ripper = new WordpressComicRipper(
+                new URL("http://spyingwithlana.com/comic/the-big-hookup/"));
+        testRipper(ripper);
+    }
+
+    public void test_spyingwithlana_getAlbumTitle() throws IOException {
+        URL url = new URL("http://spyingwithlana.com/comic/the-big-hookup/");
+        WordpressComicRipper ripper = new WordpressComicRipper(url);
+        assertEquals("spyingwithlana_the-big-hookup", ripper.getAlbumTitle(url));
+    }
+
     // https://github.com/RipMeApp/ripme/issues/269 - Disabled test - WordpressRipperTest: various domains flaky in CI
 //    public void test_pepsaga() throws IOException {
 //        WordpressComicRipper ripper = new WordpressComicRipper(


### PR DESCRIPTION
…he wordpress comic ripper

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a refactoring



# Description

I added support for spyingwithlana.com; Did some minor refactoring of WordpresscomicRIpper and added some unit tests


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
