### PR TITLE
Can now blacklist nhentai tags

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NhentaiRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NhentaiRipper.java
@@ -79,8 +79,7 @@ public class NhentaiRipper extends AbstractHTMLRipper {
      * @param doc
      * @return String
      */
-    private String checkTags(Document doc) {
-        String[] blackListedTags = Utils.getConfigStringArray("nhentai.blacklist.tags");
+    public String checkTags(Document doc, String[] blackListedTags) {
         // If the user hasn't blacklisted any tags we return false;
         if (blackListedTags == null) {
             return null;
@@ -89,8 +88,9 @@ public class NhentaiRipper extends AbstractHTMLRipper {
         List<String> tagsOnPage = getTags(doc);
         for (String tag : blackListedTags) {
             for (String pageTag : tagsOnPage) {
-                logger.info("tag: " + tag + " pageTag: " + pageTag);
-                if (tag.trim().toLowerCase().equals(pageTag.toLowerCase())) {
+                // We replace all dashes in the tag with spaces because the tags we get from the site are separated using
+                // dashes
+                if (tag.trim().toLowerCase().equals(pageTag.replaceAll("-", " ").toLowerCase())) {
                     return tag;
                 }
             }
@@ -117,7 +117,7 @@ public class NhentaiRipper extends AbstractHTMLRipper {
             firstPage = Http.url(url).get();
         }
 
-        String blacklistedTag = checkTags(firstPage);
+        String blacklistedTag = checkTags(firstPage, Utils.getConfigStringArray("nhentai.blacklist.tags"));
         if (blacklistedTag != null) {
             sendUpdate(RipStatusMessage.STATUS.DOWNLOAD_WARN, "Skipping " + url.toExternalForm() + " as it " +
                     "contains the blacklisted tag \"" + blacklistedTag + "\"");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NhentaiRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NhentaiRipper.java
@@ -2,6 +2,7 @@ package com.rarchives.ripme.ripper.rippers;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import com.rarchives.ripme.ripper.DownloadThreadPool;
+import com.rarchives.ripme.ui.RipStatusMessage;
 import com.rarchives.ripme.utils.Http;
 import com.rarchives.ripme.utils.Utils;
 import org.jsoup.nodes.Document;
@@ -64,6 +65,39 @@ public class NhentaiRipper extends AbstractHTMLRipper {
         return "nhentai" + title;
     }
 
+    private List<String> getTags(Document doc) {
+        List<String> tags = new ArrayList<>();
+        for (Element tag : doc.select("a.tag")) {
+            tags.add(tag.attr("href").replaceAll("/tag/", "").replaceAll("/", ""));
+        }
+        return tags;
+    }
+
+    /**
+     * Checks for blacklisted tags on page. If it finds one it returns it, if not it return null
+     *
+     * @param doc
+     * @return String
+     */
+    private String checkTags(Document doc) {
+        String[] blackListedTags = Utils.getConfigStringArray("nhentai.blacklist.tags");
+        // If the user hasn't blacklisted any tags we return false;
+        if (blackListedTags == null) {
+            return null;
+        }
+        logger.info("Blacklisted tags " + blackListedTags[0]);
+        List<String> tagsOnPage = getTags(doc);
+        for (String tag : blackListedTags) {
+            for (String pageTag : tagsOnPage) {
+                logger.info("tag: " + tag + " pageTag: " + pageTag);
+                if (tag.trim().toLowerCase().equals(pageTag.toLowerCase())) {
+                    return tag;
+                }
+            }
+        }
+        return null;
+    }
+
     @Override
     public String getGID(URL url) throws MalformedURLException {
         // Ex: https://nhentai.net/g/159174/
@@ -81,6 +115,13 @@ public class NhentaiRipper extends AbstractHTMLRipper {
     public Document getFirstPage() throws IOException {
         if (firstPage == null) {
             firstPage = Http.url(url).get();
+        }
+
+        String blacklistedTag = checkTags(firstPage);
+        if (blacklistedTag != null) {
+            sendUpdate(RipStatusMessage.STATUS.DOWNLOAD_WARN, "Skipping " + url.toExternalForm() + " as it " +
+                    "contains the blacklisted tag \"" + blacklistedTag + "\"");
+            return null;
         }
         return firstPage;
     }

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -92,6 +92,16 @@ public class Utils {
     public static String getConfigString(String key, String defaultValue) {
         return config.getString(key, defaultValue);
     }
+
+    public static String[] getConfigStringArray(String key) {
+        String[] s = config.getStringArray(key);
+        if (s.length == 0) {
+            return null;
+        } else {
+            return s;
+        }
+    }
+
     public static int getConfigInteger(String key, int defaultValue) {
         return config.getInt(key, defaultValue);
     }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NhentaiRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NhentaiRipperTest.java
@@ -1,0 +1,33 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.NhentaiRipper;
+
+public class NhentaiRipperTest extends RippersTest {
+    public void testRip() throws IOException {
+        NhentaiRipper ripper = new NhentaiRipper(new URL("https://nhentai.net/g/233295/"));
+        testRipper(ripper);
+    }
+
+    public void testGetGID()  throws IOException {
+        NhentaiRipper ripper = new NhentaiRipper(new URL("https://nhentai.net/g/233295/"));
+        assertEquals("233295", ripper.getGID(new URL("https://nhentai.net/g/233295/")));
+    }
+
+    // Test the tag black listing
+    public void testTagBlackList()  throws IOException {
+        URL url = new URL("https://nhentai.net/g/233295/");
+        NhentaiRipper ripper = new NhentaiRipper(url);
+        // Test multiple blacklisted tags
+        String[] tags = {"test", "one", "blowjob"};
+        String blacklistedTag = ripper.checkTags(ripper.getFirstPage(), tags);
+        assertEquals("blowjob", blacklistedTag);
+
+        // test tags with spaces in them
+        String[] tags2 = {"test", "one", "sole female"};
+        blacklistedTag = ripper.checkTags(ripper.getFirstPage(), tags2);
+        assertEquals("sole female", blacklistedTag);
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] A new feature


# Description

The user can now add a comma separated list of tags in the config file with a key of "nhentai.blacklist.tags" and the ripper will skip any albums with those tags

I also added a way to get ConfigStringArrays from ripmes config file

Example: Adding "nhentai.blacklist.tags = one,two, three" will cause ripme to skip any nhentai album with the tags one, two or three


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
