### PR TITLE
Now uses update_change_list to update change list inststead of just i…

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -65,15 +65,8 @@ subprocess.call(['git', 'grep', '<version>' + nextVersion + '</version>', 'pom.x
 commitMessage = nextVersion + ': ' + message
 changeLogLine = '        \"' + commitMessage + '\",\n'
 
-dataFile = open("ripme.json", "r")
-ripmeJsonLines = dataFile.readlines()
-ripmeJsonLines.insert(3, changeLogLine)
-outputContent = ''.join(ripmeJsonLines)
-dataFile.close()
+update_change_list(changeLogLine)
 
-dataFile = open("ripme.json", "w")
-dataFile.write(outputContent)
-dataFile.close()
 
 print("Building ripme")
 subprocess.call(["mvn", "clean", "compile", "assembly:single"])


### PR DESCRIPTION
…nserting a string at a hardcoded line number

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #734 )


# Description

Now uses update_change_list to update change list inststead of just inserting a string at a hardcoded line number


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
