### PR TITLE
Added possibility to save reddit posts with multiple images in separat…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -255,6 +255,7 @@ public abstract class AbstractRipper
         File saveFileAs;
         try {
             if (!subdirectory.equals("")) {
+                subdirectory = Utils.filesystemSafe(subdirectory);
                 subdirectory = File.separator + subdirectory;
             }
             prefix = Utils.filesystemSanitized(prefix);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -158,16 +158,16 @@ public class RedditRipper extends AlbumRipper {
         JSONObject data = child.getJSONObject("data");
         if (kind.equals("t1")) {
             // Comment
-            handleBody(data.getString("body"), data.getString("id"));
+            handleBody(data.getString("body"), data.getString("id"), "");
         }
         else if (kind.equals("t3")) {
             // post
             if (data.getBoolean("is_self")) {
                 // TODO Parse self text
-                handleBody(data.getString("selftext"), data.getString("id"));
+                handleBody(data.getString("selftext"), data.getString("id"), data.getString("title"));
             } else {
                 // Get link
-                handleURL(data.getString("url"), data.getString("id"));
+                handleURL(data.getString("url"), data.getString("id"), data.getString("title"));
             }
             if (data.has("replies") && data.get("replies") instanceof JSONObject) {
                 JSONArray replies = data.getJSONObject("replies")
@@ -180,7 +180,7 @@ public class RedditRipper extends AlbumRipper {
         }
     }
 
-    private void handleBody(String body, String id) {
+    private void handleBody(String body, String id, String title) {
         Pattern p = RipUtils.getURLRegex();
         Matcher m = p.matcher(body);
         while (m.find()) {
@@ -188,7 +188,7 @@ public class RedditRipper extends AlbumRipper {
             while (url.endsWith(")")) {
                 url = url.substring(0, url.length() - 1);
             }
-            handleURL(url, id);
+            handleURL(url, id, title);
         }
     }
 
@@ -218,12 +218,20 @@ public class RedditRipper extends AlbumRipper {
 
     }
 
-    private void handleURL(String theUrl, String id) {
+    private void handleURL(String theUrl, String id, String title) {
         URL originalURL;
         try {
             originalURL = new URL(theUrl);
         } catch (MalformedURLException e) {
             return;
+        }
+
+        String subdirectory = "";
+        if (Utils.getConfigBoolean("album_titles.save", true)) {
+            subdirectory = title;
+            title = "-" + title + "-";
+        } else {
+            title = "";
         }
 
         List<URL> urls = RipUtils.getFilesFromURL(originalURL);
@@ -234,24 +242,24 @@ public class RedditRipper extends AlbumRipper {
             if (m.matches()) {
                 // It's from reddituploads. Assume .jpg extension.
                 String savePath = this.workingDir + File.separator;
-                savePath += id + "-" + m.group(1) + ".jpg";
+                savePath += id + "-" + m.group(1) + title + ".jpg";
                 addURLToDownload(urls.get(0), new File(savePath));
             }
             if (url.contains("v.redd.it")) {
                 String savePath = this.workingDir + File.separator;
-                savePath += id + "-" + url.split("/")[3] + ".mp4";
+                savePath += id + "-" + url.split("/")[3] + title + ".mp4";
                 addURLToDownload(parseRedditVideoMPD(urls.get(0).toExternalForm()), new File(savePath));
             }
             else {
-                addURLToDownload(urls.get(0), id + "-", "", theUrl, null);
+                addURLToDownload(urls.get(0), id + title, "", theUrl, null);
             }
         } else if (urls.size() > 1) {
             for (int i = 0; i < urls.size(); i++) {
-                String prefix = id + "-";
+                String prefix = id + "";
                 if (Utils.getConfigBoolean("download.save_order", true)) {
                     prefix += String.format("%03d-", i + 1);
                 }
-                addURLToDownload(urls.get(i), prefix, "", theUrl, null);
+                addURLToDownload(urls.get(i), prefix, subdirectory, theUrl, null);
             }
         }
     }


### PR DESCRIPTION
…e subdirectory with title name.

Added title to the saved filename when only one image/video.

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix


# Description

When you run a ripper on a subreddit, it saves all images in on directory, but some posts have multiple images etc.. So I added the possibility, when the option flag to save album title is set, to save these in subdirectories with the posts title. Some more addition is, that the posts title is also saved to single image etc. filenames.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
* [x] Downloads all relevant content.
* [x] Downloads content from multiple pages (as necessary or appropriate).
* [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
