### PR TITLE
Picstatio ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PicstatioRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PicstatioRipper.java
@@ -1,0 +1,82 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class PicstatioRipper extends AbstractHTMLRipper {
+
+    public PicstatioRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    private String getFullSizedImageFromURL(String fileName) {
+        try {
+            return Http.url("https://www.picstatio.com/wallpaper/" + fileName + "/download").get().select("p.text-center > a").attr("href");
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public String getHost() {
+        return "picstatio";
+    }
+
+    @Override
+    public String getDomain() {
+        return "picstatio.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https?://www.picstatio.com/([a-zA-Z1-9_-]*)/?$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected picstatio URL format: " +
+                "www.picstatio.com//ID - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        if (doc.select("a.next_page") != null) {
+            return Http.url("https://www.picstatio.com" + doc.select("a.next_page").attr("href")).get();
+        }
+        throw new IOException("No more pages");
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        for (Element e : doc.select("img.img")) {
+            String imageName = e.parent().attr("href");
+            LOGGER.info(getFullSizedImageFromURL(imageName.split("/")[2]));
+            result.add(getFullSizedImageFromURL(imageName.split("/")[2]));
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PicstatioRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PicstatioRipper.java
@@ -22,7 +22,8 @@ public class PicstatioRipper extends AbstractHTMLRipper {
 
     private String getFullSizedImageFromURL(String fileName) {
         try {
-            return Http.url("https://www.picstatio.com/wallpaper/" + fileName + "/download").get().select("p.text-center > a").attr("href");
+            LOGGER.info("https://www.picstatio.com/wallpaper/" + fileName + "/download");
+            return Http.url("https://www.picstatio.com/wallpaper/" + fileName + "/download").get().select("p.text-center > span > a").attr("href");
         } catch (IOException e) {
             e.printStackTrace();
             return null;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PicstatioRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PicstatioRipperTest.java
@@ -1,0 +1,19 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.PicstatioRipper;
+
+public class PicstatioRipperTest extends RippersTest {
+
+    public void testRip() throws IOException {
+        PicstatioRipper ripper = new PicstatioRipper(new URL("https://www.picstatio.com/aerial-view-wallpapers"));
+        testRipper(ripper);
+    }
+
+    public void testGID() throws IOException {
+        PicstatioRipper ripper = new PicstatioRipper(new URL("https://www.picstatio.com/aerial-view-wallpapers"));
+        assertEquals("aerial-view-wallpapers", ripper.getGID(new URL("https://www.picstatio.com/aerial-view-wallpapers")));
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #710)



# Description

Added support for picstatio.com


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
