### PR TITLE
No longer writes url to url_history file is save urls only is checked

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -67,6 +67,10 @@ public abstract class AbstractRipper
      * @param downloadedURL URL to check if downloaded
      */
     private void writeDownloadedURL(String downloadedURL) throws IOException {
+        // If "save urls only" is checked don't write to the url history file
+        if (Utils.getConfigBoolean("urls_only.save", false)) {
+            return;
+        }
         downloadedURL = normalizeUrl(downloadedURL);
         BufferedWriter bw = null;
         FileWriter fw = null;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #237)



# Description

if `Utils.getConfigBoolean("urls_only.save", false)` returns true `writeDownloadedURL` now just returns and doesn't write the downloaded url


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
