### PR TITLE
Added support for Desuarchive.org

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -97,6 +97,9 @@ public class ChanRipper extends AbstractHTMLRipper {
         if (url.toExternalForm().contains("xchan.pw") && url.toExternalForm().contains("/board/")) {
             return true;
         }
+        if (url.toExternalForm().contains("desuarchive.org")) {
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #799)



# Description

Added Desuarchive.org to chanrippers canRip


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
