### PR TITLE
JabArchivesRipper now allows for www. to appear in url

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/JabArchivesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/JabArchivesRipper.java
@@ -33,7 +33,7 @@ public class JabArchivesRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://(:?www.)jabarchives.com/main/view/([a-zA-Z0-9_]+).*$");
+        Pattern p = Pattern.compile("^https?://(:?www\\.)jabarchives.com/main/view/([a-zA-Z0-9_]+).*$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             // Return the text contained between () in the regex

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/JabArchivesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/JabArchivesRipper.java
@@ -33,7 +33,7 @@ public class JabArchivesRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://jabarchives.com/main/view/([a-zA-Z0-9_]+).*$");
+        Pattern p = Pattern.compile("^https?://(:?www.)jabarchives.com/main/view/([a-zA-Z0-9_]+).*$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             // Return the text contained between () in the regex

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/JabArchivesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/JabArchivesRipper.java
@@ -33,7 +33,7 @@ public class JabArchivesRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://(:?www\\.)jabarchives.com/main/view/([a-zA-Z0-9_]+).*$");
+        Pattern p = Pattern.compile("^https?://(?:www\\.)?jabarchives.com/main/view/([a-zA-Z0-9_]+).*$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             // Return the text contained between () in the regex


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #853)



# Description

Changed the getGID regex


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
