### PR TITLE
Updating the VideoRipper class

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/VideoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/VideoRipper.java
@@ -1,5 +1,9 @@
 package com.rarchives.ripme.ripper;
 
+import com.rarchives.ripme.ui.RipStatusMessage;
+import com.rarchives.ripme.ui.RipStatusMessage.STATUS;
+import com.rarchives.ripme.utils.Utils;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -7,29 +11,26 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 
-import com.rarchives.ripme.ui.RipStatusMessage;
-import com.rarchives.ripme.ui.RipStatusMessage.STATUS;
-import com.rarchives.ripme.utils.Utils;
-import com.sun.org.apache.xpath.internal.operations.Bool;
-
 public abstract class VideoRipper extends AbstractRipper {
 
-    private int bytesTotal = 1,
-                 bytesCompleted = 1;
+    private int bytesTotal = 1;
+    private int bytesCompleted = 1;
 
     protected VideoRipper(URL url) throws IOException {
         super(url);
     }
 
-    public abstract boolean canRip(URL url);
     public abstract void rip() throws IOException;
+
     public abstract String getHost();
+
     public abstract String getGID(URL url) throws MalformedURLException;
 
     @Override
     public void setBytesTotal(int bytes) {
         this.bytesTotal = bytes;
     }
+
     @Override
     public void setBytesCompleted(int bytes) {
         this.bytesCompleted = bytes;
@@ -56,8 +57,7 @@ public abstract class VideoRipper extends AbstractRipper {
                 logger.error("Error while writing to " + urlFile, e);
                 return false;
             }
-        }
-        else {
+        } else {
             if (isThisATest()) {
                 // Tests shouldn't download the whole video
                 // Just change this.url to the download URL so the test knows we found it.
@@ -71,52 +71,54 @@ public abstract class VideoRipper extends AbstractRipper {
     }
 
     @Override
-    public boolean addURLToDownload(URL url, File saveAs, String referrer, Map<String,String> cookies, Boolean getFileExtFromMIME) {
+    public boolean addURLToDownload(URL url, File saveAs, String referrer, Map<String, String> cookies, Boolean getFileExtFromMIME) {
         return addURLToDownload(url, saveAs);
     }
 
-    
     /**
      * Creates & sets working directory based on URL.
-     * @param url
-     *      Target URL
+     *
+     * @param url Target URL
      */
     @Override
     public void setWorkingDir(URL url) throws IOException {
         String path = Utils.getWorkingDirectory().getCanonicalPath();
+
         if (!path.endsWith(File.separator)) {
             path += File.separator;
         }
+
         path += "videos" + File.separator;
-        this.workingDir = new File(path);
-        if (!this.workingDir.exists()) {
-            logger.info("[+] Creating directory: " + Utils.removeCWD(this.workingDir));
-            this.workingDir.mkdirs();
+        workingDir = new File(path);
+
+        if (!workingDir.exists()) {
+            logger.info("[+] Creating directory: " + Utils.removeCWD(workingDir));
+            workingDir.mkdirs();
         }
-        logger.debug("Set working directory to: " + this.workingDir);
+
+        logger.debug("Set working directory to: " + workingDir);
     }
-    
+
     /**
-     * @return
-     *      Returns % of video done downloading.
+     * @return Returns % of video done downloading.
      */
     @Override
     public int getCompletionPercentage() {
         return (int) (100 * (bytesCompleted / (float) bytesTotal));
     }
-    
+
     /**
      * Runs if download successfully completed.
-     * @param url
-     *      Target URL
-     * @param saveAs
-     *      Path to file, including filename.
+     *
+     * @param url    Target URL
+     * @param saveAs Path to file, including filename.
      */
     @Override
     public void downloadCompleted(URL url, File saveAs) {
         if (observer == null) {
             return;
         }
+
         try {
             String path = Utils.removeCWD(saveAs);
             RipStatusMessage msg = new RipStatusMessage(STATUS.DOWNLOAD_COMPLETE, path);
@@ -127,62 +129,58 @@ public abstract class VideoRipper extends AbstractRipper {
             logger.error("Exception while updating observer: ", e);
         }
     }
-    
+
     /**
      * Runs if the download errored somewhere.
-     * @param url
-     *      Target URL
-     * @param reason
-     *      Reason why the download failed.
+     *
+     * @param url    Target URL
+     * @param reason Reason why the download failed.
      */
     @Override
     public void downloadErrored(URL url, String reason) {
         if (observer == null) {
             return;
         }
+
         observer.update(this, new RipStatusMessage(STATUS.DOWNLOAD_ERRORED, url + " : " + reason));
         checkIfComplete();
     }
-    
-    
+
     /**
      * Runs if user tries to redownload an already existing File.
-     * @param url
-     *      Target URL
-     * @param file
-     *      Existing file
+     *
+     * @param url  Target URL
+     * @param file Existing file
      */
     @Override
     public void downloadExists(URL url, File file) {
         if (observer == null) {
             return;
         }
+
         observer.update(this, new RipStatusMessage(STATUS.DOWNLOAD_WARN, url + " already saved as " + file));
         checkIfComplete();
     }
 
     /**
      * Gets the status and changes it to a human-readable form.
-     * @return 
-     *      Status of current download.
+     *
+     * @return Status of current download.
      */
     @Override
     public String getStatusText() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(getCompletionPercentage())
-          .append("% ")
-          .append(" - ")
-          .append(Utils.bytesToHumanReadable(bytesCompleted))
-          .append(" / ")
-          .append(Utils.bytesToHumanReadable(bytesTotal));
-        return sb.toString();
+        return String.valueOf(getCompletionPercentage()) +
+                "%  - " +
+                Utils.bytesToHumanReadable(bytesCompleted) +
+                " / " +
+                Utils.bytesToHumanReadable(bytesTotal);
     }
 
-    @Override
     /**
      * Sanitizes URL.
      * Usually just returns itself.
      */
+    @Override
     public URL sanitizeURL(URL url) throws MalformedURLException {
         return url;
     }
@@ -195,8 +193,10 @@ public abstract class VideoRipper extends AbstractRipper {
         if (observer == null) {
             return;
         }
+
         if (bytesCompleted >= bytesTotal) {
             super.checkIfComplete();
         }
     }
+
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix


# Description

- ordered imports alphabetically;
- removed signature of the canRip method, which is already in AbstractRipper;
- split variable declaration in different lines;
- corrected javadocs alignment;
- replaced unnecessary use of StringBuilder.
- added a few empty lines to increase the readability of the code


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
