### PR TITLE
Ripper and Unit test for Tubex6.com.  Closes digitalnoise/ripme#1

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/Tubex6Ripper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/Tubex6Ripper.java
@@ -1,0 +1,59 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
+import org.jsoup.nodes.Document;
+
+import com.rarchives.ripme.utils.Http;
+
+public class Tubex6Ripper extends AbstractSingleFileRipper {
+
+    public Tubex6Ripper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "tubex6";
+    }
+
+    @Override
+    public String getDomain() {
+        return "tubex6.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^http://.*tubex6\\.com/(.*)/$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected tubex6.com URL format: " +
+                "tubex6.com/NAME - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        return Http.url(url).get();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        result.add(doc.select("source[type=video/mp4]").attr("src"));
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/Tubex6RipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/Tubex6RipperTest.java
@@ -1,0 +1,19 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.Tubex6Ripper;
+
+public class Tubex6RipperTest extends RippersTest {
+    public void testRip() throws IOException {
+        Tubex6Ripper ripper = new Tubex6Ripper(new URL("http://www.tubex6.com/my-sister-sleeps-naked-1/"));
+        testRipper(ripper);
+    }
+
+    public void testGetGID() throws IOException {
+        URL url = new URL("http://www.tubex6.com/my-sister-sleeps-naked-1/");
+        Tubex6Ripper ripper = new Tubex6Ripper(url);
+        assertEquals("my-sister-sleeps-naked-1", ripper.getGID(url));
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

New ripper and unit test for Tubex6.com.  Builds and tests clean locally.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
