### PR TITLE
Fixed EightmusesRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -11,6 +11,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.rarchives.ripme.utils.Utils;
+import org.json.JSONObject;
 import org.jsoup.Connection.Response;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -116,25 +117,24 @@ public class EightmusesRipper extends AbstractHTMLRipper {
                     image = thumb.attr("data-cfsrc");
                 }
                 else {
-                    String imageHref = thumb.attr("href");
-                    if (imageHref.equals("")) continue;
-                    if (imageHref.startsWith("/")) {
-                        imageHref = "https://www.8muses.com" + imageHref;
-                    }
+                    // Deobfustace the json data
+                    String rawJson = deobfuscateJSON(page.select("script#ractive-public").html()
+                            .replaceAll("&gt;", ">").replaceAll("&lt;", "<").replace("&amp;", "&"));
+                    JSONObject json = new JSONObject(rawJson);
                     try {
-                        LOGGER.info("Retrieving full-size image location from " + imageHref);
-                        image = getFullSizeImage(imageHref);
-                        URL imageUrl = new URL(image);
-                        if (Utils.getConfigBoolean("8muses.use_short_names", false)) {
-                            addURLToDownload(imageUrl, getPrefixShort(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies, "", null, true);
-                        } else {
-                            addURLToDownload(imageUrl, getPrefixLong(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies, "", null, true);
+                        for (int i = 0; i != json.getJSONArray("pictures").length(); i++) {
+                            image = "https://www.8muses.com/image/fm/" + json.getJSONArray("pictures").getJSONObject(i).getString("publicUri");
+                            URL imageUrl = new URL(image);
+                            if (Utils.getConfigBoolean("8muses.use_short_names", false)) {
+                                addURLToDownload(imageUrl, getPrefixShort(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies, "", null, true);
+                            } else {
+                                addURLToDownload(imageUrl, getPrefixLong(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies, "", null, true);
+                            }
+                            // X is our page index
+                            x++;
                         }
-                        // X is our page index
-                        x++;
 
                     } catch (IOException e) {
-                        LOGGER.error("Failed to get full-size image from " + imageHref);
                         continue;
                     }
                 }
@@ -154,7 +154,7 @@ public class EightmusesRipper extends AbstractHTMLRipper {
         sendUpdate(STATUS.LOADING_RESOURCE, imageUrl);
         LOGGER.info("Getting full sized image from " + imageUrl);
         Document doc = new Http(imageUrl).get(); // Retrieve the webpage  of the image URL
-        String imageName = doc.select("input[id=imageName]").attr("value"); // Select the "input" element from the page
+        String imageName = doc.select("div.photo > a > img").attr("src");
         return "https://www.8muses.com/image/fm/" + imageName;
     }
 
@@ -188,5 +188,29 @@ public class EightmusesRipper extends AbstractHTMLRipper {
 
     public String getPrefixShort(int index) {
         return String.format("%03d", index);
+    }
+
+    private String deobfuscateJSON(String obfuscatedString) {
+        LOGGER.info("obfuscatedString: " + obfuscatedString);
+        StringBuilder deobfuscatedString = new StringBuilder();
+        // The first char in one of 8muses obfuscated strings is always ! so we replace it
+        for (char ch : obfuscatedString.replaceFirst("!", "").toCharArray()){
+            LOGGER.info(ch + ":" + deobfuscateChar(ch));
+            LOGGER.info((int) ch + ":" + (int) deobfuscateChar(ch).charAt(0));
+            deobfuscatedString.append(deobfuscateChar(ch));
+        }
+        return deobfuscatedString.toString();
+    }
+
+    private String deobfuscateChar(char c) {
+        if ((int) c == 32) {
+            return fromCharCode(32);
+        }
+        return fromCharCode(33 + (c + 14) % 94);
+
+    }
+
+    private static String fromCharCode(int... codePoints) {
+        return new String(codePoints, 0, codePoints.length);
     }
 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -191,12 +191,9 @@ public class EightmusesRipper extends AbstractHTMLRipper {
     }
 
     private String deobfuscateJSON(String obfuscatedString) {
-        LOGGER.info("obfuscatedString: " + obfuscatedString);
         StringBuilder deobfuscatedString = new StringBuilder();
         // The first char in one of 8muses obfuscated strings is always ! so we replace it
         for (char ch : obfuscatedString.replaceFirst("!", "").toCharArray()){
-            LOGGER.info(ch + ":" + deobfuscateChar(ch));
-            LOGGER.info((int) ch + ":" + (int) deobfuscateChar(ch).charAt(0));
             deobfuscatedString.append(deobfuscateChar(ch));
         }
         return deobfuscatedString.toString();


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #827)



# Description

Ripper now uses the obfuscated json data to get all image urls for each album.  


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
