### PR TITLE
Added ripper for Wallpapersite.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WallpapersiteRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WallpapersiteRipper.java
@@ -1,0 +1,81 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class WallpapersiteRipper extends AbstractHTMLRipper {
+
+    public WallpapersiteRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    private String getFullSizedImageFromURL(String imageURL) {
+        try {
+            return Http.url("https://wallpapersite.com/" + getGID(url) + "/" + imageURL).get().select("span.res-ttl > a.original").attr("href");
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public String getHost() {
+        return "wallpapersite";
+    }
+
+    @Override
+    public String getDomain() {
+        return "wallpapersite.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https://wallpapersite.com/([a-zA-Z1-9_-]+)/?$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected wallpapersite URL format: " +
+                "www.wallpapersite.com/ID - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        if (doc.select("a.ctrl-right") != null) {
+            return Http.url(url.toExternalForm() + doc.select("a.ctrl-right").attr("href")).get();
+        }
+        throw new IOException("No more pages");
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        for (Element e : doc.select("div#pics-list > p > a")) {
+            String imageURL = e.attr("href");
+            result.add("https://wallpapersite.com/" + getFullSizedImageFromURL(imageURL));
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a new Ripper



# Description

I added a ripper for Wallpapersite.com


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
