### PR TITLE
Added Jagodibuja ripper test

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/JagodibujaRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/JagodibujaRipper.java
@@ -50,6 +50,12 @@ public class JagodibujaRipper extends AbstractHTMLRipper {
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         for (Element comicPageUrl : doc.select("div.gallery-icon > a")) {
+            // Check if the ripper has been stopped
+            try {
+                stopCheck();
+            } catch (IOException e) {
+                return result;
+            }
             try {
                 sleep(500);
                 Document comicPage = Http.url(comicPageUrl.attr("href")).get();

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/JagodibujaRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/JagodibujaRipperTest.java
@@ -6,5 +6,9 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.JagodibujaRipper;
 
 public class JagodibujaRipperTest extends RippersTest {
-    // TODO add a test
+    public void testJagodibujaRipper() throws IOException {
+        // a photo set
+        JagodibujaRipper ripper = new JagodibujaRipper(new URL("http://www.jagodibuja.com/comic-in-me/"));
+        testRipper(ripper);
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #917)



# Description

Added a unit test for Jagodibuja ripper and added a stop check to the ripper so that it stops gathering urls when stopcheck() throws an IOException


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
