### PR TITLE
Fixed Aerisdies ripper

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/AerisdiesRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/AerisdiesRipperTest.java
@@ -16,5 +16,16 @@ public class AerisdiesRipperTest extends RippersTest {
         testRipper(ripper);
     }
 
+    public void testDjAlbum() throws IOException {
+        AerisdiesRipper ripper = new AerisdiesRipper(new URL("http://www.aerisdies.com/html/lb/douj_5230_1.html"));
+        testRipper(ripper);
+    }
+
+    public void testGetGID() throws IOException {
+        URL url = new URL("http://www.aerisdies.com/html/lb/douj_5230_1.html");
+        AerisdiesRipper ripper = new AerisdiesRipper(url);
+        assertEquals("5230", ripper.getGID(url));
+    }
+
     // TODO: Add a test for an album with a title.
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #335)


# Description

Changed how the ripper gets the album title and added more unit test


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [X] I've added a unit test to cover my change.
