### PR TITLE
DeviantartRipper now logs in using cookies 

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
@@ -132,10 +132,7 @@ public class DeviantartRipper extends AbstractHTMLRipper {
                 LOGGER.warn("Failed to get login cookies");
                 cookies.put("agegate_state","1"); // Bypasses the age gate
             }
-
-        LOGGER.info(Http.url(this.url)
-                .cookies(cookies)
-                .get());
+            
         return Http.url(this.url)
                    .cookies(cookies)
                    .get();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
@@ -437,15 +437,19 @@ public class DeviantartRipper extends AbstractHTMLRipper {
         if (username == null || password == null) {
             throw new IOException("could not find username or password in config");
         }
-        Response resp = Http.url("http://www.deviantart.com/")
+        Response resp = Http.url("http://www.deviantart.com/users/login")
                             .response();
-        for (Element input : resp.parse().select("form#form-login input[type=hidden]")) {
-            postData.put(input.attr("name"), input.attr("value"));
-        }
+//        for (Element input : resp.parse().select("form#form-login input[type=hidden]")) {
+//            postData.put(input.attr("name"), input.attr("value"));
+//        }
+        Document r = resp.parse();
+        LOGGER.info("R: " + r.html());
         postData.put("username", username);
         postData.put("password", password);
-        postData.put("remember_me", "1");
-
+        postData.put("validate_token", "829439d1f0b53e20f2f5");
+        postData.put("validate_key", "1528530690");
+//        postData.put("remember_me", "1");
+        LOGGER.info(postData);
         // Send login request
         resp = Http.url("https://www.deviantart.com/users/login")
                     .userAgent(USER_AGENT)
@@ -453,6 +457,7 @@ public class DeviantartRipper extends AbstractHTMLRipper {
                     .cookies(resp.cookies())
                     .method(Method.POST)
                     .response();
+//        LOGGER.info("RESP: " + resp.parse().html());
 
         // Assert we are logged in
         if (resp.hasHeader("Location") && resp.header("Location").contains("password")) {

--- a/src/main/java/com/rarchives/ripme/utils/RipUtils.java
+++ b/src/main/java/com/rarchives/ripme/utils/RipUtils.java
@@ -3,9 +3,7 @@ package com.rarchives.ripme.utils;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -278,5 +276,17 @@ public class RipUtils {
             }
         }
         return url;
+    }
+    /**
+     * Reads a cookie string (Key1=value1;key2=value2) from the config file and turns it into a hashmap
+     * @return Map of cookies containing session data.
+     */
+    public static Map<String, String> getCookiesFromString(String line) {
+        Map<String,String> cookies = new HashMap<>();
+        for (String pair : line.split(";")) {
+            String[] kv = pair.split("=");
+            cookies.put(kv[0], kv[1]);
+        }
+        return cookies;
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #599)


# Description

As Deviantart now blocks automatic log in, I changed the ripper to use cookies dumped from a browser

TODO: Retest this in 3 days to see if the userinfo cookie has expired or not


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
