### PR TITLE
Fix #789: Implemented wraparound for log window and status label

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,6 @@
       <version>1.3.2</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.7</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.3.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
       <version>1.3.2</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.7</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.3.3</version>

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -299,7 +299,7 @@ public abstract class AbstractRipper
      *      Prefix to prepend to the saved filename.
      * @param subdirectory
      *      Sub-directory of the working directory to save the images to.
-     * @return True on success, flase on failure.
+     * @return True on success, false on failure.
      */
     protected boolean addURLToDownload(URL url, String prefix, String subdirectory) {
         return addURLToDownload(url, prefix, subdirectory, null, null, null);
@@ -316,7 +316,7 @@ public abstract class AbstractRipper
      *      URL to download
      * @param prefix
      *      Text to append to saved filename.
-     * @return True on success, flase on failure.
+     * @return True on success, false on failure.
      */
     protected boolean addURLToDownload(URL url, String prefix) {
         // Use empty subdirectory

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -51,7 +51,6 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Level;
@@ -153,8 +152,12 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     }
 
     private static int getAverageFontWidth(JComponent component) {
+        int sum = 0;
         int[] widths = component.getFontMetrics(component.getFont()).getWidths();
-        return Collections.max(Arrays.asList(ArrayUtils.toObject(widths)));
+        for(int i : widths) {
+            sum += i;
+        }
+        return sum / widths.length;
     }
 
     private static void insertWrappedString(JComponent parent, StyledDocument document, String string, SimpleAttributeSet s) 
@@ -165,7 +168,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         while(i < string.length()/maxCharsToFit) {
             if(i > 0) resultString.append(string.substring(i*maxCharsToFit-2, i*maxCharsToFit));
             resultString.append(string.substring(i*maxCharsToFit, (i+1)*maxCharsToFit-2));
-            resultString.append("\\\n");
+            resultString.append("\n");
             i++;
         }
         resultString.append(string.substring(string.length()-(string.length()%maxCharsToFit)));
@@ -383,7 +386,6 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         logPanel.setBorder(emptyBorder);
         logText = new JTextPane();
         logText.setEditable(false);
-        logText.setFont(new Font(Font.MONOSPACED, Font.PLAIN, 12));
         JScrollPane logTextScroll = new JScrollPane(logText);
         logTextScroll.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_ALWAYS);
         logPanel.setVisible(false);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Extraordinarily long URLs can cause the log window to expand with them. Implemented wraparound to combat this. Also truncated the status label since it was affected as well.

For the log window, I did change the font to a mono-spaced font because the sans-serif font on my system caused the wraparound to behave strangely.

I did also, while scanning some of the code at first, change "flase" to "false" in a few comments.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
