### PR TITLE
Revert "Fix #789: Implemented wraparound for log window and status label"

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -300,7 +300,7 @@ public abstract class AbstractRipper
      *      Prefix to prepend to the saved filename.
      * @param subdirectory
      *      Sub-directory of the working directory to save the images to.
-     * @return True on success, false on failure.
+     * @return True on success, flase on failure.
      */
     protected boolean addURLToDownload(URL url, String prefix, String subdirectory) {
         return addURLToDownload(url, prefix, subdirectory, null, null, null);
@@ -317,7 +317,7 @@ public abstract class AbstractRipper
      *      URL to download
      * @param prefix
      *      Text to append to saved filename.
-     * @return True on success, false on failure.
+     * @return True on success, flase on failure.
      */
     protected boolean addURLToDownload(URL url, String prefix) {
         // Use empty subdirectory

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -27,7 +27,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
-import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -159,30 +158,6 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         }
     }
 
-    private static int getAverageFontWidth(JComponent component) {
-        int sum = 0;
-        int[] widths = component.getFontMetrics(component.getFont()).getWidths();
-        for(int i : widths) {
-            sum += i;
-        }
-        return sum / widths.length;
-    }
-
-    private static void insertWrappedString(JComponent parent, StyledDocument document, String string, SimpleAttributeSet s) 
-        throws BadLocationException {
-        StringBuilder resultString = new StringBuilder();
-        int maxCharsToFit = parent.getWidth() / getAverageFontWidth(parent);
-        int i = 0;
-        while(i < string.length()/maxCharsToFit) {
-            if(i > 0) resultString.append(string.substring(i*maxCharsToFit-2, i*maxCharsToFit));
-            resultString.append(string.substring(i*maxCharsToFit, (i+1)*maxCharsToFit-2));
-            resultString.append("\n");
-            i++;
-        }
-        resultString.append(string.substring(string.length()-(string.length()%maxCharsToFit)));
-        resultString.append("\n");
-        document.insertString(document.getLength(), resultString.toString(), s);
-    }
 
     private static void addCheckboxListener(JCheckBox checkBox, String configString) {
         checkBox.addActionListener(arg0 -> {
@@ -274,14 +249,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
     private void statusWithColor(String text, Color color) {
         statusLabel.setForeground(color);
-        statusLabel.setToolTipText(text);
-        int averageWidth = getAverageFontWidth(statusLabel);
-        int numCharsToFit = statusLabel.getWidth() / averageWidth;
-        if(text.length() > (mainFrame.getWidth() / averageWidth)) {
-            statusLabel.setText(text.substring(0, numCharsToFit-6) + "...");
-        } else {
-            statusLabel.setText(text);
-        }
+        statusLabel.setText(text);
         pack();
     }
 
@@ -348,7 +316,6 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         gbc.weightx = 1;
 
         statusLabel = new JLabel(rb.getString("inactive"));
-        statusLabel.setToolTipText(rb.getString("inactive"));
         statusLabel.setHorizontalAlignment(JLabel.CENTER);
         openButton = new JButton();
         openButton.setVisible(false);
@@ -1092,7 +1059,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         StyledDocument sd = logText.getStyledDocument();
         try {
             synchronized (this) {
-                insertWrappedString(logText, sd, text, sas);
+                sd.insertString(sd.getLength(), text + "\n", sas);
             }
         } catch (BadLocationException e) { }
 


### PR DESCRIPTION
Reverts RipMeApp/ripme#805

I'm reverting this PR as it interdocued a few new bugs (Such as #880) and didn't wrap all text. These issues should be fixed and the PR should be remerged 