### PR TITLE
 Furaffinity ripper now uses RipUtils.getCookiesFromString to load cookies

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
@@ -26,6 +26,8 @@ import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import com.rarchives.ripme.ripper.DownloadThreadPool;
 import com.rarchives.ripme.utils.Http;
 
+import static com.rarchives.ripme.utils.RipUtils.getCookiesFromString;
+
 public class FuraffinityRipper extends AbstractHTMLRipper {
 
     private static final String urlBase = "https://www.furaffinity.net";
@@ -34,16 +36,14 @@ public class FuraffinityRipper extends AbstractHTMLRipper {
     private void setCookies() {
         if (Utils.getConfigBoolean("furaffinity.login", true)) {
             LOGGER.info("Logging in using cookies");
-            String faACookie = Utils.getConfigString("furaffinity.cookie.a", "897bc45b-1f87-49f1-8a85-9412bc103e7a");
-            String faBCookie = Utils.getConfigString("furaffinity.cookie.b", "c8807f36-7a85-4caf-80ca-01c2a2368267");
-            warnAboutSharedAccount(faACookie, faBCookie);
-            cookies.put("a", faACookie);
-            cookies.put("b", faBCookie);
+            String faCookies = Utils.getConfigString("furaffinity.cookies", "a=897bc45b-1f87-49f1-8a85-9412bc103e7a;b=c8807f36-7a85-4caf-80ca-01c2a2368267");
+            warnAboutSharedAccount(faCookies);
+            cookies = getCookiesFromString(faCookies);
         }
     }
 
-    private void warnAboutSharedAccount(String a, String b) {
-        if (a.equals("897bc45b-1f87-49f1-8a85-9412bc103e7a") && b.equals("c8807f36-7a85-4caf-80ca-01c2a2368267")) {
+    private void warnAboutSharedAccount(String loginCookies) {
+        if (loginCookies.equals("a=897bc45b-1f87-49f1-8a85-9412bc103e7a;b=c8807f36-7a85-4caf-80ca-01c2a2368267")) {
             sendUpdate(RipStatusMessage.STATUS.DOWNLOAD_ERRORED,
                     "WARNING: Using the shared furaffinity account exposes both your IP and how many items you downloaded to the other users of the share account");
         }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuraffinityRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuraffinityRipperTest.java
@@ -16,4 +16,12 @@ public class FuraffinityRipperTest extends RippersTest {
         FuraffinityRipper ripper = new FuraffinityRipper(url);
         assertEquals("mustardgas", ripper.getGID(url));
     }
+
+    public void testLogin() throws IOException {
+        URL url = new URL("https://www.furaffinity.net/gallery/mustardgas/");
+        FuraffinityRipper ripper = new FuraffinityRipper(url);
+        // Check if the first page contain the username of ripmes shared account
+        Boolean containsUsername = ripper.getFirstPage().html().contains("ripmethrowaway");
+        assert containsUsername;
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a refactoring



# Description

I made the ripper use RipUtils.getCookiesFromString when loading cookies and added a login unit test

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [X] I've added a unit test to cover my change.
