### PR TITLE
Added an Abstraction for rippers that only ever download a single fil…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractSingleFileRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractSingleFileRipper.java
@@ -1,0 +1,43 @@
+package com.rarchives.ripme.ripper;
+
+import com.rarchives.ripme.utils.Utils;
+
+import java.io.IOException;
+import java.net.URL;
+
+
+/**
+ * This is just an extension of AbstractHTMLRipper that auto overrides a few things
+ * to help cut down on copy pasted code
+ */
+public abstract class AbstractSingleFileRipper extends AbstractHTMLRipper {
+    private int bytesTotal = 1;
+    private int bytesCompleted = 1;
+
+    protected AbstractSingleFileRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getStatusText() {
+        return Utils.getByteStatusText(getCompletionPercentage(), bytesCompleted, bytesTotal);
+    }
+
+    @Override
+    public int getCompletionPercentage() {
+        return (int) (100 * (bytesCompleted / (float) bytesTotal));
+    }
+
+    @Override
+    public void setBytesTotal(int bytes) {
+        this.bytesTotal = bytes;
+    }
+
+    @Override
+    public void setBytesCompleted(int bytes) {
+        this.bytesCompleted = bytes;
+    }
+
+    @Override
+    public boolean useByteProgessBar() {return true;}
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
@@ -9,18 +9,14 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.rarchives.ripme.ripper.AbstractHTMLRipper;
-import com.rarchives.ripme.utils.Utils;
+import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 
 import com.rarchives.ripme.utils.Http;
 
 
-public class GfycatRipper extends AbstractHTMLRipper {
-
-    private int bytesTotal = 1;
-    private int bytesCompleted = 1;
+public class GfycatRipper extends AbstractSingleFileRipper {
 
     private static final String HOST = "gfycat.com";
 
@@ -109,27 +105,4 @@ public class GfycatRipper extends AbstractHTMLRipper {
         }
         return vidUrl;
     }
-
-    @Override
-    public String getStatusText() {
-        return Utils.getByteStatusText(getCompletionPercentage(), bytesCompleted, bytesTotal);
-    }
-
-    @Override
-    public int getCompletionPercentage() {
-        return (int) (100 * (bytesCompleted / (float) bytesTotal));
-    }
-
-    @Override
-    public void setBytesTotal(int bytes) {
-        this.bytesTotal = bytes;
-    }
-
-    @Override
-    public void setBytesCompleted(int bytes) {
-        this.bytesCompleted = bytes;
-    }
-
-    @Override
-    public boolean useByteProgessBar() {return true;}
 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatporntubeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatporntubeRipper.java
@@ -8,17 +8,12 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.rarchives.ripme.utils.Utils;
+import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 
-import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import com.rarchives.ripme.utils.Http;
 
-public class GfycatporntubeRipper extends AbstractHTMLRipper {
-
-    private int bytesTotal = 1;
-    private int bytesCompleted = 1;
+public class GfycatporntubeRipper extends AbstractSingleFileRipper {
 
     public GfycatporntubeRipper(URL url) throws IOException {
         super(url);
@@ -62,27 +57,4 @@ public class GfycatporntubeRipper extends AbstractHTMLRipper {
     public void downloadURL(URL url, int index) {
         addURLToDownload(url, getPrefix(index));
     }
-
-    @Override
-    public String getStatusText() {
-        return Utils.getByteStatusText(getCompletionPercentage(), bytesCompleted, bytesTotal);
-    }
-
-    @Override
-    public int getCompletionPercentage() {
-        return (int) (100 * (bytesCompleted / (float) bytesTotal));
-    }
-
-    @Override
-    public void setBytesTotal(int bytes) {
-        this.bytesTotal = bytes;
-    }
-
-    @Override
-    public void setBytesCompleted(int bytes) {
-        this.bytesCompleted = bytes;
-    }
-
-    @Override
-    public boolean useByteProgessBar() {return true;}
 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XvideosRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XvideosRipper.java
@@ -8,20 +8,17 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.rarchives.ripme.ripper.AbstractHTMLRipper;
-import com.rarchives.ripme.utils.Utils;
+
+import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
 import com.rarchives.ripme.utils.Http;
 
-public class XvideosRipper extends AbstractHTMLRipper {
+public class XvideosRipper extends AbstractSingleFileRipper {
 
     private static final String HOST = "xvideos";
-
-    private int bytesTotal = 1;
-    private int bytesCompleted = 1;
 
     public XvideosRipper(URL url) throws IOException {
         super(url);
@@ -86,27 +83,4 @@ public class XvideosRipper extends AbstractHTMLRipper {
     public void downloadURL(URL url, int index) {
         addURLToDownload(url, getPrefix(index));
     }
-
-    @Override
-    public String getStatusText() {
-        return Utils.getByteStatusText(getCompletionPercentage(), bytesCompleted, bytesTotal);
-    }
-
-    @Override
-    public int getCompletionPercentage() {
-        return (int) (100 * (bytesCompleted / (float) bytesTotal));
-    }
-
-    @Override
-    public void setBytesTotal(int bytes) {
-        this.bytesTotal = bytes;
-    }
-
-    @Override
-    public void setBytesCompleted(int bytes) {
-        this.bytesCompleted = bytes;
-    }
-
-    @Override
-    public boolean useByteProgessBar() {return true;}
 }


### PR DESCRIPTION
…e and want to use the bytes progress bar

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix


# Description

Added AbstractSingleFileRipper.java which extents AbstractHTMLRipper but overrides the funcs required to have a byte progress bar


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
