### PR TITLE
Fixed minor bug with DeviantartRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
@@ -260,13 +260,13 @@ public class DeviantartRipper extends AbstractJSONRipper {
             if (doc.html().contains("ismature")) {
                 LOGGER.info("Downloading nsfw image");
                 String nsfwImage = getFullsizedNSFWImage(doc.select("span").attr("href"));
-                if (nsfwImage != null) {
+                if (nsfwImage != null && nsfwImage.startsWith("http")) {
                     imageURLs.add(nsfwImage);
                 }
             }
             try {
                 String imageURL = doc.select("span").first().attr("data-super-full-img");
-                if (!imageURL.isEmpty()) {
+                if (!imageURL.isEmpty() && imageURL.startsWith("http")) {
                     imageURLs.add(imageURL);
                 }
             } catch (NullPointerException e) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #790 )



# Description

Now checks that a link starts with http before trying to download it


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
