### PR TITLE
Brazilian Portuguese (pt_BR) translation added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,7 @@ rips/
 ripme.jar.update
 *.swp
 *.properties
+!LabelsBundle*.properties
 history.json
 *.iml
 .settings/

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -144,7 +144,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
     private ResourceBundle rb = Utils.getResourceBundle(null);
 
     // All the langs ripme has been translated into
-    private static String[] supportedLanges = new String[] {"en_US", "de_DE", "es_ES", "fr_CH", "kr_KR", "pt_PT",
+    private static String[] supportedLanges = new String[] {"en_US", "de_DE", "es_ES", "fr_CH", "kr_KR", "pt_BR", "pt_PT",
             "fi_FI", "in_ID", "nl_NL", "porrisavvo_FI", "ru_RU"};
 
     private void updateQueueLabel() {

--- a/src/main/resources/LabelsBundle_pt_BR.properties
+++ b/src/main/resources/LabelsBundle_pt_BR.properties
@@ -1,0 +1,37 @@
+Log = Registro
+History = Histórico
+created = criado
+modified = modificado
+Queue = Fila
+Configuration = Configuração
+
+# Keys for the Configuration menu
+
+current.version = Versão atual
+check.for.updates = Verificar atualizações
+auto.update = Atualização automática?
+max.download.threads = Número máximo de conexões:
+timeout.mill = Tempo limite (em milissegundos):
+retry.download.count = Número de tentativas
+overwrite.existing.files = Sobrescrever arquivos existentes?
+sound.when.rip.completes = Som quando terminar o rip
+preserve.order = Preservar ordem
+save.logs = Salvar registros
+notification.when.rip.starts = Som quando rip começar
+save.urls.only = Salvar apenas URLs
+save.album.titles = Salvar títulos dos álbums
+autorip.from.clipboard = Autorip da área de transferência
+save.descriptions = Salvar descrições
+prefer.mp4.over.gif = Preferir MP4 a GIF
+restore.window.position = Restaurar posição da janela
+remember.url.history = Lembrar histórico de URL
+loading.history.from = Carregando histórico de
+
+# Misc UI keys
+
+loading.history.from.configuration = Carregando o histórico da configuração
+interrupted.while.waiting.to.rip.next.album = Interrompido enquanto esperava o rip do próximo álbum
+inactive = Inativo
+re-rip.checked = Re-ripar selecionados
+remove = Remover
+clear = Limpar


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] new translation
 

# Description

Included a new bundle for pt_BR translations.

Altered .gitignore to negate *.properties rule for the i18n bundle resources. (why are the .properties files being ignored anyway?)

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
