### PR TITLE
ModelmayhemRipper can now donwload nsfw images again

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ModelmayhemRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ModelmayhemRipper.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -15,6 +17,8 @@ import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import com.rarchives.ripme.utils.Http;
 
 public class ModelmayhemRipper extends AbstractHTMLRipper {
+
+    private Map<String,String> cookies = new HashMap<>();
 
     public ModelmayhemRipper(URL url) throws IOException {
         super(url);
@@ -43,8 +47,10 @@ public class ModelmayhemRipper extends AbstractHTMLRipper {
 
     @Override
     public Document getFirstPage() throws IOException {
+        // Bypass NSFW filter
+        cookies.put("worksafe", "0");
         // "url" is an instance field of the superclass
-        return Http.url(url).get();
+        return Http.url(url).cookies(cookies).get();
     }
 
     @Override


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #720)



# Description

The ripper now sets the worksafe cookie to 0 when making requests, so the site returns the nsfw version


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
