### PR TITLE
Fixed TheyiffgalleryRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TheyiffgalleryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TheyiffgalleryRipper.java
@@ -59,8 +59,8 @@ public class TheyiffgalleryRipper extends AbstractHTMLRipper {
     @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
-        for (Element el : doc.select("ul.thumbnails > li.gdthumb")) {
-            String imageSource = el.select("a > img").attr("src");
+        for (Element el : doc.select("img.thumbnail")) {
+            String imageSource = el.attr("src");
             imageSource = imageSource.replaceAll("_data/i", "");
             imageSource = imageSource.replaceAll("-\\w\\w_\\w\\d+x\\d+", "");
             result.add("https://theyiffgallery.com" + imageSource);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #653)



# Description

The ripper now finds thumbs by grabbing all images in the "thumbnail" class


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
