### PR TITLE
getFilesFromURL now handles imgur gifvs

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/RipUtils.java
+++ b/src/main/java/com/rarchives/ripme/utils/RipUtils.java
@@ -57,7 +57,7 @@ public class RipUtils {
         }  else if (url.getHost().endsWith("i.imgur.com") && url.toExternalForm().contains("gifv")) {
             // links to imgur gifvs
             try {
-                result.add(new URL(Http.url(url).get().select("meta[itemprop=contentURL]").attr("content")));
+                result.add(new URL(url.toExternalForm().replaceAll(".gifv", ".mp4")));
             } catch (IOException e) {
                 logger.info("Couldn't get gifv from " + url);
             }

--- a/src/main/java/com/rarchives/ripme/utils/RipUtils.java
+++ b/src/main/java/com/rarchives/ripme/utils/RipUtils.java
@@ -54,6 +54,15 @@ public class RipUtils {
             } catch (IOException e) {
                 logger.error("[!] Exception while loading album " + url, e);
             }
+        }  else if (url.getHost().endsWith("i.imgur.com") && url.toExternalForm().contains("gifv")) {
+            // links to imgur gifvs
+            try {
+                result.add(new URL(Http.url(url).get().select("meta[itemprop=contentURL]").attr("content")));
+            } catch (IOException e) {
+                logger.info("Couldn't get gifv from " + url);
+            }
+            return result;
+
         }
         else if (url.getHost().endsWith("gfycat.com")) {
             try {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)



# Description

getFilesFromURL can now get imgur mp4s


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
