### PR TITLE
Now checks that URLHistory exists and that we can write to it before …

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -74,15 +74,24 @@ public abstract class AbstractRipper
             File file = new File(URLHistoryFile);
             if (!new File(Utils.getConfigDir()).exists()) {
                 logger.error("Config dir doesn't exist");
-                return;
+                logger.info("Making config dir");
+                boolean couldMakeDir = new File(Utils.getConfigDir()).mkdirs();
+                if (!couldMakeDir) {
+                    logger.error("Couldn't make config dir");
+                    return;
+                }
+            }
+            // if file doesnt exists, then create it
+            if (!file.exists()) {
+                boolean couldMakeDir = file.createNewFile();
+                if (!couldMakeDir) {
+                    logger.error("Couldn't url history file");
+                    return;
+                }
             }
             if (!file.canWrite()) {
                 logger.error("Can't write to url history file: " + URLHistoryFile);
                 return;
-            }
-            // if file doesnt exists, then create it
-            if (!file.exists()) {
-                file.createNewFile();
             }
             fw = new FileWriter(file.getAbsoluteFile(), true);
             bw = new BufferedWriter(fw);

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -72,6 +72,14 @@ public abstract class AbstractRipper
         FileWriter fw = null;
         try {
             File file = new File(URLHistoryFile);
+            if (!new File(Utils.getConfigDir()).exists()) {
+                logger.error("Config dir doesn't exist");
+                return;
+            }
+            if (!file.canWrite()) {
+                logger.error("Can't write to url history file: " + URLHistoryFile);
+                return;
+            }
             // if file doesnt exists, then create it
             if (!file.exists()) {
                 file.createNewFile();


### PR DESCRIPTION
…trying to write to it

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #610)



# Description

Added an if statement to check that we can write to the URLHistoryFile before trying and will make the config dir if it doesn't exist


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
