### PR TITLE
Added flag for appending a string to folder name

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -41,6 +41,7 @@ import com.rarchives.ripme.utils.Utils;
 public class App {
 
     public static final Logger logger = Logger.getLogger(App.class);
+    public static String stringToAppendToFoldername = null;
     private static final History HISTORY = new History();
 
     /**
@@ -61,6 +62,12 @@ public class App {
             Proxy.setHTTPProxy(Utils.getConfigString("proxy.http", null));
         } else if (Utils.getConfigString("proxy.socks", null) != null) {
             Proxy.setSocks(Utils.getConfigString("proxy.socks", null));
+        }
+
+        // This has to be here instead of handleArgs because handleArgs isn't parsed until after a item is ripper
+        if (cl.hasOption("a")) {
+            logger.info(cl.getOptionValue("a"));
+            stringToAppendToFoldername = cl.getOptionValue("a");
         }
 
         if (GraphicsEnvironment.isHeadless() || args.length > 0) {
@@ -295,6 +302,7 @@ public class App {
         opts.addOption("s", "socks-server", true, "Use socks server ([user:password]@host[:port])");
         opts.addOption("p", "proxy-server", true, "Use HTTP Proxy server ([user:password]@host[:port])");
         opts.addOption("j", "update", false, "Update ripme");
+        opts.addOption("a","append-to-folder", true, "Append a string to the output folder name");
         return opts;
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Observable;
 
+import com.rarchives.ripme.App;
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Logger;
 import org.jsoup.HttpStatusException;
@@ -258,8 +259,12 @@ public abstract class AbstractRipper
                 subdirectory = File.separator + subdirectory;
             }
             prefix = Utils.filesystemSanitized(prefix);
+            String topFolderName = workingDir.getCanonicalPath();
+            if (App.stringToAppendToFoldername != null) {
+                topFolderName = topFolderName + App.stringToAppendToFoldername;
+            }
             saveFileAs = new File(
-                    workingDir.getCanonicalPath()
+                    topFolderName
                     + subdirectory
                     + File.separator
                     + prefix


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a new feature 


# Description

Add the -a flag for appending a string to the rip folder name


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
