### PR TITLE
SinnercomicsRipper no longer adds -page-01 to folder names

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SinnercomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SinnercomicsRipper.java
@@ -34,7 +34,7 @@ public class SinnercomicsRipper extends AbstractHTMLRipper {
         Pattern p = Pattern.compile("^https?://sinnercomics.com/comic/([a-zA-Z0-9-]*)/?$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
-            return m.group(1);
+            return m.group(1).replaceAll("-page-\\d+", "");
         }
         throw new MalformedURLException("Expected sinnercomics.com URL format: " +
                         "sinnercomics.com/comic/albumName - got " + url + " instead");


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #567)



# Description

I added a regex to remove -page-01 from folder names


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
