### PR TITLE
Xvideo ripper now uses AbstractHTMLRipper 

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VideoRippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VideoRippersTest.java
@@ -7,9 +7,8 @@ import java.util.List;
 
 import com.rarchives.ripme.ripper.VideoRipper;
 import com.rarchives.ripme.ripper.rippers.video.PornhubRipper;
-import com.rarchives.ripme.ripper.rippers.video.TwitchVideoRipper;
 import com.rarchives.ripme.ripper.rippers.video.XhamsterRipper;
-import com.rarchives.ripme.ripper.rippers.video.XvideosRipper;
+import com.rarchives.ripme.ripper.rippers.XvideosRipper;
 import com.rarchives.ripme.ripper.rippers.video.YoupornRipper;
 import com.rarchives.ripme.ripper.rippers.video.YuvutuRipper;
 
@@ -57,17 +56,7 @@ public class VideoRippersTest extends RippersTest {
             videoTestHelper(ripper);
         }
     }
-
-    public void testXvideosRipper() throws IOException {
-        List<URL> contentURLs = new ArrayList<>();
-        contentURLs.add(new URL("https://www.xvideos.com/video19719109/ziggy_star_ultra_hard_anal_pounding"));
-        contentURLs.add(new URL("https://www.xvideos.com/video23515878/dee_s_pool_toys"));
-        for (URL url : contentURLs) {
-            XvideosRipper ripper = new XvideosRipper(url);
-            videoTestHelper(ripper);
-        }
-    }
-
+    
     public void testPornhubRipper() throws IOException {
         List<URL> contentURLs = new ArrayList<>();
         contentURLs.add(new URL("https://www.pornhub.com/view_video.php?viewkey=ph5a329fa707269"));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XvideosRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XvideosRipperTest.java
@@ -1,0 +1,16 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.XvideosRipper;
+import com.rarchives.ripme.tst.ripper.rippers.RippersTest;
+
+public class XvideosRipperTest extends RippersTest {
+
+    public void testXhamsterAlbum1() throws IOException {
+        XvideosRipper ripper = new XvideosRipper(new URL("https://www.xvideos.com/video23515878/dee_s_pool_toys"));
+        testRipper(ripper);
+    }
+
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [X] a refactoring



# Description


Xvideo ripper now uses AbstractHTMLRipper 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
