### PR TITLE
Fixed xhamster getNextPage

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -69,11 +69,13 @@ public class XhamsterRipper extends AbstractHTMLRipper {
 
     @Override
     public Document getNextPage(Document doc) throws IOException {
-        if (!doc.select("a.next").first().attr("href").equals("")) {
-            return Http.url(doc.select("a.next").first().attr("href")).get();
-        } else {
-            throw new IOException("No more pages");
+        if (doc.select("a.next").first() != null) {
+            if (doc.select("a.next").first().attr("href").startsWith("http")) {
+                return Http.url(doc.select("a.next").first().attr("href")).get();
+            }
         }
+        throw new IOException("No more pages");
+
     }
 
     @Override


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #765)



# Description

Fixed getNextPage


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
