### PR TITLE
Fixed xhamster getnextpage

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -69,9 +69,9 @@ public class XhamsterRipper extends AbstractHTMLRipper {
 
     @Override
     public Document getNextPage(Document doc) throws IOException {
-        if (doc.select("a.next").first() != null) {
-            if (doc.select("a.next").first().attr("href").startsWith("http")) {
-                return Http.url(doc.select("a.next").first().attr("href")).get();
+        if (doc.select("a[data-page=next]").first() != null) {
+            if (doc.select("a[data-page=next]").first().attr("href").startsWith("http")) {
+                return Http.url(doc.select("a[data-page=next]").first().attr("href")).get();
             }
         }
         throw new IOException("No more pages");


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #943)



# Description

Fixed the getNextPage function 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
