### PR TITLE
Removed support for tnbutu.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -31,7 +31,6 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
     // http://www.konradokonski.com/wiory/comic/08182008/
     // http://freeadultcomix.com/finders-feepaid-in-full-sparrow/
     // http://thisis.delvecomic.com/NewWP/comic/in-too-deep/
-    // http://tnbtu.com/comic/01-00/
     // http://shipinbottle.pepsaga.com/?p=281
 
     private static List<String> explicit_domains = Arrays.asList(
@@ -43,7 +42,6 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         "www.konradokonski.com",
         "freeadultcomix.com",
         "thisis.delvecomic.com",
-        "tnbtu.com",
         "shipinbottle.pepsaga.com",
         "8muses.download",
         "spyingwithlana.com"
@@ -56,7 +54,6 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             "prismblush.com",
             "www.konradokonski.com",
             "thisis.delvecomic.com",
-            "tnbtu.com",
             "spyingwithlana.com"
     );
 
@@ -134,12 +131,6 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             Pattern comicsxxxPat = Pattern.compile("https?://comics-xxx.com/([a-zA-Z0-9_\\-]*)/?$");
             Matcher comicsxxxMat = comicsxxxPat.matcher(url.toExternalForm());
             if (comicsxxxMat.matches()) {
-                return true;
-            }
-
-            Pattern tnbtuPat = Pattern.compile("https?://tnbtu.com/comic/([0-9_\\-]*)/?$");
-            Matcher tnbtuMat = tnbtuPat.matcher(url.toExternalForm());
-            if (tnbtuMat.matches()) {
                 return true;
             }
 
@@ -277,12 +268,6 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
             return getHost() + "_" + comicsxxxMat.group(1);
         }
 
-        Pattern tnbtuPat = Pattern.compile("https?://tnbtu.com/comic/([0-9_\\-]*)/?$");
-        Matcher tnbtuMat = tnbtuPat.matcher(url.toExternalForm());
-        if (tnbtuMat.matches()) {
-            return getHost() + "_" + "The_Night_Belongs_to_Us";
-        }
-
         Pattern shipinbottlePat = Pattern.compile("https?://shipinbottle.pepsaga.com/\\?p=([0-9]*)/?$");
         Matcher shipinbottleMat =shipinbottlePat.matcher(url.toExternalForm());
         if (shipinbottleMat.matches()) {
@@ -413,13 +398,10 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
                 || getHost().contains("themonsterunderthebed.net")) {
             addURLToDownload(url, pageTitle + "_");
         }
-        if (getHost().contains("tnbtu.com")) {
-            // We need to set the referrer header for tnbtu
-            addURLToDownload(url, getPrefix(index), "","http://www.tnbtu.com/comic", null);
-        } else {
-            // If we're ripping a site where we can't get the page number/title we just rip normally
-            addURLToDownload(url, getPrefix(index));
-        }
+
+        // If we're ripping a site where we can't get the page number/title we just rip normally
+        addURLToDownload(url, getPrefix(index));
+
 
     }
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
@@ -86,12 +86,6 @@ public class WordpressComicRipperTest extends RippersTest {
         testRipper(ripper);
     }
 
-    public void test_tnbtu() throws IOException {
-        WordpressComicRipper ripper = new WordpressComicRipper(
-                new URL("http://tnbtu.com/comic/01-00/"));
-        testRipper(ripper);
-    }
-
     public void test_Eightmuses_download() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("https://8muses.download/lustomic-playkittens-josh-samuel-porn-comics-8-muses/"));


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #633)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

I removed support for tnbtu.com from wordpressComicRipper as the site is now just a tumblr account with a custom domain


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
