### PR TITLE
hentai2read can now get the album thumbnail link again

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
@@ -48,7 +48,7 @@ public class Hentai2readRipper extends AbstractHTMLRipper {
                 Document tempDoc;
                 tempDoc = Http.url(url).get();
                 // Get the thumbnail page so we can rip all images without loading every page in the comic
-                String thumbnailLink = tempDoc.select("a[data-original-title=Thumbnails").attr("href");
+                String thumbnailLink = tempDoc.select("div.col-xs-12 > div.reader-controls > div.controls-block > button > a").attr("href");
                 return Http.url(thumbnailLink).get();
             } catch (IOException e) {
                 throw new IOException("Unable to get first page");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
@@ -44,12 +44,17 @@ public class Hentai2readRipper extends AbstractHTMLRipper {
 
         @Override
         public Document getFirstPage() throws IOException {
+            String thumbnailLink;
             try {
                 Document tempDoc;
                 tempDoc = Http.url(url).get();
                 // Get the thumbnail page so we can rip all images without loading every page in the comic
-                String thumbnailLink = tempDoc.select("div.col-xs-12 > div.reader-controls > div.controls-block > button > a").attr("href");
-                return Http.url(thumbnailLink).get();
+                thumbnailLink = tempDoc.select("div.col-xs-12 > div.reader-controls > div.controls-block > button > a").attr("href");
+                if (thumbnailLink != null) {
+                    return Http.url(thumbnailLink).get();
+                } else {
+                    return Http.url(tempDoc.select("a[data-original-title=Thumbnails").attr("href")).get();
+                }
             } catch (IOException e) {
                 throw new IOException("Unable to get first page");
             }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Hentai2readRipper.java
@@ -50,7 +50,7 @@ public class Hentai2readRipper extends AbstractHTMLRipper {
                 tempDoc = Http.url(url).get();
                 // Get the thumbnail page so we can rip all images without loading every page in the comic
                 thumbnailLink = tempDoc.select("div.col-xs-12 > div.reader-controls > div.controls-block > button > a").attr("href");
-                if (thumbnailLink != null) {
+                if (!thumbnailLink.equals("")) {
                     return Http.url(thumbnailLink).get();
                 } else {
                     return Http.url(tempDoc.select("a[data-original-title=Thumbnails").attr("href")).get();


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #593)



# Description

I changed the select statement that the ripper uses to find the first page


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
