### PR TITLE
Releases are now automatic

### DIFF
--- a/release.py
+++ b/release.py
@@ -3,6 +3,7 @@ import re
 import os
 
 import sys
+from hashlib import sha256
 from github import Github
 import json
 from datetime import timezone
@@ -13,6 +14,7 @@ parser = argparse.ArgumentParser(description="Make a new ripme release on github
 parser.add_argument("-f", "--file", help="Path to the version of ripme to release")
 parser.add_argument("-t", "--token", help="Your github personal access token")
 parser.add_argument("-d", "--debug", help="Run in debug mode", action="store_true")
+parser.add_argument("-n", "--non-interactive", help="Do not ask for any input from the user", action="store_true")
 args = parser.parse_args()
 
 
@@ -23,6 +25,8 @@ def isJar(filename):
     return filename.endswith("jar")
 
 
+# Returns true if last entry to the "changeList" section of ripme.json is in the format of $number.$number.$number: and
+# false if not
 def isValidCommitMessage(message):
     if debug:
         print("Checking if {} matchs pattern ^\d+\.\d+\.\d+:".format(message))
@@ -30,19 +34,41 @@ def isValidCommitMessage(message):
     return re.match(pattern, message)
 
 
-fileToUpload = args.file
-commitMessage = json.loads(open("ripme.json").read()).get("changeList")[0]
+ripmeJson = json.loads(open("ripme.json").read())
+fileToUploadPath = args.file
+InNoninteractiveMode = args.non_interactive
+commitMessage = ripmeJson.get("changeList")[0]
 debug = args.debug
 
-
-if not os.path.isfile(fileToUpload):
-    print("[!] Error: {} does not exist".format(fileToUpload))
+if not os.path.isfile(fileToUploadPath):
+    print("[!] Error: {} does not exist".format(fileToUploadPath))
     sys.exit(1)
 
-if not isJar(fileToUpload):
-    print("[!] Error: {} is not a jar file!".format(fileToUpload))
+if not isJar(fileToUploadPath):
+    print("[!] Error: {} is not a jar file!".format(fileToUploadPath))
     sys.exit(1)
 
 if not isValidCommitMessage(commitMessage):
-    print("[!] Error: {} is not a valid commit message as it does not start with a version".format(fileToUpload))
+    print("[!] Error: {} is not a valid commit message as it does not start with a version".format(fileToUploadPath))
     sys.exit(1)
+
+ripmeUpdate = open(fileToUploadPath, mode='rb').read()
+
+# The hash that we expect the update to have
+expectedHash = ripmeJson.get("currentHash")
+
+# The actual hash of the file on disk
+actualHash = sha256(ripmeUpdate).hexdigest()
+
+# Make sure that the hash of the file we're uploading matches the hash in ripme.json. These hashes not matching will
+# cause ripme to refuse to install the update for all users who haven't disabled update hash checking
+if expectedHash != actualHash:
+    print("[!] Error: expected hash of file and actual hash differ")
+    print("[!] Expected hash is {}".format(expectedHash))
+    print("[!] Actual hash is {}".format(actualHash))
+
+# This only runs in we're in interactive mode
+if not InNoninteractiveMode:
+    print("File path: {}\n".format(fileToUploadPath))
+    print("Release title: {}".format(commitMessage))
+    input("\nPlease review the information above and ensure it is correct and then press enter")

--- a/release.py
+++ b/release.py
@@ -6,8 +6,6 @@ import sys
 from hashlib import sha256
 from github import Github
 import json
-from datetime import timezone
-import datetime
 import argparse
 
 parser = argparse.ArgumentParser(description="Make a new ripme release on github")
@@ -38,8 +36,11 @@ ripmeJson = json.loads(open("ripme.json").read())
 fileToUploadPath = args.file
 InNoninteractiveMode = args.non_interactive
 commitMessage = ripmeJson.get("changeList")[0]
+releaseVersion = ripmeJson.get("latestVersion")
 debug = args.debug
 accessToken = args.token
+repoOwner = "ripmeapp"
+repoName = "ripme"
 
 if not os.path.isfile(fileToUploadPath):
     print("[!] Error: {} does not exist".format(fileToUploadPath))
@@ -71,9 +72,17 @@ if expectedHash != actualHash:
 # Ask the user to review the information before we precede
 # This only runs in we're in interactive mode
 if not InNoninteractiveMode:
-    print("File path: {}\n".format(fileToUploadPath))
+    print("File path: {}".format(fileToUploadPath))
     print("Release title: {}".format(commitMessage))
+    print("Repo: {}/{}".format(repoOwner, repoName))
     input("\nPlease review the information above and ensure it is correct and then press enter")
 
 print("Accessing github using token")
 g = Github(accessToken)
+
+
+print("Creating release")
+release = g.get_user(repoOwner).get_repo(repoName).create_git_release(releaseVersion, commitMessage, "")
+
+print("Uploading file")
+release.upload_asset(fileToUploadPath, "ripme.jar")

--- a/release.py
+++ b/release.py
@@ -39,6 +39,7 @@ fileToUploadPath = args.file
 InNoninteractiveMode = args.non_interactive
 commitMessage = ripmeJson.get("changeList")[0]
 debug = args.debug
+accessToken = args.token
 
 if not os.path.isfile(fileToUploadPath):
     print("[!] Error: {} does not exist".format(fileToUploadPath))
@@ -67,8 +68,12 @@ if expectedHash != actualHash:
     print("[!] Expected hash is {}".format(expectedHash))
     print("[!] Actual hash is {}".format(actualHash))
 
+# Ask the user to review the information before we precede
 # This only runs in we're in interactive mode
 if not InNoninteractiveMode:
     print("File path: {}\n".format(fileToUploadPath))
     print("Release title: {}".format(commitMessage))
     input("\nPlease review the information above and ensure it is correct and then press enter")
+
+print("Accessing github using token")
+g = Github(accessToken)

--- a/release.py
+++ b/release.py
@@ -1,0 +1,48 @@
+import re
+
+import os
+
+import sys
+from github import Github
+import json
+from datetime import timezone
+import datetime
+import argparse
+
+parser = argparse.ArgumentParser(description="Make a new ripme release on github")
+parser.add_argument("-f", "--file", help="Path to the version of ripme to release")
+parser.add_argument("-t", "--token", help="Your github personal access token")
+parser.add_argument("-d", "--debug", help="Run in debug mode", action="store_true")
+args = parser.parse_args()
+
+
+# Make sure the file the user selected is a jar
+def isJar(filename):
+    if debug:
+        print("Checking if {} is a jar file".format(filename))
+    return filename.endswith("jar")
+
+
+def isValidCommitMessage(message):
+    if debug:
+        print("Checking if {} matchs pattern ^\d+\.\d+\.\d+:".format(message))
+    pattern = re.compile("^\d+\.\d+\.\d+:")
+    return re.match(pattern, message)
+
+
+fileToUpload = args.file
+commitMessage = json.loads(open("ripme.json").read()).get("changeList")[0]
+debug = args.debug
+
+
+if not os.path.isfile(fileToUpload):
+    print("[!] Error: {} does not exist".format(fileToUpload))
+    sys.exit(1)
+
+if not isJar(fileToUpload):
+    print("[!] Error: {} is not a jar file!".format(fileToUpload))
+    sys.exit(1)
+
+if not isValidCommitMessage(commitMessage):
+    print("[!] Error: {} is not a valid commit message as it does not start with a version".format(fileToUpload))
+    sys.exit(1)

--- a/release.py
+++ b/release.py
@@ -68,6 +68,7 @@ if expectedHash != actualHash:
     print("[!] Error: expected hash of file and actual hash differ")
     print("[!] Expected hash is {}".format(expectedHash))
     print("[!] Actual hash is {}".format(actualHash))
+    sys.exit(1)
 
 # Ask the user to review the information before we precede
 # This only runs in we're in interactive mode

--- a/release.py
+++ b/release.py
@@ -17,6 +17,11 @@ parser.add_argument("-d", "--debug", help="Run in debug mode", action="store_tru
 parser.add_argument("-n", "--non-interactive", help="Do not ask for any input from the user", action="store_true")
 args = parser.parse_args()
 
+try:
+    input = raw_input
+except NameError:
+    pass
+
 
 # Make sure the file the user selected is a jar
 def isJar(filename):

--- a/release.py
+++ b/release.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import re
 
 import os


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #665)


# Description

I wrote a script to automate new releases


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
