### PR TITLE
support for creating a url_history.txt in each rips/<name> directory.…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -28,7 +28,7 @@ public abstract class AbstractRipper
                 implements RipperInterface, Runnable {
 
     protected static final Logger LOGGER = Logger.getLogger(AbstractRipper.class);
-    private final String URLHistoryFile = Utils.getURLHistoryFile();
+    private String URLHistoryFile = Utils.getURLHistoryFile();
 
     public static final String USER_AGENT =
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 Safari/537.36";
@@ -76,6 +76,8 @@ public abstract class AbstractRipper
         FileWriter fw = null;
         try {
             File file = new File(URLHistoryFile);
+            LOGGER.debug("url_history.txt file: " + file.toString());
+
             if (!new File(Utils.getConfigDir()).exists()) {
                 LOGGER.error("Config dir doesn't exist");
                 LOGGER.info("Making config dir");
@@ -236,6 +238,19 @@ public abstract class AbstractRipper
      *      False if failed to download
      */
     protected boolean addURLToDownload(URL url, String prefix, String subdirectory, String referrer, Map<String, String> cookies, String fileName, String extension, Boolean getFileExtFromMIME) {
+      
+        // if a url_history.txt file exists in the default location, continue using that.
+        // otherwise, save the url_history.txt file to each individual directory
+        try {
+            if (!new File(Utils.getURLHistoryFile()).exists()) {
+                LOGGER.debug("Using " + workingDir.getCanonicalPath() + " for url_history.txt");
+                URLHistoryFile = workingDir.getCanonicalPath() + File.separator + "url_history.txt";
+            }
+        } catch (IOException e) {
+            LOGGER.debug("IOException. Will not process.");
+            return false;
+        }
+        
         // Don't re-add the url if it was downloaded in a previous rip
         if (Utils.getConfigBoolean("remember.url_history", true) && !isThisATest()) {
             if (hasDownloadedURL(url.toExternalForm())) {


### PR DESCRIPTION
… this will considerably improve performance

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ x ] a refactoring
* [ x  ] a style change/fix


# Description

As the url_history.txt file grows, performance decreases. This PR will now save the url_history.txt file to each individual directory being processed. This will not break backwards compatibility with existing installations; if a url_history.txt file exists in ~/.config/ripme (or where ever the rip.properties file is), it will continue to use this file until it is removed or renamed.

Example:
```
 java -jar target/ripme-1.7.61-jar-with-dependencies.jar -u 'https://www.instagram.com/puppies/'

head rips/instagram_puppies/url_history.txt
https://scontent-lga3-1.cdninstagram.com/vp/1ec454f99a4c6fd0ab16256b9156a58e/t51.2885-15/e35/38531095_542541279509261_7708136067639017472_n.jpg
https://scontent-lga3-1.cdninstagram.com/vp/3d725a1dcef1dfd264dd440a3517c326/t50.2886-16/37779799_743762896015565_6202087789383647232_n.mp4
https://scontent-lga3-1.cdninstagram.com/vp/7b5630909646ef319f035d9ee2e1b633/t50.2886-16/38130576_444954456007413_605107561397485568_n.mp4
https://scontent-lga3-1.cdninstagram.com/vp/4da5931f57d371d4ecd7a4b2bc30f31a/t51.2885-15/e35/37304592_641259729588873_5656126192554606592_n.jpg
https://scontent-lga3-1.cdninstagram.com/vp/d7bdab173e467d8074ccd4c6fed61fdd/t50.2886-16/37223956_256773365104275_5677799125769404342_n.mp4
https://scontent-lga3-1.cdninstagram.com/vp/cf8509a8704057005b028971bbc91578/t51.2885-15/e35/37202580_1571061726526461_4026329117543628800_n.jpg
https://scontent-lga3-1.cdninstagram.com/vp/86a87f388e25b285a41285853c2db34e/t51.2885-15/e35/35575312_501913830222914_9132211729659330560_n.jpg
https://scontent-lga3-1.cdninstagram.com/vp/5e869e98aaf810e8081073f98e127591/t51.2885-15/e35/35575471_2096872163659383_5062661617481678848_n.jpg
https://scontent-lga3-1.cdninstagram.com/vp/0eaf03e6b85f13768388375422c83d50/t51.2885-15/e35/35574810_1862890253749285_4106889737510322176_n.jpg
https://scontent-lga3-1.cdninstagram.com/vp/2a095643616b5de19d8dcc47599223b9/t51.2885-15/e35/35617062_2094110887524918_5019118049328889856_n.jpg

```

# Testing

Required verification:
* [ x ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ x ] I've verified that this change works as intended.
  * [ x ] Downloads all relevant content.
  * [ x ] Downloads content from multiple pages (as necessary or appropriate).
  *  [ x ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ x ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
