### PR TITLE
Added ability to download range of urls

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1266,11 +1266,12 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                         int rangeStart = Integer.parseInt(rangeToParse.split("-")[0]);
                         int rangeEnd = Integer.parseInt(rangeToParse.split("-")[1]);
                         for (int i = rangeStart; i < rangeEnd +1; i++) {
-                            if (canRip(url.replaceAll("\\{\\S*\\}", Integer.toString(i)))) {
-                                queueListModel.add(queueListModel.size(), url.replaceAll("\\{\\S*\\}", Integer.toString(i)));
+                            String realURL = url.replaceAll("\\{\\S*\\}", Integer.toString(i));
+                            if (canRip(realURL)) {
+                                queueListModel.add(queueListModel.size(), realURL);
                                 ripTextfield.setText("");
                             } else {
-                                LOGGER.error("Can't find ripper for " + url.replaceAll("\\{\\S*\\}", Integer.toString(i)));
+                                LOGGER.error("Can't find ripper for " +realURL);
                             }
                         }
                     }

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -12,7 +12,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -21,7 +20,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.List;
-import java.util.stream.Stream;
 
 import javax.imageio.ImageIO;
 import javax.swing.DefaultListModel;
@@ -1238,11 +1236,48 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         return null;
     }
 
+    private boolean canRip(String urlString) {
+        try {
+            String urlText = urlString.trim();
+            if (urlText.equals("")) {
+                return false;
+            }
+            if (!urlText.startsWith("http")) {
+                urlText = "http://" + urlText;
+            }
+            URL url = new URL(urlText);
+            // Ripper is needed here to throw.not throw an Exception
+            AbstractRipper ripper = AbstractRipper.getRipper(url);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     class RipButtonHandler implements ActionListener {
         public void actionPerformed(ActionEvent event) {
-            if (!queueListModel.contains(ripTextfield.getText()) && !ripTextfield.getText().equals("")) {
-                queueListModel.add(queueListModel.size(), ripTextfield.getText());
-                ripTextfield.setText("");
+            String url = ripTextfield.getText();
+            if (!queueListModel.contains(url) && !url.equals("")) {
+                // Check if we're ripping a range of urls
+                if (url.contains("{")) {
+                    // Make sure the user hasn't forgotten the closing }
+                    if (url.contains("}")) {
+                        String rangeToParse = url.substring(url.indexOf("{") + 1, url.indexOf("}"));
+                        int rangeStart = Integer.parseInt(rangeToParse.split("-")[0]);
+                        int rangeEnd = Integer.parseInt(rangeToParse.split("-")[1]);
+                        for (int i = rangeStart; i < rangeEnd +1; i++) {
+                            if (canRip(url.replaceAll("\\{\\S*\\}", Integer.toString(i)))) {
+                                queueListModel.add(queueListModel.size(), url.replaceAll("\\{\\S*\\}", Integer.toString(i)));
+                                ripTextfield.setText("");
+                            } else {
+                                LOGGER.error("Can't find ripper for " + url.replaceAll("\\{\\S*\\}", Integer.toString(i)));
+                            }
+                        }
+                    }
+                } else {
+                    queueListModel.add(queueListModel.size(), ripTextfield.getText());
+                    ripTextfield.setText("");
+                }
             } else {
                 if (!isRipping) {
                     ripNextAlbum();


### PR DESCRIPTION
# Category

* [x] A new feature


# Description

Added the ability to rip a range of urls. Example: entering "http://test.tld/test={1-10}" will rip http://test.tld/test=1, http://test.tld/test=2 ect


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
