### PR TITLE
Nhentai rewrite

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NhentaiRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NhentaiRipper.java
@@ -27,6 +27,30 @@ public class NhentaiRipper extends AbstractHTMLRipper {
     private DownloadThreadPool nhentaiThreadPool = new DownloadThreadPool("nhentai");
 
     @Override
+    public boolean hasQueueSupport() {
+        return true;
+    }
+
+    @Override
+    public boolean pageContainsAlbums(URL url) {
+        Pattern pa = Pattern.compile("^https?://nhentai\\.net/tag/([a-zA-Z0-9_\\-]+)/?");
+        Matcher ma = pa.matcher(url.toExternalForm());
+        if (ma.matches()) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public List<String> getAlbumsToQueue(Document doc) {
+        List<String> urlsToAddToQueue = new ArrayList<>();
+        for (Element elem : doc.select("a.cover")) {
+            urlsToAddToQueue.add("https://" + getDomain() + elem.attr("href"));
+        }
+        return urlsToAddToQueue;
+    }
+
+    @Override
     public DownloadThreadPool getThreadPool() {
         return nhentaiThreadPool;
     }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a refactoring


# Description

I rewrote the ripper to get image links from thumbnails and added quickQueue support for tag pages


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
