### PR TITLE
8muses ripper now gets full sized images

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -123,7 +123,7 @@ public class EightmusesRipper extends AbstractHTMLRipper {
                     JSONObject json = new JSONObject(rawJson);
                     try {
                         for (int i = 0; i != json.getJSONArray("pictures").length(); i++) {
-                            image = "https://www.8muses.com/image/fm/" + json.getJSONArray("pictures").getJSONObject(i).getString("publicUri");
+                            image = "https://www.8muses.com/image/fl/" + json.getJSONArray("pictures").getJSONObject(i).getString("publicUri");
                             URL imageUrl = new URL(image);
                             if (Utils.getConfigBoolean("8muses.use_short_names", false)) {
                                 addURLToDownload(imageUrl, getPrefixShort(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies, "", null, true);
@@ -155,7 +155,7 @@ public class EightmusesRipper extends AbstractHTMLRipper {
         LOGGER.info("Getting full sized image from " + imageUrl);
         Document doc = new Http(imageUrl).get(); // Retrieve the webpage  of the image URL
         String imageName = doc.select("div.photo > a > img").attr("src");
-        return "https://www.8muses.com/image/fm/" + imageName;
+        return "https://www.8muses.com/image/fl/" + imageName;
     }
 
     private String getTitle(String albumTitle) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #912)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Now uses /fl/ image url instead of /fm/


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
