### PR TITLE
Some ui changes

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -496,7 +496,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         configURLHistoryCheckbox = addNewCheckbox(rb.getString("remember.url.history"), "remember.url_history", true);
 
         configLogLevelCombobox = new JComboBox<>(new String[] {"Log level: Error", "Log level: Warn", "Log level: Info", "Log level: Debug"});
-        configSelectLangComboBox = new JComboBox<>(new String[] {"en_US", "de_DE", "es_ES", "fr_CH", "kr_KR", "pt_PT", "fi_FI", "in_ID", "porrisavvo_FI"});
+        configSelectLangComboBox = new JComboBox<>(new String[] {"en_US", "de_DE", "es_ES", "fr_CH", "kr_KR", "pt_PT", "fi_FI", "in_ID", "it_IT", "porrisavvo_FI"});
         configLogLevelCombobox.setSelectedItem(Utils.getConfigString("log.level", "Log level: Debug"));
         setLogLevel(configLogLevelCombobox.getSelectedItem().toString());
         configSaveDirLabel = new JLabel();
@@ -508,7 +508,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         } catch (Exception e) { }
         configSaveDirLabel.setToolTipText(configSaveDirLabel.getText());
         configSaveDirLabel.setHorizontalAlignment(JLabel.RIGHT);
-        configSaveDirButton = new JButton("Select Save Directory...");
+        configSaveDirButton = new JButton(rb.getString("select.save.directory"));
 
         addItemToConfigGridBagConstraints(gbc, 0, configUpdateLabel, configUpdateButton);
         addItemToConfigGridBagConstraints(gbc, 1, configAutoupdateCheckbox, configLogLevelCombobox);

--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -26,6 +26,8 @@ prefer.mp4.over.gif = Prefer MP4 over GIF
 restore.window.position = Restore window position
 remember.url.history = Remember URL history
 loading.history.from = Loading history from
+language = Language
+select.save.directory = Select Save Directory
 
 # Misc UI keys
 

--- a/src/main/resources/LabelsBundle_de_DE.properties
+++ b/src/main/resources/LabelsBundle_de_DE.properties
@@ -26,6 +26,8 @@ prefer.mp4.over.gif = Bevorzuge MP4 über GIF
 restore.window.position = Wieder herstellen der Fensterposition
 remember.url.history = Erinnere URL Verlauf
 loading.history.from = Lade Verlauf von
+language = Language
+select.save.directory = Select Save Directory
 
 # Misc UI keys
 

--- a/src/main/resources/LabelsBundle_en_US.properties
+++ b/src/main/resources/LabelsBundle_en_US.properties
@@ -26,6 +26,8 @@ prefer.mp4.over.gif = Prefer MP4 over GIF
 restore.window.position = Restore window position
 remember.url.history = Remember URL history
 loading.history.from = Loading history from
+language = Language
+select.save.directory = Select Save Directory
 
 # Misc UI keys
 

--- a/src/main/resources/LabelsBundle_es_ES.properties
+++ b/src/main/resources/LabelsBundle_es_ES.properties
@@ -26,6 +26,8 @@ prefer.mp4.over.gif = Preferir MP4 sobre GIF
 restore.window.position = Restaurar posicion de ventana
 remember.url.history = Recordar historia URL
 loading.history.from = Cargando historia desde
+language = Language
+select.save.directory = Select Save Directory
 
 # Misc UI keys
 

--- a/src/main/resources/LabelsBundle_fi_FI.properties
+++ b/src/main/resources/LabelsBundle_fi_FI.properties
@@ -26,6 +26,8 @@ prefer.mp4.over.gif = Suosi MP4:jää GIF:fin sijasta
 restore.window.position = Palauta ikkunan sijainti
 remember.url.history = Muista osoitehistoria
 loading.history.from = Ladataan historiaa kohteesta
+language = Language
+select.save.directory = Select Save Directory
 
 # Misc UI keys
 

--- a/src/main/resources/LabelsBundle_fr_CH.properties
+++ b/src/main/resources/LabelsBundle_fr_CH.properties
@@ -26,6 +26,8 @@ prefer.mp4.over.gif = Préférer MP4 à GIF
 restore.window.position = Restaurer la position de la fenêtre
 remember.url.history = Se souvenir de l'historique des URL
 loading.history.from = Charger l'historique depuis
+language = Language
+select.save.directory = Select Save Directory
 
 # Misc UI keys
 

--- a/src/main/resources/LabelsBundle_in_ID.properties
+++ b/src/main/resources/LabelsBundle_in_ID.properties
@@ -26,6 +26,8 @@ prefer.mp4.over.gif = Utamakan MP4 dari GIF
 restore.window.position = Kembalikan ukuran Window
 remember.url.history = Ingat riwayat URL
 loading.history.from = Ambil riwayat dari
+language = Language
+select.save.directory = Select Save Directory
 
 # Misc UI keys
 

--- a/src/main/resources/LabelsBundle_it_IT.properties
+++ b/src/main/resources/LabelsBundle_it_IT.properties
@@ -26,6 +26,8 @@ prefer.mp4.over.gif = Preferisci MP4 a GIF
 restore.window.position = Ripristina posizione della finestra
 remember.url.history = Riscorda la cronologia degli URL
 loading.history.from = Carica cronologia da
+language = Language
+select.save.directory = Select Save Directory
 
 # Misc UI keys
 

--- a/src/main/resources/LabelsBundle_kr_KR.properties
+++ b/src/main/resources/LabelsBundle_kr_KR.properties
@@ -26,6 +26,8 @@ prefer.mp4.over.gif = GIF\uBCF4\uB2E4 MP4 \uC120\uD638
 restore.window.position = \uCC3D \uC704\uCE58 \uBCF5\uC6D0
 remember.url.history = URL \uD788\uC2A4\uD1A0\uB9AC \uAE30\uC5B5\uD558\uAE30
 loading.history.from = \uD788\uC2A4\uD1A0\uB9AC \uAC00\uC838\uC624\uAE30
+language = Language
+select.save.directory = Select Save Directory
 
 # Misc UI keys
 

--- a/src/main/resources/LabelsBundle_porrisavvo_FI.properties
+++ b/src/main/resources/LabelsBundle_porrisavvo_FI.properties
@@ -26,6 +26,8 @@ prefer.mp4.over.gif = Suasi MP4 GIF sijjaa
 restore.window.position = Palaut ikkunna sijaant
 remember.url.history = Muist osot'hissa
 loading.history.from = Larrataa hissaa lähteest
+language = Language
+select.save.directory = Select Save Directory
 
 # Misc UI keys
 

--- a/src/main/resources/LabelsBundle_pt_PT.properties
+++ b/src/main/resources/LabelsBundle_pt_PT.properties
@@ -26,6 +26,8 @@ prefer.mp4.over.gif = Preferir MP4 a GIF
 restore.window.position = Restaurar posição da janela
 remember.url.history = Lembrar histórico de URL
 loading.history.from = Carregar histórico de
+language = Language
+select.save.directory = Select Save Directory
 
 # Misc UI keys
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Added a missing label)



# Description

The button labeled "Select save Directory" wasn't in any of the resource bundles. I added it to all of them so it can be translated

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
