### PR TITLE
Tsumino tag black listing

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TsuminoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TsuminoRipper.java
@@ -12,6 +12,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.rarchives.ripme.ui.RipStatusMessage;
+import com.rarchives.ripme.utils.Utils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jsoup.Connection;
@@ -21,12 +22,48 @@ import org.jsoup.nodes.Document;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import com.rarchives.ripme.utils.Http;
+import org.jsoup.nodes.Element;
 
 public class TsuminoRipper extends AbstractHTMLRipper {
     private Map<String,String> cookies = new HashMap<>();
 
     public TsuminoRipper(URL url) throws IOException {
         super(url);
+    }
+
+    private List<String> getTags(Document doc) {
+        List<String> tags = new ArrayList<>();
+        LOGGER.info("Getting tags");
+        for (Element tag : doc.select("div#Tag > a")) {
+            LOGGER.info("Found tag " + tag.text());
+            tags.add(tag.text().toLowerCase());
+        }
+        return tags;
+    }
+
+    /**
+     * Checks for blacklisted tags on page. If it finds one it returns it, if not it return null
+     *
+     * @param doc
+     * @return String
+     */
+    public String checkTags(Document doc, String[] blackListedTags) {
+        // If the user hasn't blacklisted any tags we return null;
+        if (blackListedTags == null) {
+            return null;
+        }
+        LOGGER.info("Blacklisted tags " + blackListedTags[0]);
+        List<String> tagsOnPage = getTags(doc);
+        for (String tag : blackListedTags) {
+            for (String pageTag : tagsOnPage) {
+                // We replace all dashes in the tag with spaces because the tags we get from the site are separated using
+                // dashes
+                if (tag.trim().toLowerCase().equals(pageTag.toLowerCase())) {
+                    return tag.toLowerCase();
+                }
+            }
+        }
+        return null;
     }
 
     private JSONArray getPageUrls() {
@@ -86,7 +123,14 @@ public class TsuminoRipper extends AbstractHTMLRipper {
     public Document getFirstPage() throws IOException {
         Connection.Response resp = Http.url(url).response();
         cookies.putAll(resp.cookies());
-        return resp.parse();
+        Document doc =  resp.parse();
+        String blacklistedTag = checkTags(doc, Utils.getConfigStringArray("tsumino.blacklist.tags"));
+        if (blacklistedTag != null) {
+            sendUpdate(RipStatusMessage.STATUS.DOWNLOAD_WARN, "Skipping " + url.toExternalForm() + " as it " +
+                    "contains the blacklisted tag \"" + blacklistedTag + "\"");
+            return null;
+        }
+        return doc;
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/utils/RipUtils.java
+++ b/src/main/java/com/rarchives/ripme/utils/RipUtils.java
@@ -305,4 +305,28 @@ public class RipUtils {
         }
         return cookies;
     }
+
+    /**
+     * Checks for blacklisted tags on page. If it finds one it returns it, if not it return null
+     *
+     * @param blackListedTags a string array of the blacklisted tags
+     * @param tagsOnPage the tags on the page
+     * @return String
+     */
+    public static String checkTags(String[] blackListedTags, List<String> tagsOnPage) {
+        // If the user hasn't blacklisted any tags we return null;
+        if (blackListedTags == null) {
+            return null;
+        }
+        for (String tag : blackListedTags) {
+            for (String pageTag : tagsOnPage) {
+                // We replace all dashes in the tag with spaces because the tags we get from the site are separated using
+                // dashes
+                if (tag.trim().toLowerCase().equals(pageTag.toLowerCase())) {
+                    return tag.toLowerCase();
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TsuminoRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TsuminoRipperTest.java
@@ -5,6 +5,9 @@ import java.net.URL;
 import java.util.List;
 
 import com.rarchives.ripme.ripper.rippers.TsuminoRipper;
+import com.rarchives.ripme.utils.RipUtils;
+import org.jsoup.nodes.Document;
+
 
 public class TsuminoRipperTest extends RippersTest {
     public void testTsuminoRipper() throws IOException {
@@ -14,14 +17,21 @@ public class TsuminoRipperTest extends RippersTest {
 
     public void testTagBlackList() throws IOException {
         TsuminoRipper ripper = new TsuminoRipper(new URL("http://www.tsumino.com/Book/Info/42882/chaldea-maid-"));
+        Document doc = ripper.getFirstPage();
+        List<String> tagsOnPage = ripper.getTags(doc);
         String[] tags1 = {"test", "one", "Blowjob"};
-        String blacklistedTag = ripper.checkTags(ripper.getFirstPage(), tags1);
+        String blacklistedTag = RipUtils.checkTags(tags1, tagsOnPage);
         assertEquals("blowjob", blacklistedTag);
 
         // Test a tag with spaces
         String[] tags2 = {"test", "one", "Full Color"};
-        blacklistedTag = ripper.checkTags(ripper.getFirstPage(), tags2);
+        blacklistedTag = RipUtils.checkTags(tags2, tagsOnPage);
         assertEquals("full color", blacklistedTag);
+
+        // Test a album with no blacklisted tags
+        String[] tags3 = {"nothing", "one", "null"};
+        blacklistedTag = RipUtils.checkTags(tags3, tagsOnPage);
+        assertNull(blacklistedTag);
 
     }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TsuminoRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TsuminoRipperTest.java
@@ -2,13 +2,26 @@ package com.rarchives.ripme.tst.ripper.rippers;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.List;
 
 import com.rarchives.ripme.ripper.rippers.TsuminoRipper;
 
 public class TsuminoRipperTest extends RippersTest {
-    public void testPahealRipper() throws IOException {
-        // a photo set
+    public void testTsuminoRipper() throws IOException {
         TsuminoRipper ripper = new TsuminoRipper(new URL("http://www.tsumino.com/Book/Info/42882/chaldea-maid-"));
         testRipper(ripper);
+    }
+
+    public void testTagBlackList() throws IOException {
+        TsuminoRipper ripper = new TsuminoRipper(new URL("http://www.tsumino.com/Book/Info/42882/chaldea-maid-"));
+        String[] tags1 = {"test", "one", "Blowjob"};
+        String blacklistedTag = ripper.checkTags(ripper.getFirstPage(), tags1);
+        assertEquals("blowjob", blacklistedTag);
+
+        // Test a tag with spaces
+        String[] tags2 = {"test", "one", "Full Color"};
+        blacklistedTag = ripper.checkTags(ripper.getFirstPage(), tags2);
+        assertEquals("full color", blacklistedTag);
+
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a new feature


# Description

Added the ability to blacklist tags on Tsumino 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
