### PR TITLE
Got InstagramRipper working again 

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
@@ -69,7 +69,7 @@ public abstract class AbstractJSONRipper extends AlbumRipper {
                 }
             }
 
-            if (imageURLs.isEmpty()) {
+            if (imageURLs.isEmpty() && !hasASAPRipping()) {
                 throw new IOException("No images found at " + this.url);
             }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -76,6 +76,10 @@ public class InstagramRipper extends AbstractJSONRipper {
         return url.replaceAll("/[A-Z0-9]{8}/", "/");
     }
 
+    @Override public boolean hasASAPRipping() {
+        return true;
+    }
+
     private List<String> getPostsFromSinglePage(JSONObject json) {
         List<String> imageURLs = new ArrayList<>();
         JSONArray datas;
@@ -231,9 +235,21 @@ public class InstagramRipper extends AbstractJSONRipper {
         return imageURL;
     }
 
+    public String getAfter(JSONObject json) {
+        try {
+            return json.getJSONObject("entry_data").getJSONArray("ProfilePage").getJSONObject(0)
+                    .getJSONObject("graphql").getJSONObject("user")
+                    .getJSONObject("edge_owner_to_timeline_media").getJSONObject("page_info").getString("end_cursor");
+        } catch (JSONException e) {
+            return json.getJSONObject("data").getJSONObject("user")
+                    .getJSONObject("edge_owner_to_timeline_media").getJSONObject("page_info").getString("end_cursor");
+        }
+    }
+
     @Override
     public List<String> getURLsFromJSON(JSONObject json) {
         List<String> imageURLs = new ArrayList<>();
+        nextPageID = getAfter(json);
 
         // get the rhx_gis value so we can get the next page later on
         if (rhx_gis == null) {
@@ -251,7 +267,7 @@ public class InstagramRipper extends AbstractJSONRipper {
                             .getJSONObject("edge_owner_to_timeline_media").getJSONArray("edges");
                 } catch (JSONException e) {
                     datas = json.getJSONObject("data").getJSONObject("user")
-                            .getJSONObject("edge_user_to_photos_of_you").getJSONArray("edges");
+                            .getJSONObject("edge_owner_to_timeline_media").getJSONArray("edges");
                 }
             } else {
                 try {
@@ -301,10 +317,9 @@ public class InstagramRipper extends AbstractJSONRipper {
                         }
                     }
                 } catch (MalformedURLException e) {
+                    LOGGER.info("Got MalformedURLException");
                     return imageURLs;
                 }
-
-                nextPageID = data.getString("id");
 
                 if (isThisATest()) {
                     break;
@@ -369,10 +384,11 @@ public class InstagramRipper extends AbstractJSONRipper {
             try {
                 // Sleep for a while to avoid a ban
                 sleep(2500);
-                String vars = "{\"id\":\"" + userID + "\",\"first\":50,\"after\":\"" + nextPageID + "\"}";
+                String vars = "{\"id\":\"" + userID + "\",\"first\":12,\"after\":\"" + nextPageID + "\"}";
                 String ig_gis = getIGGis(vars);
                 LOGGER.info(ig_gis);
 
+                LOGGER.info("https://www.instagram.com/graphql/query/?query_hash=" + qHash + "&variables=" + vars);
                 toreturn = getPage("https://www.instagram.com/graphql/query/?query_hash=" + qHash + "&variables=" + vars, ig_gis);
                 if (!pageHasImages(toreturn)) {
                     throw new IOException("No more pages");
@@ -394,7 +410,7 @@ public class InstagramRipper extends AbstractJSONRipper {
     private boolean pageHasImages(JSONObject json) {
         LOGGER.info(json);
         int numberOfImages = json.getJSONObject("data").getJSONObject("user")
-                .getJSONObject("edge_user_to_photos_of_you").getJSONArray("edges").length();
+                .getJSONObject("edge_owner_to_timeline_media").getJSONArray("edges").length();
         if (numberOfImages == 0) {
             return false;
         }
@@ -453,23 +469,8 @@ public class InstagramRipper extends AbstractJSONRipper {
             return null;
         }
         if (!rippingTag) {
-            Pattern jsP = Pattern.compile("o},queryId:.([a-zA-Z0-9]+).");
+            Pattern jsP = Pattern.compile("m=\"9ca88e465c3f866a76f7adee3871bdd8\",g=Object\\(c.b\\)\\(\\{pageSize:p.a,pagesToPreload:0,getState:function\\(e,t\\)\\{var o;return null===\\(o=e.profilePosts.byUserId.get\\(t\\)\\)\\|\\|void 0===o\\?void 0:o\\.pagination},queryId:.([a-zA-Z0-9]+)");
             Matcher m = jsP.matcher(sb.toString());
-            if (m.find()) {
-                return m.group(1);
-            }
-            jsP = Pattern.compile("n.pagination:n},queryId:.([a-zA-Z0-9]+).");
-            m = jsP.matcher(sb.toString());
-            if (m.find()) {
-                return m.group(1);
-            }
-            jsP = Pattern.compile("0:n.pagination},queryId:.([a-zA-Z0-9]+).");
-            m = jsP.matcher(sb.toString());
-            if (m.find()) {
-                return m.group(1);
-            }
-            jsP = Pattern.compile("o.pagination},queryId:.([a-zA-Z0-9]+).");
-            m = jsP.matcher(sb.toString());
             if (m.find()) {
                 return m.group(1);
             }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -249,7 +249,9 @@ public class InstagramRipper extends AbstractJSONRipper {
     @Override
     public List<String> getURLsFromJSON(JSONObject json) {
         List<String> imageURLs = new ArrayList<>();
-        nextPageID = getAfter(json);
+        if (!url.toExternalForm().contains("/p/")) {
+            nextPageID = getAfter(json);
+        }
 
         // get the rhx_gis value so we can get the next page later on
         if (rhx_gis == null) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #718)


# Description

I changed AbstractJSONRipper to respect hasASAPRipping and fixed the instagram ripper


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
