### PR TITLE
Gfycat fixes

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
@@ -73,7 +73,7 @@ public class GfycatRipper extends AbstractSingleFileRipper {
     @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
-        Elements videos = doc.select("source#mp4Source");
+        Elements videos = doc.select("source");
         String vidUrl = videos.first().attr("src");
         if (vidUrl.startsWith("//")) {
             vidUrl = "http:" + vidUrl;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/GfycatRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/GfycatRipperTest.java
@@ -11,7 +11,7 @@ public class GfycatRipperTest extends RippersTest {
      * Rips correctly formatted URL directly from Gfycat
      * @throws IOException 
      */
-    public void GfycatGoodURL() throws IOException{
+    public void testGfycatGoodURL() throws IOException{
         GfycatRipper ripper = new GfycatRipper(new URL("https://gfycat.com/TemptingExcellentIchthyosaurs"));
         testRipper(ripper);
     }
@@ -19,7 +19,7 @@ public class GfycatRipperTest extends RippersTest {
      * Rips badly formatted URL directly from Gfycat
      * @throws IOException 
      */
-    public void GfycatBadURL() throws IOException {
+    public void testGfycatBadURL() throws IOException {
         GfycatRipper ripper  = new GfycatRipper(new URL("https://gfycat.com/gifs/detail/limitedtestyamericancrow"));
         testRipper(ripper);
     }


### PR DESCRIPTION
# Category


* [x] a bug fix (Fix #876)



# Description

The ripper now doesn't find elements based on ID


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
