### PR TITLE
Can now update ripme from the commandline

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -241,6 +241,10 @@ public class App {
             ripURL(url, !cl.hasOption("n"));
         }
 
+        if (cl.hasOption('j')) {
+            UpdateUtils.updateProgramCLI();
+        }
+
     }
 
     /**
@@ -290,6 +294,7 @@ public class App {
         opts.addOption("v", "version", false, "Show current version");
         opts.addOption("s", "socks-server", true, "Use socks server ([user:password]@host[:port])");
         opts.addOption("p", "proxy-server", true, "Use HTTP Proxy server ([user:password]@host[:port])");
+        opts.addOption("j", "update", false, "Update ripme");
         return opts;
     }
 

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -198,7 +198,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         if (!configurationPanel.isVisible()) {
             optionConfiguration.doClick();
         }
-        Runnable r = () -> UpdateUtils.updateProgram(configUpdateLabel);
+        Runnable r = () -> UpdateUtils.updateProgramGUI(configUpdateLabel);
         new Thread(r).start();
     }
 
@@ -786,7 +786,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             }
         });
         configUpdateButton.addActionListener(arg0 -> {
-            Thread t = new Thread(() -> UpdateUtils.updateProgram(configUpdateLabel));
+            Thread t = new Thread(() -> UpdateUtils.updateProgramGUI(configUpdateLabel));
             t.start();
         });
         configLogLevelCombobox.addActionListener(arg0 -> {

--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -20,7 +20,7 @@ import com.rarchives.ripme.utils.Utils;
 public class UpdateUtils {
 
     private static final Logger logger = Logger.getLogger(UpdateUtils.class);
-    private static final String DEFAULT_VERSION = "1.7.49";
+    private static final String DEFAULT_VERSION = "1.7.50";
     private static final String REPO_NAME = "ripmeapp/ripme";
     private static final String updateJsonURL = "https://raw.githubusercontent.com/" + REPO_NAME + "/master/ripme.json";
     private static final String mainFileName = "ripme.jar";


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #648)


# Description

I added a -j flag that updates ripme


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
