### PR TITLE
Various update improvements

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -161,6 +161,7 @@ public class UpdateUtils {
     private static boolean isNewerVersion(String latestVersion) {
         // If we're testing the update utils we want the program to always try to update
         if (Utils.getConfigBoolean("testing.always_try_to_update", false)) {
+            logger.info("isNewerVersion is returning true because the key \"testing.always_try_to_update\" is true");
             return true;
         }
         int[] oldVersions = versionStringToInt(getThisJarVersion());

--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -159,6 +159,10 @@ public class UpdateUtils {
     }
 
     private static boolean isNewerVersion(String latestVersion) {
+        // If we're testing the update utils we want the program to always try to update
+        if (Utils.getConfigBoolean("testing.always_try_to_update", false)) {
+            return true;
+        }
         int[] oldVersions = versionStringToInt(getThisJarVersion());
         int[] newVersions = versionStringToInt(latestVersion);
         if (oldVersions.length < newVersions.length) {

--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -68,8 +68,9 @@ public class UpdateUtils {
             if (change.startsWith(UpdateUtils.getThisJarVersion() + ":")) {
                 break;
             }
-            changeList.append("<br>  + ").append(change);
+            changeList.append("\n").append(change);
         }
+        logger.info("Change log: \n" + changeList.toString());
 
         String latestVersion = ripmeJson.getString("latestVersion");
         if (UpdateUtils.isNewerVersion(latestVersion)) {

--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -229,17 +229,20 @@ public class UpdateUtils {
         try (FileOutputStream out = new FileOutputStream(updateFileName)) {
             out.write(response.bodyAsBytes());
         }
-        String updateHash = createSha256(new File(updateFileName));
-        logger.info("Download of new version complete; saved to " + updateFileName);
-        logger.info("Checking hash of update");
+        // Only check the hash if the user hasn't disabled hash checking
+        if (Utils.getConfigBoolean("security.check_update_hash", true)) {
+            String updateHash = createSha256(new File(updateFileName));
+            logger.info("Download of new version complete; saved to " + updateFileName);
+            logger.info("Checking hash of update");
 
-        if (!ripmeJson.getString("currentHash").equals(updateHash)) {
-            logger.error("Error: Update has bad hash");
-            logger.debug("Expected hash: " + ripmeJson.getString("currentHash"));
-            logger.debug("Actual hash: " + updateHash);
-            throw new IOException("Got bad file hash");
-        } else {
-            logger.info("Hash is good");
+            if (!ripmeJson.getString("currentHash").equals(updateHash)) {
+                logger.error("Error: Update has bad hash");
+                logger.debug("Expected hash: " + ripmeJson.getString("currentHash"));
+                logger.debug("Actual hash: " + updateHash);
+                throw new IOException("Got bad file hash");
+            } else {
+                logger.info("Hash is good");
+            }
         }
         if (shouldLaunch) {
             // Setup updater script

--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -39,6 +39,20 @@ public class UpdateUtils {
         }
         return thisVersion;
     }
+
+    private static String getChangeList(JSONObject rj) {
+        JSONArray jsonChangeList = rj.getJSONArray("changeList");
+        StringBuilder changeList = new StringBuilder();
+        for (int i = 0; i < jsonChangeList.length(); i++) {
+            String change = jsonChangeList.getString(i);
+            if (change.startsWith(UpdateUtils.getThisJarVersion() + ":")) {
+                break;
+            }
+            changeList.append("\n").append(change);
+        }
+        return changeList.toString();
+    }
+
     public static void updateProgramCLI() {
         logger.info("Checking for update...");
 
@@ -61,16 +75,10 @@ public class UpdateUtils {
         }
         String jsonString = doc.body().html().replaceAll("&quot;", "\"");
         ripmeJson = new JSONObject(jsonString);
-        JSONArray jsonChangeList = ripmeJson.getJSONArray("changeList");
-        StringBuilder changeList = new StringBuilder();
-        for (int i = 0; i < jsonChangeList.length(); i++) {
-            String change = jsonChangeList.getString(i);
-            if (change.startsWith(UpdateUtils.getThisJarVersion() + ":")) {
-                break;
-            }
-            changeList.append("\n").append(change);
-        }
-        logger.info("Change log: \n" + changeList.toString());
+
+        String changeList = getChangeList(ripmeJson);
+
+        logger.info("Change log: \n" + changeList);
 
         String latestVersion = ripmeJson.getString("latestVersion");
         if (UpdateUtils.isNewerVersion(latestVersion)) {
@@ -112,15 +120,8 @@ public class UpdateUtils {
         }
         String jsonString = doc.body().html().replaceAll("&quot;", "\"");
         ripmeJson = new JSONObject(jsonString);
-        JSONArray jsonChangeList = ripmeJson.getJSONArray("changeList");
-        StringBuilder changeList = new StringBuilder();
-        for (int i = 0; i < jsonChangeList.length(); i++) {
-            String change = jsonChangeList.getString(i);
-            if (change.startsWith(UpdateUtils.getThisJarVersion() + ":")) {
-                break;
-            }
-            changeList.append("<br>  + ").append(change);
-        }
+
+        String changeList = getChangeList(ripmeJson);
 
         String latestVersion = ripmeJson.getString("latestVersion");
         if (UpdateUtils.isNewerVersion(latestVersion)) {
@@ -128,7 +129,7 @@ public class UpdateUtils {
             int result = JOptionPane.showConfirmDialog(
                     null,
                     "<html><font color=\"green\">New version (" + latestVersion + ") is available!</font>"
-                    + "<br><br>Recent changes:" + changeList.toString()
+                    + "<br><br>Recent changes:" + changeList
                     + "<br><br>Do you want to download and run the newest version?</html>",
                     "RipMe Updater",
                     JOptionPane.YES_NO_OPTION);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a refactoring



# Description

When updating ripme using the -j flag the changes since the last version of ripme will be printed on screen and cut down on repeated code by moving said code to the getChangeList func

You can now force ripme to update even if it's the latest version by setting the config key "testing.always_try_to_update" to true

You can now disable update hash checking by setting the config key "security.check_update_hash" to false


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
