### PR TITLE
Fixed NudeGalsRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NudeGalsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NudeGalsRipper.java
@@ -33,23 +33,6 @@ public class NudeGalsRipper extends AbstractHTMLRipper {
         return "nude-gals.com";
     }
 
-    public String getAlbumTitle(URL url) throws MalformedURLException {
-        try {
-            Document doc = getFirstPage();
-            Elements elems = doc.select("#left_col > #grid_title > .right");
-
-            String girl = elems.get(3).text();
-            String magazine = elems.get(2).text();
-            String title = elems.get(0).text();
-
-            return getHost() + "_" + girl + "-" + magazine + "-" + title;
-        } catch (Exception e) {
-            // Fall back to default album naming convention
-            logger.warn("Failed to get album title from " + url, e);
-        }
-        return super.getAlbumTitle(url);
-    }
-
     @Override
     public String getGID(URL url) throws MalformedURLException {
         Pattern p;
@@ -79,9 +62,9 @@ public class NudeGalsRipper extends AbstractHTMLRipper {
     public List<String> getURLsFromPage(Document doc) {
         List<String> imageURLs = new ArrayList<>();
 
-        Elements thumbs = doc.select("#grid_container .grid > .grid_box");
+        Elements thumbs = doc.select("img.thumbnail");
         for (Element thumb : thumbs) {
-            String link = thumb.select("a").get(1).attr("href");
+            String link = thumb.attr("src").replaceAll("thumbs/th_", "");
             String imgSrc = "http://nude-gals.com/" + link;
             imageURLs.add(imgSrc);
         }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NudeGalsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NudeGalsRipperTest.java
@@ -1,0 +1,4 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+public class NudeGalsRipperTest {
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NudeGalsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NudeGalsRipperTest.java
@@ -1,4 +1,18 @@
 package com.rarchives.ripme.tst.ripper.rippers;
 
-public class NudeGalsRipperTest {
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.NudeGalsRipper;
+
+public class NudeGalsRipperTest extends RippersTest {
+    public void testRip() throws IOException {
+        NudeGalsRipper ripper = new NudeGalsRipper(new URL("https://nude-gals.com/photoshoot.php?photoshoot_id=5541"));
+        testRipper(ripper);
+    }
+
+    public void testGetGID() throws IOException {
+        NudeGalsRipper ripper = new NudeGalsRipper(new URL("https://nude-gals.com/photoshoot.php?photoshoot_id=5541"));
+        assertEquals("5541", ripper.getGID( new URL("https://nude-gals.com/photoshoot.php?photoshoot_id=5541")));
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #259)


# Description

I updated the NudeGalsRipper

# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [X] I've added a unit test to cover my change.
