### PR TITLE
getFilesFromURL now can handle imgur videos

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/RipUtils.java
+++ b/src/main/java/com/rarchives/ripme/utils/RipUtils.java
@@ -149,7 +149,11 @@ public class RipUtils {
                         .userAgent(AbstractRipper.USER_AGENT)
                         .get();
                 for (Element el : doc.select("meta")) {
-                    if (el.attr("name").equals("twitter:image:src")) {
+                    if (el.attr("property").equals("og:video")) {
+                        result.add(new URL(el.attr("content")));
+                        return result;
+                    }
+                    else if (el.attr("name").equals("twitter:image:src")) {
                         result.add(new URL(el.attr("content")));
                         return result;
                     }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #895)



# Description

getFilesFromURL now can handle imgur videos


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
