### PR TITLE
Twitter ripper now rips retweets

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
@@ -20,6 +20,8 @@ import com.rarchives.ripme.utils.Utils;
 
 public class TwitterRipper extends AlbumRipper {
 
+    int downloadUrls = 1;
+
     private static final String DOMAIN = "twitter.com",
             HOST = "twitter";
 
@@ -197,12 +199,18 @@ public class TwitterRipper extends AlbumRipper {
                             urlToDownload = variant.getString("url");
                         }
                     }
-                    addURLToDownload(new URL(urlToDownload));
+                    if (urlToDownload != null) {
+                        addURLToDownload(new URL(urlToDownload), getPrefix(downloadUrls));
+                        downloadUrls++;
+                    } else {
+                        LOGGER.error("URLToDownload was null");
+                    }
                     parsedCount++;
                 } else if (media.getString("type").equals("photo")) {
                     if (url.contains(".twimg.com/")) {
                         url += ":orig";
-                        addURLToDownload(new URL(url));
+                        addURLToDownload(new URL(url), getPrefix(downloadUrls));
+                        downloadUrls++;
                         parsedCount++;
                     } else {
                         LOGGER.debug("Unexpected media_url: " + url);
@@ -213,6 +221,10 @@ public class TwitterRipper extends AlbumRipper {
 
 
         return parsedCount;
+    }
+
+    public String getPrefix(int index) {
+        return String.format("%03d_", index);
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
@@ -123,7 +123,7 @@ public class TwitterRipper extends AlbumRipper {
                         .append("&include_entities=true")
                         .append("&exclude_replies=true")
                         .append("&trim_user=true")
-                        .append("&include_rts=false")
+                        .append("&include_rts=true")
                         .append("&count=" + 200);
                 break;
             case SEARCH:
@@ -187,14 +187,18 @@ public class TwitterRipper extends AlbumRipper {
                 url = media.getString("media_url");
                 if (media.getString("type").equals("video")) {
                     JSONArray variants = media.getJSONObject("video_info").getJSONArray("variants");
+                    int largestBitrate = 0;
+                    String urlToDownload = null;
+                    // Loop over all the video options and find the biggest video
                     for (int j = 0; j < medias.length(); j++) {
                         JSONObject variant = (JSONObject) variants.get(i);
-                        if (variant.has("bitrate") && variant.getInt("bitrate") == 832000) {
-                            addURLToDownload(new URL(variant.getString("url")));
-                            parsedCount++;
-                            break;
+                        if (variant.getInt("bitrate") > largestBitrate) {
+                            largestBitrate = variant.getInt("bitrate");
+                            urlToDownload = variant.getString("url");
                         }
                     }
+                    addURLToDownload(new URL(urlToDownload));
+                    parsedCount++;
                 } else if (media.getString("type").equals("photo")) {
                     if (url.contains(".twimg.com/")) {
                         url += ":orig";


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #390 fixes #445 fixes #286)


# Description

The ripper now requests all of a users retweets as well as their tweets. The ripper now also downloads videos in the largest size possible


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
