### PR TITLE
Added ripper for bato.to

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/BatoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/BatoRipper.java
@@ -1,0 +1,109 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.json.JSONObject;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class BatoRipper extends AbstractHTMLRipper {
+
+    public BatoRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "bato";
+    }
+
+    @Override
+    public String getDomain() {
+        return "bato.to";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https?://bato.to/chapter/([\\d]+)/?");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected bato.to URL format: " +
+                "bato.to/chapter/ID - got " + url + " instead");
+    }
+
+    @Override
+    public boolean canRip(URL url) {
+        Pattern p = Pattern.compile("https?://bato.to/series/([\\d]+)/?");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return true;
+        }
+
+        p = Pattern.compile("https?://bato.to/chapter/([\\d]+)/?");
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        // Find next page
+        String nextUrl = "";
+        // We use comic-nav-next to the find the next page
+        Element elem = doc.select("div.nav-next > a").first();
+        // If there are no more chapters to download the last chapter will link to bato.to/series/ID
+        if (elem == null || elem.attr("href").contains("/series/")) {
+            throw new IOException("No more pages");
+        }
+        String nextPage = elem.attr("href");
+        return Http.url("https://bato.to" + nextPage).get();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        for (Element script : doc.select("script")) {
+            if (script.data().contains("var images = ")) {
+                String s = script.data();
+                s = s.replaceAll("var seriesId = \\d+;", "");
+                s = s.replaceAll("var chapterId = \\d+;", "");
+                s = s.replaceAll("var pages = \\d+;", "");
+                s = s.replaceAll("var page = \\d+;", "");
+                s = s.replaceAll("var prevCha = null;", "");
+                s = s.replaceAll("var nextCha = \\.*;", "");
+                String json = s.replaceAll("var images = ", "").replaceAll(";", "");
+                logger.info(s);
+                JSONObject images = new JSONObject(json);
+                for (int i = 1; i < images.length() +1; i++) {
+                    result.add(images.getString(Integer.toString(i)));
+                }
+
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/BatoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/BatoRipper.java
@@ -43,6 +43,18 @@ public class BatoRipper extends AbstractHTMLRipper {
     }
 
     @Override
+    public String getAlbumTitle(URL url) throws MalformedURLException {
+        try {
+            // Attempt to use album title as GID
+            return getHost() + "_" + getGID(url) + "_" + getFirstPage().select("title").first().text().replaceAll(" ", "_");
+        } catch (IOException e) {
+            // Fall back to default album naming convention
+            logger.info("Unable to find title at " + url);
+        }
+        return super.getAlbumTitle(url);
+    }
+
+    @Override
     public boolean canRip(URL url) {
         Pattern p = Pattern.compile("https?://bato.to/series/([\\d]+)/?");
         Matcher m = p.matcher(url.toExternalForm());

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BatoRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BatoRipperTest.java
@@ -10,4 +10,16 @@ public class BatoRipperTest extends RippersTest {
         BatoRipper ripper = new BatoRipper(new URL("https://bato.to/chapter/1207152"));
         testRipper(ripper);
     }
+
+    public void testGetGID() throws IOException {
+        URL url = new URL("https://bato.to/chapter/1207152");
+        BatoRipper ripper = new BatoRipper(url);
+        assertEquals("1207152", ripper.getGID(url));
+    }
+
+    public void testGetAlbumTitle() throws IOException {
+        URL url = new URL("https://bato.to/chapter/1207152");
+        BatoRipper ripper = new BatoRipper(url);
+        assertEquals("bato_1207152_I_Messed_Up_by_Teaching_at_a_Black_Gyaru_School!_Ch.2", ripper.getAlbumTitle(url));
+    }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BatoRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BatoRipperTest.java
@@ -1,0 +1,13 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.BatoRipper;
+
+public class BatoRipperTest extends RippersTest {
+    public void testRip() throws IOException {
+        BatoRipper ripper = new BatoRipper(new URL("https://bato.to/chapter/1207152"));
+        testRipper(ripper);
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a new Ripper


# Description

Added a ripper plus unit tests for bato.to


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
