### PR TITLE
Hentai image

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiimageRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiimageRipper.java
@@ -23,17 +23,27 @@ public class HentaiimageRipper extends AbstractHTMLRipper {
 
     @Override
     public String getHost() {
-        return "hentai-image";
+        return url.toExternalForm().split("/")[2];
     }
 
     @Override
     public String getDomain() {
-        return "hentai-image.com";
+        return url.toExternalForm().split("/")[2];
+    }
+
+    @Override
+    public boolean canRip(URL url) {
+        try {
+            getGID(url);
+            return true;
+        } catch (MalformedURLException e) {
+            return false;
+        }
     }
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("https://(?:\\w\\w\\.)?hentai-image.com/image/([a-zA-Z0-9_-]+)/?");
+        Pattern p = Pattern.compile("https://(?:\\w\\w\\.)?hentai-(image|comic).com/image/([a-zA-Z0-9_-]+)/?");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiimageRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiimageRipper.java
@@ -1,0 +1,77 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+public class HentaiimageRipper extends AbstractHTMLRipper {
+
+
+    public HentaiimageRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "hentai-image";
+    }
+
+    @Override
+    public String getDomain() {
+        return "hentai-image.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https://(?:\\w\\w\\.)?hentai-image.com/image/([a-zA-Z0-9_-]+)/?");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected hitomi URL format: " +
+                "https://hentai-image.com/image/ID - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        for (Element el : doc.select("div.icon-overlay > a > img")) {
+            result.add(el.attr("src"));
+        }
+        return result;
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+
+        for (Element el : doc.select("div[id=paginator] > span")) {
+            if (el.select("a").text().equals("next>")) {
+                return Http.url("https://" + getDomain() + el.select("a").attr("href")).get();
+            }
+        }
+
+        throw new IOException("No more pages");
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaiimageRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaiimageRipperTest.java
@@ -1,0 +1,13 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.HentaiimageRipper;
+
+public class HentaiimageRipperTest extends RippersTest {
+    public void testHentaifoundryRip() throws IOException {
+        HentaiimageRipper ripper = new HentaiimageRipper(new URL("https://hentai-image.com/image/afrobull-gerudo-ongoing-12/"));
+        testRipper(ripper);
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [x] a new Ripper


# Description

Added ripper and unittest for hentai-image.com and hentai-comic.com


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
