### PR TITLE
Added quick queue support for 8muses.download

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -172,6 +172,12 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             if (mat.matches()) {
                 return true;
             }
+
+            pat = Pattern.compile("https://8muses.download/category/([a-zA-Z0-9-]*)/?");
+            mat = pat.matcher(url.toExternalForm());
+            if (mat.matches()) {
+                return true;
+            }
         }
 
 
@@ -196,6 +202,13 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         if (mat.matches()) {
             return true;
         }
+
+        pat = Pattern.compile("https://8muses.download/category/([a-zA-Z0-9-]*)/?");
+        mat = pat.matcher(url.toExternalForm());
+        if (mat.matches()) {
+            return true;
+        }
+
         return false;
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -160,10 +160,52 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             if (spyingwithlanaMat.matches()) {
                 return true;
             }
+
+            Pattern pa = Pattern.compile("^https?://8muses.download/\\?s=([a-zA-Z0-9-]*)");
+            Matcher ma = pa.matcher(url.toExternalForm());
+            if (ma.matches()) {
+                return true;
+            }
+
+            Pattern pat = Pattern.compile("https?://8muses.download/page/\\d+/\\?s=([a-zA-Z0-9-]*)");
+            Matcher mat = pat.matcher(url.toExternalForm());
+            if (mat.matches()) {
+                return true;
+            }
         }
 
 
         return false;
+    }
+
+    @Override
+    public boolean hasQueueSupport() {
+        return true;
+    }
+
+    @Override
+    public boolean pageContainsAlbums(URL url) {
+        Pattern pa = Pattern.compile("^https?://8muses.download/\\?s=([a-zA-Z0-9-]*)");
+        Matcher ma = pa.matcher(url.toExternalForm());
+        if (ma.matches()) {
+            return true;
+        }
+
+        Pattern pat = Pattern.compile("https?://8muses.download/page/\\d+/\\?s=([a-zA-Z0-9-]*)");
+        Matcher mat = pat.matcher(url.toExternalForm());
+        if (mat.matches()) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public List<String> getAlbumsToQueue(Document doc) {
+        List<String> urlsToAddToQueue = new ArrayList<>();
+        for (Element elem : doc.select("#post_masonry > article > div > figure > a")) {
+            urlsToAddToQueue.add(elem.attr("href"));
+        }
+        return urlsToAddToQueue;
     }
 
     @Override


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a refactoring



# Description

I added quick queue support for 8muses.download search pages and category pages


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
