### PR TITLE
Added try-with-resources blocks

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -35,7 +35,7 @@ import com.rarchives.ripme.utils.Utils;
  * Entry point to application.
  * This is where all the fun happens, with the main method.
  * Decides to display UI or to run silently via command-line.
- * 
+ *
  * As the "controller" to all other classes, it parses command line parameters and loads the history.
  */
 public class App {
@@ -46,7 +46,7 @@ public class App {
     /**
      * Where everything starts. Takes in, and tries to parse as many commandline arguments as possible.
      * Otherwise, it launches a GUI.
-     * 
+     *
      * @param args Array of command line arguments.
      */
     public static void main(String[] args) throws MalformedURLException {
@@ -84,7 +84,7 @@ public class App {
      * Creates an abstract ripper and instructs it to rip.
      * @param url URL to be ripped
      * @throws Exception Nothing too specific here, just a catch-all.
-     * 
+     *
      */
     private static void rip(URL url) throws Exception {
         AbstractRipper ripper = AbstractRipper.getRipper(url);
@@ -217,9 +217,9 @@ public class App {
         //Read URLs from File
         if (cl.hasOption('f')) {
             String filename = cl.getOptionValue('f');
-            try {
+
+            try (BufferedReader br = new BufferedReader(new FileReader(filename))) {
                 String url;
-                BufferedReader br = new BufferedReader(new FileReader(filename));
                 while ((url = br.readLine()) != null) {
                     if (url.startsWith("//") || url.startsWith("#")) {
                         logger.debug("Skipping over line \"" + url + "\"because it is a comment");

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -129,8 +129,8 @@ public abstract class AbstractRipper
     private boolean hasDownloadedURL(String url) {
         File file = new File(URLHistoryFile);
         url = normalizeUrl(url);
-        try {
-            Scanner scanner = new Scanner(file);
+
+        try (Scanner scanner = new Scanner(file)) {
             while (scanner.hasNextLine()) {
                 final String lineFromFile = scanner.nextLine();
                 if (lineFromFile.equals(url)) {
@@ -140,6 +140,7 @@ public abstract class AbstractRipper
         } catch (FileNotFoundException e) {
             return false;
         }
+
         return false;
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -68,11 +68,10 @@ public abstract class AlbumRipper extends AbstractRipper {
         if (Utils.getConfigBoolean("urls_only.save", false)) {
             // Output URL to file
             String urlFile = this.workingDir + File.separator + "urls.txt";
-            try {
-                FileWriter fw = new FileWriter(urlFile, true);
+            try (FileWriter fw = new FileWriter(urlFile, true)) {
                 fw.write(url.toExternalForm());
                 fw.write("\n");
-                fw.close();
+
                 RipStatusMessage msg = new RipStatusMessage(STATUS.DOWNLOAD_COMPLETE, urlFile);
                 itemsCompleted.put(url, new File(urlFile));
                 observer.update(this, msg);

--- a/src/main/java/com/rarchives/ripme/ripper/VideoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/VideoRipper.java
@@ -45,11 +45,11 @@ public abstract class VideoRipper extends AbstractRipper {
         if (Utils.getConfigBoolean("urls_only.save", false)) {
             // Output URL to file
             String urlFile = this.workingDir + File.separator + "urls.txt";
-            try {
-                FileWriter fw = new FileWriter(urlFile, true);
+
+            try (FileWriter fw = new FileWriter(urlFile, true)) {
                 fw.write(url.toExternalForm());
                 fw.write("\n");
-                fw.close();
+
                 RipStatusMessage msg = new RipStatusMessage(STATUS.DOWNLOAD_COMPLETE, urlFile);
                 observer.update(this, msg);
             } catch (IOException e) {

--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -149,9 +149,11 @@ public class UpdateUtils {
                 .timeout(Utils.getConfigInteger("download.timeout", 60 * 1000))
                 .maxBodySize(1024 * 1024 * 100)
                 .execute();
-        FileOutputStream out = new FileOutputStream(updateFileName);
-        out.write(response.bodyAsBytes());
-        out.close();
+
+        try (FileOutputStream out = new FileOutputStream(updateFileName)) {
+            out.write(response.bodyAsBytes());
+        }
+
         logger.info("Download of new version complete; saved to " + updateFileName);
 
         // Setup updater script
@@ -185,11 +187,13 @@ public class UpdateUtils {
                     + "rm -f " + batchPath + "\n";
             batchExec = new String[] { "sh", batchPath };
         }
+
         // Create updater script
-        BufferedWriter bw = new BufferedWriter(new FileWriter(batchFile));
-        bw.write(script);
-        bw.flush();
-        bw.close();
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(batchFile))) {
+            bw.write(script);
+            bw.flush();
+        }
+
         logger.info("Saved update script to " + batchFile);
         // Run updater script on exit
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [x] a style change/fix


# Description

Changed try blocks that used streams and other classes that implement the Closeable, to try-with-resources statement, which implicitly close Closeables.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
