### PR TITLE
Changed how magic number look ups are done (now uses a hash map); add…

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Constructor;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
@@ -45,6 +46,7 @@ public class Utils {
 
     private static PropertiesConfiguration config;
     private static HashMap<String, HashMap<String, String>> cookieCache;
+    private static HashMap<ByteBuffer, String> magicHash = new HashMap<>();
 
     static {
         cookieCache = new HashMap<>();
@@ -732,13 +734,21 @@ public class Utils {
                 Utils.bytesToHumanReadable(bytesTotal);
     }
 
-    public static String getEXTFromMagic(byte[] magic) {
-        if (Arrays.equals(magic, new byte[]{-1, -40, -1, -37, 0, 0, 0, 0})) {
-            return "jpeg";
-        } else {
-            LOGGER.info("Unknown magic number " + Arrays.toString(magic));
+    public static String getEXTFromMagic(ByteBuffer magic) {
+        if (magicHash.isEmpty()) {
+            LOGGER.debug("initialising map");
+            initialiseMagicHashMap();
         }
-        return null;
+        return magicHash.get(magic);
+    }
+
+    public static String getEXTFromMagic(byte[] magic) {
+        return getEXTFromMagic(ByteBuffer.wrap(magic));
+    }
+
+    private static void initialiseMagicHashMap() {
+        magicHash.put(ByteBuffer.wrap(new byte[]{-1, -40, -1, -37, 0, 0, 0, 0}), "jpeg");
+        magicHash.put(ByteBuffer.wrap(new byte[]{-119, 80, 78, 71, 13, 0, 0, 0}), "png");
     }
 
     // Checks if a file exists ignoring it's extension.

--- a/src/test/java/com/rarchives/ripme/tst/UtilsTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/UtilsTest.java
@@ -3,10 +3,13 @@ package com.rarchives.ripme.tst;
 import junit.framework.TestCase;
 import com.rarchives.ripme.utils.Utils;
 
+import java.nio.ByteBuffer;
+
 public class UtilsTest extends TestCase {
 
     public void testGetEXTFromMagic() {
         assertEquals("jpeg", Utils.getEXTFromMagic(new byte[]{-1, -40, -1, -37, 0, 0, 0, 0}));
+        assertEquals("png", Utils.getEXTFromMagic(new byte[]{-119, 80, 78, 71, 13, 0, 0, 0}));
     }
 
     public void testStripURLParameter() {


### PR DESCRIPTION
…ed magic number for png; added unit test

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [x] a refactoring



# Description

Magic numbers are now stored in a hashMap<ByteBuffer, String>. A byte buffer is used instead of a byte[] because byte[]s don't work as map keys on their own ([see here for more infomation](https://stackoverflow.com/questions/1058149/using-a-byte-array-as-map-key#1058169))

The hashmap is initialised when getEXTFromMagic is first called

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
