### PR TITLE
Added url range downloading to list of ripmes features

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ For information about running the `.jar` file, see [the How To Run wiki](https:/
 * Can rip images from tumblr in the size they were uploaded in [See here for how to enable](https://github.com/RipMeApp/ripme/wiki/Config-options#tumblrget_raw_image)
 * Skips already downloaded images by default
 * Can auto skip e-hentai and nhentai albums containing certain tags [See here for how to enable](https://github.com/RipMeApp/ripme/wiki/Config-options#nhentaiblacklisttags)
+* Download a range of urls [See here for how](https://github.com/RipMeApp/ripme/wiki/How-To-Run-RipMe#docker)
 
 ## [List of Supported Sites](https://github.com/ripmeapp/ripme/wiki/Supported-Sites)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For information about running the `.jar` file, see [the How To Run wiki](https:/
 * Can rip images from tumblr in the size they were uploaded in [See here for how to enable](https://github.com/RipMeApp/ripme/wiki/Config-options#tumblrget_raw_image)
 * Skips already downloaded images by default
 * Can auto skip e-hentai and nhentai albums containing certain tags [See here for how to enable](https://github.com/RipMeApp/ripme/wiki/Config-options#nhentaiblacklisttags)
-* Download a range of urls [See here for how](https://github.com/RipMeApp/ripme/wiki/How-To-Run-RipMe#docker)
+* Download a range of urls [See here for how](https://github.com/RipMeApp/ripme/wiki/How-To-Run-RipMe#downloading-a-url-range)
 
 ## [List of Supported Sites](https://github.com/ripmeapp/ripme/wiki/Supported-Sites)
 


### PR DESCRIPTION
# Category


* [X] a refactoring



# Description

Added a line about ripmes url range downloading


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
