### PR TITLE
Update improvements

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -1,19 +1,40 @@
 import json
 import subprocess
+from hashlib import sha256
 
 # This script will:
 # - read current version
 # - increment patch version
 # - update version in a few places
 # - insert new line in ripme.json with message
+# - build ripme
+# - add the hash of the lastest binary to ripme.json
 
 message = input('message: ')
 
-with open('ripme.json') as dataFile:
-    ripmeJson = json.load(dataFile)
-currentVersion = ripmeJson["latestVersion"]
+def get_ripme_json():
+    with open('ripme.json') as dataFile:
+        ripmeJson = json.load(dataFile)
+    return ripmeJson
 
-print ('Current version ' + currentVersion)
+def update_hash(current_hash):
+    ripmeJson = get_ripme_json()
+    with open('ripme.json', 'w') as dataFile:
+        ripmeJson["currentHash"] = current_hash
+        print(ripmeJson["currentHash"])
+        json.dump(ripmeJson, dataFile, indent=4)
+
+def update_change_list(message):
+    ripmeJson = get_ripme_json()
+    with open('ripme.json', 'w') as dataFile:
+        ripmeJson["changeList"] = ripmeJson["changeList"].insert(0, message)
+        print(ripmeJson["currentHash"])
+        json.dump(ripmeJson, dataFile, indent=4)
+
+
+currentVersion = get_ripme_json()["latestVersion"]
+
+print('Current version ' + currentVersion)
 
 versionFields = currentVersion.split('.')
 patchCur = int(versionFields[2])
@@ -22,14 +43,14 @@ majorMinor = versionFields[:2]
 majorMinor.append(str(patchNext))
 nextVersion = '.'.join(majorMinor)
 
-print ('Updating to ' + nextVersion)
+print('Updating to ' + nextVersion)
 
 substrExpr = 's/' + currentVersion + '/' + nextVersion + '/'
 subprocess.call(['sed', '-i', '-e', substrExpr, 'src/main/java/com/rarchives/ripme/ui/UpdateUtils.java'])
 subprocess.call(['git', 'grep', 'DEFAULT_VERSION.*' + nextVersion,
                  'src/main/java/com/rarchives/ripme/ui/UpdateUtils.java'])
 
-substrExpr = 's/\\\"latestVersion\\\": \\\"' + currentVersion + '\\\"/\\\"latestVersion\\\": \\\"' +\
+substrExpr = 's/\\\"latestVersion\\\": \\\"' + currentVersion + '\\\"/\\\"latestVersion\\\": \\\"' + \
              nextVersion + '\\\"/'
 subprocess.call(['sed', '-i', '-e', substrExpr, 'ripme.json'])
 subprocess.call(['git', 'grep', 'latestVersion', 'ripme.json'])
@@ -51,6 +72,15 @@ dataFile = open("ripme.json", "w")
 dataFile.write(outputContent)
 dataFile.close()
 
-subprocess.call(['git', 'add', '-u'])
-subprocess.call(['git', 'commit', '-m', commitMessage])
-subprocess.call(['git', 'tag', nextVersion])
+# subprocess.call(['git', 'add', '-u'])
+# subprocess.call(['git', 'commit', '-m', commitMessage])
+# subprocess.call(['git', 'tag', nextVersion])
+print("Building ripme")
+subprocess.call(["mvn", "clean", "compile", "assembly:single"])
+print("Hashing .jar file")
+openedFile = open("./target/ripme-{}-jar-with-dependencies.jar".format(nextVersion), "rb")
+readFile = openedFile.read()
+file_hash = sha256(readFile).hexdigest()
+print("Hash is: {}".format(file_hash))
+print("Updating hash")
+update_hash(file_hash)

--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -1,13 +1,12 @@
 package com.rarchives.ripme.ui;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
+import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
 
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
@@ -21,7 +20,7 @@ import com.rarchives.ripme.utils.Utils;
 public class UpdateUtils {
 
     private static final Logger logger = Logger.getLogger(UpdateUtils.class);
-    private static final String DEFAULT_VERSION = "1.7.48";
+    private static final String DEFAULT_VERSION = "1.7.49";
     private static final String REPO_NAME = "ripmeapp/ripme";
     private static final String updateJsonURL = "https://raw.githubusercontent.com/" + REPO_NAME + "/master/ripme.json";
     private static final String mainFileName = "ripme.jar";
@@ -73,7 +72,7 @@ public class UpdateUtils {
         }
 
         String latestVersion = json.getString("latestVersion");
-        if (UpdateUtils.isNewerVersion(latestVersion)) {
+        if (!UpdateUtils.isNewerVersion(latestVersion)) {
             logger.info("Found newer version: " + latestVersion);
             int result = JOptionPane.showConfirmDialog(
                     null,
@@ -141,6 +140,30 @@ public class UpdateUtils {
         return intVersions;
     }
 
+    // Code take from https://stackoverflow.com/a/30925550
+    private static String createSha256(File file)  {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            InputStream fis = new FileInputStream(file);
+            int n = 0;
+            byte[] buffer = new byte[8192];
+            while (n != -1) {
+                n = fis.read(buffer);
+                if (n > 0) {
+                    digest.update(buffer, 0, n);
+                }
+            }
+            return new HexBinaryAdapter().marshal(digest.digest());
+        } catch (NoSuchAlgorithmException e) {
+            logger.error("Got error getting file hash " + e.getMessage());
+        } catch (FileNotFoundException e) {
+            logger.error("Could not find file: " + file.getName());
+        } catch (IOException e) {
+            logger.error("Got error getting file hash " + e.getMessage());
+        }
+        return null;
+    }
+
     private static void downloadJarAndLaunch(String updateJarURL)
             throws IOException {
         Response response;
@@ -153,6 +176,8 @@ public class UpdateUtils {
         out.write(response.bodyAsBytes());
         out.close();
         logger.info("Download of new version complete; saved to " + updateFileName);
+        logger.info("Checking hash of update");
+        logger.info("Hash: " + createSha256(new File(updateFileName)));
 
         // Setup updater script
         final String batchFile, script;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)



# Description

This update changes patch.py to include the current jar hash and adds the ability for ripme to check the hash when updating (How ever ripme currently doesn't do anything with that information)

This almost fixes #337


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
