### PR TITLE
Removed flaky unittest for PichunterRipper

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PichunterRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PichunterRipperTest.java
@@ -6,11 +6,14 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.PichunterRipper;
 
 public class PichunterRipperTest extends RippersTest {
-    public void testPichunterModelPageRip() throws IOException {
-        // A non-photoset
-        PichunterRipper ripper = new PichunterRipper(new URL("https://www.pichunter.com/models/Madison_Ivy"));
-        testRipper(ripper);
-    }
+
+    //    This test was commented out at 6/08/2018 because it was randomly failing due to issues with the site
+    // see https://github.com/RipMeApp/ripme/issues/867
+//    public void testPichunterModelPageRip() throws IOException {
+//        // A non-photoset
+//        PichunterRipper ripper = new PichunterRipper(new URL("https://www.pichunter.com/models/Madison_Ivy"));
+//        testRipper(ripper);
+//    }
 
     public void testPichunterGalleryRip() throws IOException {
         // a photo set


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #867)



# Description

Commented out a unit test that was failing randomly due to issues with pichunter.com 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
