### PR TITLE
Users can now use their own account when ripping Furaffinity

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
@@ -29,10 +29,10 @@ public class FuraffinityRipper extends AbstractHTMLRipper {
     private static final String urlBase = "https://www.furaffinity.net";
     private static Map<String,String> cookies = new HashMap<>();
     static {
-        if (Utils.getConfigString("furaffinity.cookie.a", "") != "" && Utils.getConfigString("furaffinity.cookie.b", "") != "") {
+        if (Utils.getConfigBoolean("furaffinity.login", true)) {
             LOGGER.info("Logging in using cookies");
-            cookies.put("b", Utils.getConfigString("furaffinity.cookie.b", ""));
-            cookies.put("a", Utils.getConfigString("furaffinity.cookie.a", ""));
+            cookies.put("a", Utils.getConfigString("furaffinity.cookie.a", "897bc45b-1f87-49f1-8a85-9412bc103e7a"));
+            cookies.put("b", Utils.getConfigString("furaffinity.cookie.b", "c8807f36-7a85-4caf-80ca-01c2a2368267"));
         }
     }
 
@@ -97,7 +97,7 @@ public class FuraffinityRipper extends AbstractHTMLRipper {
         Elements urlElements = page.select("figure > b > u > a");
         for (Element e : urlElements) {
             String urlToAdd = getImageFromPost(urlBase + e.select("a").first().attr("href"));
-            if (urlToAdd.startsWith("http")) {
+            if (urlToAdd.startsWith("http") && urlToAdd.contains("/view/")) {
                 urls.add(urlToAdd);
             }
         }
@@ -204,17 +204,6 @@ public class FuraffinityRipper extends AbstractHTMLRipper {
         throw new MalformedURLException("Expected furaffinity.net URL format: "
                 + "www.furaffinity.net/gallery/username  - got " + url
                 + " instead");
-    }
-
-    private class FuraffinityDocumentThread extends Thread {
-        private URL url;
-
-        FuraffinityDocumentThread(URL url) {
-            super();
-            this.url = url;
-        }
-
-
     }
 
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
@@ -29,8 +29,11 @@ public class FuraffinityRipper extends AbstractHTMLRipper {
     private static final String urlBase = "https://www.furaffinity.net";
     private static Map<String,String> cookies = new HashMap<>();
     static {
-        cookies.put("b", "bd5ccac8-51dc-4265-8ae1-7eac685ad667");
-        cookies.put("a", "7c41b782-d01d-4b0e-b45b-62a4f0b2a369");
+        if (Utils.getConfigString("furaffinity.cookie.a", "") != "" && Utils.getConfigString("furaffinity.cookie.b", "") != "") {
+            LOGGER.info("Logging in using cookies");
+            cookies.put("b", Utils.getConfigString("furaffinity.cookie.b", ""));
+            cookies.put("a", Utils.getConfigString("furaffinity.cookie.a", ""));
+        }
     }
 
     // Thread pool for finding direct image links from "image" pages (html)
@@ -91,9 +94,12 @@ public class FuraffinityRipper extends AbstractHTMLRipper {
     @Override
     public List<String> getURLsFromPage(Document page) {
         List<String> urls = new ArrayList<>();
-        Elements urlElements = page.select("figure.t-image > b > u > a");
+        Elements urlElements = page.select("figure > b > u > a");
         for (Element e : urlElements) {
-            urls.add(getImageFromPost(urlBase + e.select("a").first().attr("href")));
+            String urlToAdd = getImageFromPost(urlBase + e.select("a").first().attr("href"));
+            if (urlToAdd.startsWith("http")) {
+                urls.add(urlToAdd);
+            }
         }
         return urls;
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.rarchives.ripme.ui.RipStatusMessage;
 import com.rarchives.ripme.utils.Utils;
 import org.jsoup.Connection.Response;
 import org.jsoup.Jsoup;
@@ -27,12 +28,23 @@ import com.rarchives.ripme.utils.Http;
 public class FuraffinityRipper extends AbstractHTMLRipper {
 
     private static final String urlBase = "https://www.furaffinity.net";
-    private static Map<String,String> cookies = new HashMap<>();
-    static {
+    private  Map<String,String> cookies = new HashMap<>();
+
+    private void setCookies() {
         if (Utils.getConfigBoolean("furaffinity.login", true)) {
             LOGGER.info("Logging in using cookies");
-            cookies.put("a", Utils.getConfigString("furaffinity.cookie.a", "897bc45b-1f87-49f1-8a85-9412bc103e7a"));
-            cookies.put("b", Utils.getConfigString("furaffinity.cookie.b", "c8807f36-7a85-4caf-80ca-01c2a2368267"));
+            String faACookie = Utils.getConfigString("furaffinity.cookie.a", "897bc45b-1f87-49f1-8a85-9412bc103e7a");
+            String faBCookie = Utils.getConfigString("furaffinity.cookie.b", "c8807f36-7a85-4caf-80ca-01c2a2368267");
+            warnAboutSharedAccount(faACookie, faBCookie);
+            cookies.put("a", faACookie);
+            cookies.put("b", faBCookie);
+        }
+    }
+
+    private void warnAboutSharedAccount(String a, String b) {
+        if (a.equals("897bc45b-1f87-49f1-8a85-9412bc103e7a") && b.equals("c8807f36-7a85-4caf-80ca-01c2a2368267")) {
+            sendUpdate(RipStatusMessage.STATUS.DOWNLOAD_ERRORED,
+                    "WARNING: Using the shared furaffinity account exposes both your IP and how many items you downloaded to the other users of the share account");
         }
     }
 
@@ -64,6 +76,7 @@ public class FuraffinityRipper extends AbstractHTMLRipper {
     }
     @Override
     public Document getFirstPage() throws IOException {
+        setCookies();
         return Http.url(url).cookies(cookies).get();
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)



# Description

ripme now allows users to log in to FA using their own account cookies or to not log in at all if they're not ripping NSFW content

Ripme now also prints a warning about using the shared account when a user logs in using the shared account. I also fixed NSFW file downloading and now the ripper downloads fullsized images

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
