### PR TITLE
Hbrowse ripper test

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HbrowseRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HbrowseRipper.java
@@ -32,7 +32,7 @@ public class HbrowseRipper extends AbstractHTMLRipper {
 
         @Override
         public String getGID(URL url) throws MalformedURLException {
-            Pattern p = Pattern.compile("http://www.hbrowse.com/(\\d+)/[a-zA-Z0-9]*");
+            Pattern p = Pattern.compile("https?://www.hbrowse.com/(\\d+)/[a-zA-Z0-9]*");
             Matcher m = p.matcher(url.toExternalForm());
             if (m.matches()) {
                 return m.group(1);
@@ -45,7 +45,7 @@ public class HbrowseRipper extends AbstractHTMLRipper {
         public Document getFirstPage() throws IOException {
             // "url" is an instance field of the superclass
             Document tempDoc = Http.url(url).get();
-            return Http.url(tempDoc.select("td[id=pageTopHome] > a[title=view thumbnails (top)]").attr("href")).get();
+            return Http.url("https://www.hbrowse.com" + tempDoc.select("td[id=pageTopHome] > a[title=view thumbnails (top)]").attr("href")).get();
         }
 
         @Override
@@ -66,7 +66,7 @@ public class HbrowseRipper extends AbstractHTMLRipper {
             List<String> result = new ArrayList<String>();
             for (Element el : doc.select("table > tbody > tr > td > a > img")) {
                 String imageURL = el.attr("src").replace("/zzz", "");
-                result.add(imageURL);
+                result.add("https://www.hbrowse.com" + imageURL);
             }
                 return result;
         }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HbrowseRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HbrowseRipperTest.java
@@ -6,5 +6,8 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.HbrowseRipper;
 
 public class HbrowseRipperTest extends RippersTest {
-    // TODO add a test
+    public void testPahealRipper() throws IOException {
+        HbrowseRipper ripper = new HbrowseRipper(new URL("https://www.hbrowse.com/21013/c00001"));
+        testRipper(ripper);
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #915)



# Description

Fixed the Hbrowse ripper and added a unit test


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
