### PR TITLE
Fixed hentai2read ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
@@ -44,20 +44,15 @@ public class Hentai2readRipper extends AbstractHTMLRipper {
 
         @Override
         public Document getFirstPage() throws IOException {
-            Document tempDoc;
-            // get the first page of the comic
-            if (url.toExternalForm().substring(url.toExternalForm().length() - 1).equals("/")) {
-                tempDoc = Http.url(url + "1").get();
-            } else {
-                tempDoc = Http.url(url + "/1").get();
+            try {
+                Document tempDoc;
+                tempDoc = Http.url(url).get();
+                // Get the thumbnail page so we can rip all images without loading every page in the comic
+                String thumbnailLink = tempDoc.select("a[data-original-title=Thumbnails").attr("href");
+                return Http.url(thumbnailLink).get();
+            } catch (IOException e) {
+                throw new IOException("Unable to get first page");
             }
-            for (Element el : tempDoc.select("ul.nav > li > a")) {
-                if (el.attr("href").startsWith("https://hentai2read.com/thumbnails/")) {
-                    // Get the page with the thumbnails
-                    return Http.url(el.attr("href")).get();
-                }
-            }
-            throw new IOException("Unable to get first page");
         }
 
         @Override


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #575)



# Description

I changed how the ripper find the page with the comics thumbnails


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
