### PR TITLE
myhentaicomics ripper now requests proper url when downloading images

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaicomicsRipper.java
@@ -99,7 +99,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
             Pattern p = Pattern.compile("/index.php/[a-zA-Z0-9_-]*\\?page=\\d");
             Matcher m = p.matcher(nextPage);
             if (m.matches()) {
-                nextUrl = "http://myhentaicomics.com" + m.group(0);
+                nextUrl = "https://myhentaicomics.com" + m.group(0);
                 }
             if (nextUrl.equals("")) {
                 throw new IOException("No more pages");
@@ -120,7 +120,7 @@ public class MyhentaicomicsRipper extends AbstractHTMLRipper {
             if (!imageSource.startsWith("http://") && !imageSource.startsWith("https://")) {
             // We replace thumbs with resizes so we can the full sized images
             imageSource = imageSource.replace("thumbs", "resizes");
-            result.add("http://myhentaicomics.com/" + imageSource);
+            result.add("https://myhentaicomics.com" + imageSource);
                 }
             }
         return result;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #612)



# Description

The ripper now requests the proper url and using https for all pages


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
