### PR TITLE
Timeout now applies to both connection and read

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
 import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Arrays;
@@ -110,6 +111,7 @@ class DownloadFileThread extends Thread {
                 }
                 huc.setInstanceFollowRedirects(true);
                 huc.setConnectTimeout(TIMEOUT);
+                huc.setReadTimeout(TIMEOUT);
                 huc.setRequestProperty("accept",  "*/*");
                 if (!referrer.equals("")) {
                     huc.setRequestProperty("Referer", referrer); // Sic
@@ -222,6 +224,9 @@ class DownloadFileThread extends Thread {
                 bis.close();
                 fos.close();
                 break; // Download successful: break out of infinite loop
+            } catch (SocketTimeoutException timeoutEx) {
+                logger.error(url.toExternalForm() + " timedout!");
+                break;
             } catch (HttpStatusException hse) {
                 logger.debug("HTTP status exception", hse);
                 logger.error("[!] HTTP status " + hse.getStatusCode() + " while downloading from " + urlToDownload);

--- a/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
@@ -110,6 +110,8 @@ class DownloadFileThread extends Thread {
                     huc = (HttpURLConnection) urlToDownload.openConnection();
                 }
                 huc.setInstanceFollowRedirects(true);
+                // It is important to set both ConnectTimeout and ReadTimeout. If you don't then ripme will wait forever
+                // for the server to send data after connecting.
                 huc.setConnectTimeout(TIMEOUT);
                 huc.setReadTimeout(TIMEOUT);
                 huc.setRequestProperty("accept",  "*/*");
@@ -225,7 +227,9 @@ class DownloadFileThread extends Thread {
                 fos.close();
                 break; // Download successful: break out of infinite loop
             } catch (SocketTimeoutException timeoutEx) {
-                logger.error(url.toExternalForm() + " timedout!");
+                // Handle the timeout
+                logger.error("[!] " + url.toExternalForm() + " timedout!");
+                // Download failed, break out of loop
                 break;
             } catch (HttpStatusException hse) {
                 logger.debug("HTTP status exception", hse);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #845)



# Description

Now sets connection timeout and read timeout 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
