### PR TITLE
Fixed Viewcomic ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ViewcomicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ViewcomicRipper.java
@@ -69,7 +69,7 @@ public class ViewcomicRipper extends AbstractHTMLRipper {
         @Override
         public List<String> getURLsFromPage(Document doc) {
             List<String> result = new ArrayList<String>();
-                for (Element el : doc.select("div.pinbin-copy > a > img")) {
+                for (Element el : doc.select("div.separator > a > img")) {
                     result.add(el.attr("src"));
                 }
             return result;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ViewcomicRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ViewcomicRipperTest.java
@@ -6,5 +6,8 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.ViewcomicRipper;
 
 public class ViewcomicRipperTest extends RippersTest {
-    // TODO add a test
+    public void testViewcomicRipper() throws IOException {
+        ViewcomicRipper ripper = new ViewcomicRipper(new URL("https://view-comic.com/batman-no-mans-land-vol-1/"));
+        testRipper(ripper);
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #924)



# Description

Fixed the ripper and added a unit test


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
