### PR TITLE
loveroms ripper now properly names files

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/LoveromRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/LoveromRipper.java
@@ -70,9 +70,9 @@ public class LoveromRipper extends AbstractHTMLRipper {
     @Override
     public void downloadURL(URL url, int index) {
         if (multipart) {
-            addURLToDownload(url, "", "", "", null, null, getPrefix(index));
+            addURLToDownload(url, "", "", "", null, null, "7z." + getPrefix(index));
         } else {
-            addURLToDownload(url);
+            addURLToDownload(url, "", "", "", null, null, "7z");
         }
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)



# Description

The ripper now adds the "7z" extension to files


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
