### PR TITLE
Fix Twitter. Get images from Extended Tweets

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
@@ -126,14 +126,16 @@ public class TwitterRipper extends AlbumRipper {
                         .append("&exclude_replies=true")
                         .append("&trim_user=true")
                         .append("&include_rts=true")
-                        .append("&count=" + 200);
+                        .append("&count=" + 200)
+                        .append("&tweet_mode=extended");
                 break;
             case SEARCH:
                 req.append("https://api.twitter.com/1.1/search/tweets.json")
                         .append("?q=" + this.searchText)
                         .append("&include_entities=true")
                         .append("&result_type=recent")
-                        .append("&count=100");
+                        .append("&count=100")
+                        .append("&tweet_mode=extended");
                 break;
         }
         if (maxID > 0) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Tweets larger than 140 characters are Extended Tweets. When those Tweets are served by the standard REST API in the default compatibility mode the media is left out. Using `tweet_mode=extended` gets all of the media.

Example: https://twitter.com/BlackChono (NSFW). 1.7.56 downloads only 113 images, and this PR 174.

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
