### PR TITLE
Added nl_NL translation

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -496,7 +496,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         configURLHistoryCheckbox = addNewCheckbox(rb.getString("remember.url.history"), "remember.url_history", true);
 
         configLogLevelCombobox = new JComboBox<>(new String[] {"Log level: Error", "Log level: Warn", "Log level: Info", "Log level: Debug"});
-        configSelectLangComboBox = new JComboBox<>(new String[] {"en_US", "de_DE", "es_ES", "fr_CH", "kr_KR", "pt_PT", "fi_FI", "in_ID", "porrisavvo_FI"});
+        configSelectLangComboBox = new JComboBox<>(new String[] {"en_US", "de_DE", "es_ES", "fr_CH", "kr_KR", "pt_PT", "fi_FI", "in_ID", "nl_NL", "porrisavvo_FI"});
         configLogLevelCombobox.setSelectedItem(Utils.getConfigString("log.level", "Log level: Debug"));
         setLogLevel(configLogLevelCombobox.getSelectedItem().toString());
         configSaveDirLabel = new JLabel();

--- a/src/main/resources/LabelsBundle_nl_NL.properties
+++ b/src/main/resources/LabelsBundle_nl_NL.properties
@@ -1,0 +1,37 @@
+Log = Logboek
+History = Geschiedenis
+created = gemaakt
+modified = aangepast
+Queue = Wachtrij
+Configuration = Configuratie
+
+# Keys for the Configuration menu
+
+current.version = Huidige versie
+check.for.updates = Controleer op updates
+auto.update = Auto-update?
+max.download.threads = Maximale downloadthreads
+timeout.mill = Timeout (in milliseconden):
+retry.download.count = Aantal keren opnieuw proberen te downloaden
+overwrite.existing.files = Bestaande bestanden overschrijven?
+sound.when.rip.completes = Geluid wanneer rip klaar is
+preserve.order = Volgorde behouden
+save.logs = Logbestanden opslaan
+notification.when.rip.starts = Notificatie wanneer rip start
+save.urls.only = Alleen URLs opslaan
+save.album.titles = Album titels opslaan
+autorip.from.clipboard = Rip automatisch van klembord
+save.descriptions = Beschrijvingen opslaan
+prefer.mp4.over.gif = Geef de voorkeur aan MP4 over GIF
+restore.window.position = Vensterpositie herstellen
+remember.url.history = URL geschiedenis onthouden
+loading.history.from = Geschiedenis laden van
+
+# Misc UI keys
+
+loading.history.from.configuration = Geschiedenis laden van configuratie
+interrupted.while.waiting.to.rip.next.album = Onderbroken tijdens het wachten om volgend album te rippen
+inactive = Inactief
+re-rip.checked = Re-rip Gecheckt
+remove = Verwijderen
+clear = Opruimen


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [x] a new translation


# Description

Added the Dutch translations by @nfrelink


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
