### PR TITLE
Replaced the if-else statement by a single return statement.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/BatoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/BatoRipper.java
@@ -57,10 +57,7 @@ public class BatoRipper extends AbstractHTMLRipper {
     public boolean pageContainsAlbums(URL url) {
         Pattern p = Pattern.compile("https?://bato.to/series/([\\d]+)/?");
         Matcher m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return true;
-        }
-        return false;
+        return m.matches();
     }
 
     @Override
@@ -94,10 +91,7 @@ public class BatoRipper extends AbstractHTMLRipper {
 
         p = Pattern.compile("https?://bato.to/chapter/([\\d]+)/?");
         m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return true;
-        }
-        return false;
+        return m.matches();
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NhentaiRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NhentaiRipper.java
@@ -35,10 +35,7 @@ public class NhentaiRipper extends AbstractHTMLRipper {
     public boolean pageContainsAlbums(URL url) {
         Pattern pa = Pattern.compile("^https?://nhentai\\.net/tag/([a-zA-Z0-9_\\-]+)/?");
         Matcher ma = pa.matcher(url.toExternalForm());
-        if (ma.matches()) {
-            return true;
-        }
-        return false;
+        return ma.matches();
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PichunterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PichunterRipper.java
@@ -60,10 +60,7 @@ public class PichunterRipper extends AbstractHTMLRipper {
     private boolean isPhotoSet(URL url) {
         Pattern p = Pattern.compile("https?://www.pichunter.com/gallery/\\d+/(\\S*)/?");
         Matcher m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return true;
-        }
-        return false;
+        return m.matches();
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Rule34Ripper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Rule34Ripper.java
@@ -37,10 +37,7 @@ public class Rule34Ripper extends AbstractHTMLRipper {
     public boolean canRip(URL url){
         Pattern p = Pattern.compile("https?://rule34.xxx/index.php\\?page=post&s=list&tags=([\\S]+)");
         Matcher m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return true;
-        }
-        return false;
+        return m.matches();
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
@@ -38,10 +38,7 @@ public class WebtoonsRipper extends AbstractHTMLRipper {
     public boolean canRip(URL url) {
         Pattern pat = Pattern.compile("https?://www.webtoons.com/[a-zA-Z-_]+/[a-zA-Z_-]+/([a-zA-Z0-9_-]*)/[a-zA-Z0-9_-]+/\\S*");
         Matcher mat = pat.matcher(url.toExternalForm());
-        if (mat.matches()) {
-            return true;
-        }
-        return false;
+        return mat.matches();
     }
 
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -64,10 +64,7 @@ public class XhamsterRipper extends AbstractHTMLRipper {
     public boolean canRip(URL url) {
         Pattern p = Pattern.compile("^https?://[wmde.]*xhamster\\.com/photos/gallery/.*?(\\d+)$");
         Matcher m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return true;
-        }
-        return false;
+        return m.matches();
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/video/ViddmeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/video/ViddmeRipper.java
@@ -56,7 +56,7 @@ public class ViddmeRipper extends VideoRipper {
         logger.info("    Retrieving " + this.url.toExternalForm());
         Document doc = Http.url(this.url).get();
         Elements videos = doc.select("meta[name=twitter:player:stream]");
-        if (videos.size() == 0) {
+        if (videos.isEmpty()) {
             throw new IOException("Could not find twitter:player:stream at " + url);
         }
         String vidUrl = videos.first().attr("content");


### PR DESCRIPTION
Replaced use of Collection.size () by Collection.isEmpty () in ViddmeRipper.

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix


# Description

Replaced the if-else statement by a single return statement.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
