### PR TITLE
Added unit test for imgur videoes

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImgurRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImgurRipperTest.java
@@ -2,6 +2,7 @@ package com.rarchives.ripme.tst.ripper.rippers;
 
 import com.rarchives.ripme.ripper.rippers.ImgurRipper;
 import com.rarchives.ripme.ripper.rippers.ImgurRipper.ImgurAlbum;
+import com.rarchives.ripme.utils.RipUtils;
 
 import java.io.IOException;
 import java.net.URL;
@@ -67,6 +68,11 @@ public class ImgurRipperTest extends RippersTest {
     public void testImgurAlbumWithMoreThan100Pictures() throws IOException {
         ImgurAlbum album = ImgurRipper.getImgurAlbum(new URL("http://imgur.com/a/zXZBU"));
         assertTrue("Failed to find 100 files from " + album.url.toExternalForm() + ", only got " + album.images.size(), album.images.size() >= 100);
+    }
+
+    public void testImgurVideoFromGetFilesFromURL() throws Exception {
+        List<URL> urls = RipUtils.getFilesFromURL(new URL("https://i.imgur.com/4TtwxRN.gifv"));
+        assertEquals("https://i.imgur.com/4TtwxRN.mp4", urls.get(0).toExternalForm());
     }
 
     /*


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Added a unit test for getting a video from imgur using RipUtils.getFilesFromURL


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
