### PR TITLE
Fixed queryId regex

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -430,7 +430,7 @@ public class InstagramRipper extends AbstractHTMLRipper {
             return null;
         }
         if (!rippingTag) {
-            Pattern jsP = Pattern.compile("\\?n.pagination:n},queryId:.([a-zA-Z0-9]+).");
+            Pattern jsP = Pattern.compile("o},queryId:.([a-zA-Z0-9]+).");
             Matcher m = jsP.matcher(sb.toString());
             if (m.find()) {
                 return m.group(1);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #563)



# Description

I updated a regex so the ripper can find the query ID again


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
