### PR TITLE
Added config option to allow for using subdirs with the reddit ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -225,13 +225,14 @@ public class RedditRipper extends AlbumRipper {
         } catch (MalformedURLException e) {
             return;
         }
-
         String subdirectory = "";
-        if (Utils.getConfigBoolean("album_titles.save", true)) {
-            subdirectory = title;
-            title = "-" + title + "-";
-        } else {
-            title = "";
+        if (Utils.getConfigBoolean("reddit.use_sub_dirs", true)) {
+            if (Utils.getConfigBoolean("album_titles.save", true)) {
+                subdirectory = title;
+                title = "-" + title + "-";
+            } else {
+                title = "";
+            }
         }
 
         List<URL> urls = RipUtils.getFilesFromURL(originalURL);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #873)


# Description

I added the `reddit.use_sub_dirs` config option which if false causes the reddit ripper to not use sub dirs


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
