### PR TITLE
Fixed update box formating

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -128,9 +128,9 @@ public class UpdateUtils {
             logger.info("Found newer version: " + latestVersion);
             int result = JOptionPane.showConfirmDialog(
                     null,
-                    "<html><font color=\"green\">New version (" + latestVersion + ") is available!</font>"
-                    + "<br><br>Recent changes:" + changeList
-                    + "<br><br>Do you want to download and run the newest version?</html>",
+                    String.format("<html><font color=\"green\">New version (%s) is available!</font>"
+                            + "<br><br>Recent changes: %s"
+                            + "<br><br>Do you want to download and run the newest version?</html>", latestVersion, changeList.replaceAll("\n", "")),
                     "RipMe Updater",
                     JOptionPane.YES_NO_OPTION);
             if (result != JOptionPane.YES_OPTION) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #737)



# Description

the update Confirm Dialog now uses string.format instead of just +ing a bunch of strings and change list now has all new lines removed


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
