### PR TITLE
Re-recognize 8Chan URLs

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -1,5 +1,9 @@
 package com.rarchives.ripme.ripper.rippers;
 
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.ripper.rippers.ripperhelpers.ChanSite;
+import com.rarchives.ripme.utils.Http;
+import com.rarchives.ripme.utils.RipUtils;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -8,14 +12,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-
-import com.rarchives.ripme.ripper.AbstractHTMLRipper;
-import com.rarchives.ripme.ripper.rippers.ripperhelpers.ChanSite;
-import com.rarchives.ripme.utils.Http;
-import com.rarchives.ripme.utils.RipUtils;
 
 public class ChanRipper extends AbstractHTMLRipper {
     private static List<ChanSite> explicit_domains = Arrays.asList(
@@ -85,6 +83,7 @@ public class ChanRipper extends AbstractHTMLRipper {
                 return true;
             }
         }
+
         if (url.toExternalForm().contains("desuchan.net") && url.toExternalForm().contains("/res/")) {
             return true;
         }
@@ -98,6 +97,9 @@ public class ChanRipper extends AbstractHTMLRipper {
             return true;
         }
         if (url.toExternalForm().contains("desuarchive.org")) {
+            return true;
+        }
+        if (url.toExternalForm().contains("8ch.net") && url.toExternalForm().contains("/res/")) {
             return true;
         }
         return false;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #844 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix


# Description

Added 8chan url support again by whitelisting "8ch.net" domain while it has "/res/" in the url.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
