### PR TITLE
Manganelo ripper fixes

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ManganeloRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ManganeloRipper.java
@@ -99,7 +99,7 @@ public class ManganeloRipper extends AbstractHTMLRipper {
             Collections.reverse(urlsToGrab);
 
             for (String url : urlsToGrab) {
-                result.addAll(getURLsFromChap(url));
+                result.addAll(getURLsFromChap("https:" + url));
             }
         } else if (url.toExternalForm().contains("/chapter/")) {
             result.addAll(getURLsFromChap(doc));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ManganeloRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ManganeloRipperTest.java
@@ -7,7 +7,13 @@ import com.rarchives.ripme.ripper.rippers.ManganeloRipper;
 
 public class ManganeloRipperTest extends RippersTest {
     public void testRip() throws IOException {
-        ManganeloRipper ripper = new ManganeloRipper(new URL("http://manganelo.com/manga/black_clover"));
+        ManganeloRipper ripper = new ManganeloRipper(new URL("https://manganelo.com/manga/demonic_housekeeper"));
         testRipper(ripper);
+    }
+
+    public void testGetGID() throws IOException {
+        URL url = new URL("https://manganelo.com/manga/demonic_housekeeper");
+        ManganeloRipper ripper = new ManganeloRipper(url);
+        assertEquals("demonic_housekeeper", ripper.getGID(url));
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #785)



# Description

Fixed the ripper, added another unit test


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
