### PR TITLE
Fixed erome ripper and added quickQueue support

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EromeRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EromeRipperTest.java
@@ -1,0 +1,40 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.EromeRipper;
+
+public class EromeRipperTest extends RippersTest {
+
+    public void testGetGIDProfilePage() throws IOException {
+        URL url = new URL("https://www.erome.com/Jay-Jenna");
+        EromeRipper ripper = new EromeRipper(url);
+        assertEquals("Jay-Jenna", ripper.getGID(url));
+    }
+
+    public void testGetGIDAlbum() throws IOException {
+        URL url = new URL("https://www.erome.com/a/KbDAM1XT");
+        EromeRipper ripper = new EromeRipper(url);
+        assertEquals("KbDAM1XT", ripper.getGID(url));
+    }
+
+    public void testGetAlbumsToQueue() throws IOException {
+        URL url = new URL("https://www.erome.com/Jay-Jenna");
+        EromeRipper ripper = new EromeRipper(url);
+        assert(2 >= ripper.getAlbumsToQueue(ripper.getFirstPage()).size());
+    }
+
+    public void testPageContainsAlbums() throws IOException {
+        URL url = new URL("https://www.erome.com/Jay-Jenna");
+        EromeRipper ripper = new EromeRipper(url);
+        assert(ripper.pageContainsAlbums(url));
+        assert(!ripper.pageContainsAlbums(new URL("https://www.erome.com/a/KbDAM1XT")));
+    }
+
+    public void testRip() throws IOException {
+        URL url = new URL("https://www.erome.com/a/4FqeUxil");
+        EromeRipper ripper = new EromeRipper(url);
+        testRipper(ripper);
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #463)



# Description

I fixed the ripper and added quickQueue support for profile pages


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
