### PR TITLE
Added unit test for LusciousRipper

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LusciousRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LusciousRipperTest.java
@@ -6,5 +6,9 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.LusciousRipper;
 
 public class LusciousRipperTest extends RippersTest {
-    // TODO add a test
+    public void testPahealRipper() throws IOException {
+        // a photo set
+        LusciousRipper ripper = new LusciousRipper(new URL("https://luscious.net/albums/h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609/"));
+        testRipper(ripper);
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #918)



# Description

Added a unit test for LusciousRipper


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
