### PR TITLE
Twitter ripper no longer errors out on some videos

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
@@ -194,9 +194,13 @@ public class TwitterRipper extends AlbumRipper {
                     // Loop over all the video options and find the biggest video
                     for (int j = 0; j < medias.length(); j++) {
                         JSONObject variant = (JSONObject) variants.get(i);
-                        if (variant.getInt("bitrate") > largestBitrate) {
-                            largestBitrate = variant.getInt("bitrate");
-                            urlToDownload = variant.getString("url");
+                        LOGGER.info(variant);
+                        // If the video doesn't have a bitrate it's a m3u8 file we can't download
+                        if (variant.has("bitrate")) {
+                            if (variant.getInt("bitrate") > largestBitrate) {
+                                largestBitrate = variant.getInt("bitrate");
+                                urlToDownload = variant.getString("url");
+                            }
                         }
                     }
                     if (urlToDownload != null) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)


# Description

This fixes a bug introduced in 1.7.53 which caused some twitter videos not to download


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
