### PR TITLE
Imagefap ripper now downloads full sized images

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImagefapRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImagefapRipper.java
@@ -125,11 +125,7 @@ public class ImagefapRipper extends AbstractHTMLRipper {
             if (!thumb.hasAttr("src") || !thumb.hasAttr("width")) {
                 continue;
             }
-            String image = thumb.attr("src");
-            image = image.replaceAll(
-                    "http://x.*.fap.to/images/thumb/",
-                    "http://fap.to/images/full/");
-            image = image.replaceAll("w[0-9]+-h[0-9]+/", "");
+            String image = getFullSizedImage("https://www.imagefap.com" + thumb.parent().attr("href"));
             imageURLs.add(image);
             if (isThisATest()) {
                 break;
@@ -158,6 +154,15 @@ public class ImagefapRipper extends AbstractHTMLRipper {
             // Fall back to default album naming convention
         }
         return super.getAlbumTitle(url);
+    }
+
+    private String getFullSizedImage(String pageURL) {
+        try {
+            Document doc = Http.url(pageURL).get();
+            return doc.select("img#mainPhoto").attr("src");
+        } catch (IOException e) {
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #755)



# Description

The ripper now downloaded fullsized images


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
