### PR TITLE
patch.py now reminds users to run git push before release.py

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -8,8 +8,8 @@ from hashlib import sha256
 # - update version in a few places
 # - insert new line in ripme.json with message
 # - build ripme
-# - add the hash of the lastest binary to ripme.json
-
+# - add the hash of the latest binary to ripme.json
+# - commit all changes
 message = input('message: ')
 
 
@@ -89,3 +89,4 @@ update_hash(file_hash)
 subprocess.call(['git', 'add', '-u'])
 subprocess.call(['git', 'commit', '-m', commitMessage])
 subprocess.call(['git', 'tag', nextVersion])
+print("Remember to run `git push origin master` before release.py")


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #698)

# Description

patch.py now reminds users to push to master before running release.py


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
