### PR TITLE
Test fixes

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -47,7 +47,7 @@ public abstract class AbstractRipper
     // Everytime addUrlToDownload skips a already downloaded url this increases by 1
     public int alreadyDownloadedUrls = 0;
     private boolean shouldStop = false;
-    private boolean thisIsATest = false;
+    private static boolean thisIsATest = false;
 
     public void stop() {
         shouldStop = true;
@@ -611,7 +611,7 @@ public abstract class AbstractRipper
         LOGGER.debug("THIS IS A TEST RIP");
         thisIsATest = true;
     }
-    protected boolean isThisATest() {
+    protected static boolean isThisATest() {
         return thisIsATest;
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
@@ -23,6 +23,7 @@ import org.jsoup.HttpStatusException;
 
 import com.rarchives.ripme.ui.RipStatusMessage.STATUS;
 import com.rarchives.ripme.utils.Utils;
+import com.rarchives.ripme.ripper.AbstractRipper;
 
 /**
  * Thread for downloading files.
@@ -221,6 +222,14 @@ class DownloadFileThread extends Thread {
                         bytesDownloaded += bytesRead;
                         observer.setBytesCompleted(bytesDownloaded);
                         observer.sendUpdate(STATUS.COMPLETED_BYTES, bytesDownloaded);
+                    }
+                    // If this is a test and we're downloading a large file
+                    if (AbstractRipper.isThisATest() && bytesTotal / 10000000 >= 10) {
+                        logger.debug("Not downloading whole file because it is over 10mb and this is a test");
+                        bis.close();
+                        fos.close();
+                        break;
+
                     }
                 }
                 bis.close();

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HqpornerRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HqpornerRipperTest.java
@@ -1,0 +1,15 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import com.rarchives.ripme.ripper.rippers.HqpornerRipper;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class HqpornerRipperTest extends RippersTest{
+
+    public void testRip() throws IOException {
+        HqpornerRipper ripper = new HqpornerRipper(new URL("https://hqporner.com/hdporn/84636-pool_lesson_with_a_cheating_husband.html"));
+        testRipper(ripper);
+    }
+
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HqpornerRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HqpornerRipperTest.java
@@ -12,4 +12,10 @@ public class HqpornerRipperTest extends RippersTest{
         testRipper(ripper);
     }
 
+    public void testGetGID() throws IOException {
+        URL poolURL = new URL("https://hqporner.com/hdporn/84636-pool_lesson_with_a_cheating_husband.html");
+        HqpornerRipper ripper = new HqpornerRipper(poolURL);
+        assertEquals("84636-pool_lesson_with_a_cheating_husband", ripper.getGID(poolURL));
+    }
+
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #865)



# Description

Ripme now doesn't download the entire file during testing if the file is over 10 mb. I also added a unit test for hqporner 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
