### PR TITLE
Got DeviantartRipper working again

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
@@ -190,13 +190,11 @@ public class DeviantartRipper extends AbstractJSONRipper {
         return null;
     }
 
-    private String getGalleryID(Document doc) {
+    public String getGalleryID(Document doc) {
         for (Element el : doc.select("input[name=set]")) {
             try {
                 String galleryID = el.attr("value");
-                if (galleryID.length() == 8) {
-                    return galleryID;
-                }
+                return galleryID;
             } catch (NullPointerException e) {
                 continue;
             }
@@ -205,7 +203,7 @@ public class DeviantartRipper extends AbstractJSONRipper {
         return null;
     }
 
-    private String getUsername(Document doc) {
+    public String getUsername(Document doc) {
         return doc.select("meta[property=og:title]").attr("content").replaceAll("'s DeviantArt gallery", "");
     }
     

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
@@ -64,8 +64,10 @@ public class DeviantartRipper extends AbstractJSONRipper {
     public URL sanitizeURL(URL url) throws MalformedURLException {
         String u = url.toExternalForm();
 
-        if (!u.endsWith("/gallery/")) {
-            if (!u.endsWith("/gallery")) {
+        if (!u.endsWith("/gallery/") && !u.endsWith("/gallery")) {
+            if (!u.endsWith("/")) {
+                u += "/gallery/";
+            } else {
                 u += "gallery/";
             }
         }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DeviantartRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DeviantartRipperTest.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.DeviantartRipper;
+import com.rarchives.ripme.utils.Http;
+import org.jsoup.nodes.Document;
 
 public class DeviantartRipperTest extends RippersTest {
     public void testDeviantartAlbum() throws IOException {
@@ -21,5 +23,13 @@ public class DeviantartRipperTest extends RippersTest {
         URL url = new URL("https://www.deviantart.com/airgee/gallery/");
         DeviantartRipper ripper = new DeviantartRipper(url);
         assertEquals("airgee", ripper.getGID(url));
+    }
+
+    public void testGetGalleryIDAndUsername() throws IOException {
+        URL url = new URL("https://www.deviantart.com/airgee/gallery/");
+        DeviantartRipper ripper = new DeviantartRipper(url);
+        Document doc = Http.url(url).get();
+        assertEquals("airgee", ripper.getUsername(doc));
+        assertEquals("714589", ripper.getGalleryID(doc));
     }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DeviantartRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DeviantartRipperTest.java
@@ -2,6 +2,8 @@ package com.rarchives.ripme.tst.ripper.rippers;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.rarchives.ripme.ripper.rippers.DeviantartRipper;
 import com.rarchives.ripme.utils.Http;
@@ -31,5 +33,17 @@ public class DeviantartRipperTest extends RippersTest {
         Document doc = Http.url(url).get();
         assertEquals("airgee", ripper.getUsername(doc));
         assertEquals("714589", ripper.getGalleryID(doc));
+    }
+
+    public void testSanitizeURL() throws IOException {
+        List<URL> urls = new ArrayList<URL>();
+        urls.add(new URL("https://www.deviantart.com/airgee/"));
+        urls.add(new URL("https://www.deviantart.com/airgee"));
+        urls.add(new URL("https://www.deviantart.com/airgee/gallery/"));
+
+        for (URL url : urls) {
+            DeviantartRipper ripper = new DeviantartRipper(url);
+            assertEquals("https://www.deviantart.com/airgee/gallery/", ripper.sanitizeURL(url).toExternalForm());
+        }
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #758)



# Description

Changed how the ripper gets the galleryID and the username


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
