### PR TITLE
Reddit ripper can now rip videos from v.redd.it

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/RipUtils.java
+++ b/src/main/java/com/rarchives/ripme/utils/RipUtils.java
@@ -86,6 +86,9 @@ public class RipUtils {
                 logger.warn("Exception while retrieving eroshare page:", e);
             }
             return result;
+        } else if (url.toExternalForm().contains("v.redd.it")) {
+            result.add(url);
+            return result;
         }
 
         else if (url.toExternalForm().contains("erome.com")) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #701)


# Description

The reddit ripper can now rip v.redd.it videos


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
