### PR TITLE
Can now include comments in url files

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -221,8 +221,12 @@ public class App {
                 String url;
                 BufferedReader br = new BufferedReader(new FileReader(filename));
                 while ((url = br.readLine()) != null) {
-                    // loop through each url in the file and proces each url individually.
-                    ripURL(url.trim(), cl.hasOption("n"));
+                    if (url.startsWith("//") || url.startsWith("#")) {
+                        logger.debug("Skipping over line \"" + url + "\"because it is a comment");
+                    } else {
+                        // loop through each url in the file and process each url individually.
+                        ripURL(url.trim(), cl.hasOption("n"));
+                    }
                 }
             } catch (FileNotFoundException fne) {
                 logger.error("[!] File containing list of URLs not found. Cannot continue.");


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #607)


# Description

When ripping all urls in a file (Using the -f flag) ripme will now skip any line starting with // or #


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
