### PR TITLE
Tumblr ripper no longer tries to download images in fullsize if the i…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -235,8 +235,12 @@ public class TumblrRipper extends AlbumRipper {
                 for (int j = 0; j < photos.length(); j++) {
                     photo = photos.getJSONObject(j);
                     try {
-                        if (Utils.getConfigBoolean("tumblr.get_raw_image", false)) {
-                            String urlString = photo.getJSONObject("original_size").getString("url").replaceAll("https", "http");
+                        String imageUrl = photo.getJSONObject("original_size").getString("url");
+                        // If the url is shorter than 65 chars long we skip it because it's those images don't support grabbing them in fullsize
+                        if (Utils.getConfigBoolean("tumblr.get_raw_image", false) &&
+                                imageUrl.replaceAll("https", "http").length() > 65) {
+                            // We have to change the link to http because tumblr uses an invalid cert for data.tumblr.com
+                            String urlString = imageUrl.replaceAll("https", "http");
                             urlString = urlString.replaceAll("https?://[a-sA-Z0-9_\\-\\.]*\\.tumblr", "http://data.tumblr");
                             urlString = urlString.replaceAll("_\\d+\\.", "_raw.");
                             fileURL = new URL(urlString);


### PR DESCRIPTION
…mage doesn't support it

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #689 )


# Description

The ripper now will not try to download images with a url shorter than 65 chars (All these image no not support downloading in fullsize) in full size


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
