### PR TITLE
SankakuComplexRipper can now download from different subdomains

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SankakuComplexRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SankakuComplexRipper.java
@@ -43,7 +43,7 @@ public class SankakuComplexRipper extends AbstractHTMLRipper {
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             try {
-                return URLDecoder.decode(m.group(2), "UTF-8");
+                return URLDecoder.decode(m.group(1) + "_" + m.group(2), "UTF-8");
             } catch (UnsupportedEncodingException e) {
                 throw new MalformedURLException("Cannot decode tag name '" + m.group(1) + "'");
             }
@@ -51,6 +51,20 @@ public class SankakuComplexRipper extends AbstractHTMLRipper {
         throw new MalformedURLException("Expected sankakucomplex.com URL format: " +
                         "idol.sankakucomplex.com?...&tags=something... - got " +
                         url + "instead");
+    }
+
+    public String getSubDomain(URL url){
+        Pattern p = Pattern.compile("^https?://([a-zA-Z0-9]+\\.)?sankakucomplex\\.com/.*tags=([^&]+).*$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            try {
+                return URLDecoder.decode(m.group(1), "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                return null;
+            }
+        }
+        return null;
+
     }
 
     @Override
@@ -71,9 +85,11 @@ public class SankakuComplexRipper extends AbstractHTMLRipper {
         for (Element thumbSpan : doc.select("div.content > div > span.thumb > a")) {
             String postLink = thumbSpan.attr("href");
                 try {
+                    String subDomain = getSubDomain(url);
+                    String siteURL = "https://" + subDomain + "sankakucomplex.com";
                     // Get the page the full sized image is on
-                    Document subPage = Http.url("https://chan.sankakucomplex.com" + postLink).get();
-                    logger.info("Checking page " + "https://chan.sankakucomplex.com" + postLink);
+                    Document subPage = Http.url(siteURL + postLink).get();
+                    logger.info("Checking page " + siteURL + postLink);
                     imageURLs.add("https:" + subPage.select("div[id=stats] > ul > li > a[id=highres]").attr("href"));
                 } catch (IOException e) {
                     logger.warn("Error while loading page " + postLink, e);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SankakuComplexRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SankakuComplexRipperTest.java
@@ -17,4 +17,15 @@ public class SankakuComplexRipperTest extends RippersTest {
         testRipper(ripper);
     }
     */
+    public void testgetGID() throws IOException {
+        URL url = new URL("https://idol.sankakucomplex.com/?tags=meme_%28me%21me%21me%21%29_%28cosplay%29");
+        SankakuComplexRipper ripper = new SankakuComplexRipper(url);
+        assertEquals("idol._meme_(me!me!me!)_(cosplay)", ripper.getGID(url));
+    }
+
+    public void testgetSubDomain() throws IOException {
+        URL url = new URL("https://idol.sankakucomplex.com/?tags=meme_%28me%21me%21me%21%29_%28cosplay%29");
+        SankakuComplexRipper ripper = new SankakuComplexRipper(url);
+        assertEquals("idol.", ripper.getSubDomain(url));
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #565)


# Description

The ripper now gets posts from the subdomain of the entered url and no longer assumes the subdomain is chan


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
