### PR TITLE
Reverse -n, --no-prop-file behaviour

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -225,7 +225,7 @@ public class App {
                         logger.debug("Skipping over line \"" + url + "\"because it is a comment");
                     } else {
                         // loop through each url in the file and process each url individually.
-                        ripURL(url.trim(), cl.hasOption("n"));
+                        ripURL(url.trim(), !cl.hasOption("n"));
                     }
                 }
             } catch (FileNotFoundException fne) {
@@ -238,7 +238,7 @@ public class App {
         //The URL to rip.
         if (cl.hasOption('u')) {
             String url = cl.getOptionValue('u').trim();
-            ripURL(url, cl.hasOption("n"));
+            ripURL(url, !cl.hasOption("n"));
         }
 
     }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix https://github.com/RipMeApp/ripme/issues/610#issuecomment-391975924)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

As documented in the wiki, the `-n, --no-prop-file` option should prevent the creation of the properties file, however, it has the opposite effect currently. I believe even with the changes in ef1cab6 the `rip.properties` file will still _never_ be created for people exclusively using the CLI unless this switch is set.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
