### PR TITLE
Fixed ManganeloRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ManganeloRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ManganeloRipper.java
@@ -99,7 +99,7 @@ public class ManganeloRipper extends AbstractHTMLRipper {
             Collections.reverse(urlsToGrab);
 
             for (String url : urlsToGrab) {
-                result.addAll(getURLsFromChap("https:" + url));
+                result.addAll(getURLsFromChap(url));
             }
         } else if (url.toExternalForm().contains("/chapter/")) {
             result.addAll(getURLsFromChap(doc));


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

No longer adds extra "https:" to links


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
