### PR TITLE
ArtStationRipper: fix ripping from user profiles which many projects

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ArtStationRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ArtStationRipperTest.java
@@ -23,6 +23,7 @@ public class ArtStationRipperTest extends RippersTest {
     public void testArtStationUserProfiles() throws IOException {
         List<URL> contentURLs = new ArrayList<>();
         contentURLs.add(new URL("https://www.artstation.com/heitoramatsu"));
+        contentURLs.add(new URL("https://artstation.com/kuvshinov_ilya"));
         contentURLs.add(new URL("http://artstation.com/givemeapiggy"));
         for (URL url : contentURLs) {
             ArtStationRipper ripper = new ArtStationRipper(url);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #776 )


# Description
This PR fixes issue #776 by properly handling user profiles with more than 50 published projects. It also fixes an off-by-one bug which I still not sure how I didn't catch in the initial implementation (basically it would skip the first project of every user profile)


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
