### PR TITLE
Russian translation

### DIFF
--- a/src/main/resources/LabelsBundle_ru_RU.properties
+++ b/src/main/resources/LabelsBundle_ru_RU.properties
@@ -1,0 +1,37 @@
+﻿Log = Лог
+History = История
+created = создано
+modified = изменено
+Queue = Очередь
+Configuration = Конфигурация
+
+# Keys for the Configuration menu
+
+current.version = Текущая версия
+check.for.updates = Проверка обновлений
+auto.update = Автообновление?
+max.download.threads = Максимум потоков для загрузки
+timeout.mill = Тайм-аут (в миллисекундах):
+retry.download.count = Количество попыток загрузки
+overwrite.existing.files = Перезаписывать существующие файлы?
+sound.when.rip.completes = Проиграть звук когда рип завершен
+preserve.order = Сохранять порядок
+save.logs = Сохранять логи
+notification.when.rip.starts = Уведомление при начале рипа
+save.urls.only = Сохранять только ссылки
+save.album.titles = Сохранять названия альбомов
+autorip.from.clipboard = Автоматический рип из буффера обмена
+save.descriptions = Сохранять описание
+prefer.mp4.over.gif = Предпочитать MP4 чем GIF
+restore.window.position = Восстанавливать положение окна
+remember.url.history = Запоминать историю ссылок
+loading.history.from = Загрузка истории из
+
+# Misc UI keys
+
+loading.history.from.configuration = Загрузка истории из конфигурации
+interrupted.while.waiting.to.rip.next.album = Прервано при ожидании загрузки следующего альбома
+inactive = бездействую
+re-rip.checked = Загрузить выделенные повторно
+remove = Удалить
+clear = Очистить


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] translation


# Description

Added russian translation


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
