### PR TITLE
Fix shebang for release.py and make it executable

### DIFF
--- a/release.py
+++ b/release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Small quality of life fix to make the script more portable (Mac and Linux). Now one can type `./release.py [ARGS...]` instead of specifying `python3`.

# Testing

Required verification:
* [x] I've verified that this change works as intended.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
