### PR TITLE
Fixed Instagram ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -430,7 +430,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
             return null;
         }
         if (!rippingTag) {
-            Pattern jsP = Pattern.compile("o},queryId:.([a-zA-Z0-9]+).");
+            Pattern jsP = Pattern.compile("\\?n.pagination:n},queryId:.([a-zA-Z0-9]+).");
             Matcher m = jsP.matcher(sb.toString());
             if (m.find()) {
                 return m.group(1);
@@ -442,7 +442,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
                 return m.group(1);
             }
         }
-        logger.info("Could not find query_hash on " + jsFileURL);
+        logger.error("Could not find query_hash on " + jsFileURL);
         return null;
 
     }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #563 )


# Description

I updated a regex so the ripper can find the query ID again


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
