### PR TITLE
Added unit test for Myhentaicomics quickQueue

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MyhentaicomicsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MyhentaicomicsRipperTest.java
@@ -21,4 +21,18 @@ public class MyhentaicomicsRipperTest extends RippersTest {
         // Test a tag
         assertEquals("2409", ripper.getGID(new URL("http://myhentaicomics.com/index.php/tag/2409/")));
     }
+
+    public void testGetAlbumsToQueue() throws IOException {
+        URL url = new URL("https://myhentaicomics.com/index.php/tag/3167/");
+        MyhentaicomicsRipper ripper = new MyhentaicomicsRipper(url);
+        assertEquals(15, ripper.getAlbumsToQueue(ripper.getFirstPage()).size());
+    }
+
+    public void testPageContainsAlbums() throws IOException {
+        URL url = new URL("https://myhentaicomics.com/index.php/tag/3167/");
+        URL url2 = new URL("https://myhentaicomics.com/index.php/search?q=test");
+        MyhentaicomicsRipper ripper = new MyhentaicomicsRipper(url);
+        assertTrue(ripper.pageContainsAlbums(url));
+        assertTrue(ripper.pageContainsAlbums(url2));
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a refactoring



# Description

I added 2 new unit tests for myhentaicomics.com that cover the quickQueue features


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
