### PR TITLE
Create LabelsBundle_porrisavvo_FI.properties

### DIFF
--- a/src/main/resources/LabelsBundle_porrisavvo_FI.properties
+++ b/src/main/resources/LabelsBundle_porrisavvo_FI.properties
@@ -1,0 +1,37 @@
+Log = Loki
+History = Historriijja
+created = luatu
+modified = muakat
+Queue = Jono
+Configuration = Assetuksse
+
+# Keys for the Configuration menu
+
+current.version = Nykyne versijjo
+check.for.updates = Tarkist update
+auto.update = Automaatpäivvitys?
+max.download.threads = Yht'aikasse ripi
+timeout.mill = Timeout (millisekois):
+retry.download.count = Ripi retry count
+overwrite.existing.files = Korvvaa nykysse filu?
+sound.when.rip.completes = Valmistummis'ään
+preserve.order = Pir järestys
+save.logs = Tallen loki
+notification.when.rip.starts = Valmistummisilmotus
+save.urls.only = Tallen vaa ossottee
+save.album.titles = Tallen album'otsiko
+autorip.from.clipboard = Ot linki leikpöyrrält
+save.descriptions = Tallen kuvvauksse
+prefer.mp4.over.gif = Suasi MP4 GIF sijjaa
+restore.window.position = Palaut ikkunna sijaant
+remember.url.history = Muist osot'hissa
+loading.history.from = Larrataa hissaa lähteest
+
+# Misc UI keys
+
+loading.history.from.configuration = Larrataa hissaa asetusfilust
+interrupted.while.waiting.to.rip.next.album = Keskeytet venates seurraavvaa album
+inactive = Idle
+re-rip.checked = Re-rip merkatu
+remove = Poist
+clear = Tyhjen


### PR DESCRIPTION
Many thanks to @rautamiekka for the translation.

Apparently this dialect does not have a two character language code.

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [X] a style change/fix


# Description

Added translation for Finnish dialect Porrisavvo.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
