### PR TITLE
Added getNextPage unit test for xhamster ripper

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XhamsterRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XhamsterRipperTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.XhamsterRipper;
+import org.jsoup.nodes.Document;
 
 public class XhamsterRipperTest extends RippersTest {
 
@@ -26,5 +27,15 @@ public class XhamsterRipperTest extends RippersTest {
         URL url = new URL("https://xhamster.com/photos/gallery/japanese-dolls-4-asahi-mizuno-7254664");
         XhamsterRipper ripper = new XhamsterRipper(url);
         assertEquals("7254664", ripper.getGID(url));
+    }
+
+    public void testGetNextPage() throws IOException {
+        XhamsterRipper ripper = new XhamsterRipper(new URL("https://pt.xhamster.com/photos/gallery/silvana-7105696"));
+        Document doc = ripper.getFirstPage();
+        try {
+            ripper.getNextPage(doc);
+        } catch (IOException e) {
+            throw new Error("Was unable to get next page of album");
+        }
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [x] a refactoring



# Description

Added a unit test covering getNextPage to the xhamster ripper


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
