### PR TITLE
Ruleporn.com Ripper (NSFW)

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RulePornRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RulePornRipper.java
@@ -1,0 +1,59 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
+import org.jsoup.nodes.Document;
+
+import com.rarchives.ripme.utils.Http;
+
+public class RulePornRipper extends AbstractSingleFileRipper {
+
+    public RulePornRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "ruleporn";
+    }
+
+    @Override
+    public String getDomain() {
+        return "ruleporn.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https://.*ruleporn\\.com/(.*)/$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException(
+                "Expected ruleporn.com URL format: " + "ruleporn.com/NAME - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        return Http.url(url).get();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        result.add(doc.select("source[type=video/mp4]").attr("src"));
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/RulePornRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/RulePornRipperTest.java
@@ -3,17 +3,17 @@ package com.rarchives.ripme.tst.ripper.rippers;
 import java.io.IOException;
 import java.net.URL;
 
-import com.rarchives.ripme.ripper.rippers.Tubex6Ripper;
+import com.rarchives.ripme.ripper.rippers.RulePornRipper;
 
 public class RulePornRipperTest extends RippersTest {
     public void testRip() throws IOException {
-        Tubex6Ripper ripper = new Tubex6Ripper(new URL("https://ruleporn.com/are-you-going-to-fill-my-lil-pussy-up/"));
+        RulePornRipper ripper = new RulePornRipper(new URL("https://ruleporn.com/are-you-going-to-fill-my-lil-pussy-up/"));
         testRipper(ripper);
     }
 
     public void testGetGID() throws IOException {
         URL url = new URL("https://ruleporn.com/are-you-going-to-fill-my-lil-pussy-up/");
-        Tubex6Ripper ripper = new Tubex6Ripper(url);
+        RulePornRipper ripper = new RulePornRipper(url);
         assertEquals("are-you-going-to-fill-my-lil-pussy-up", ripper.getGID(url));
     }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/RulePornRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/RulePornRipperTest.java
@@ -1,0 +1,19 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.Tubex6Ripper;
+
+public class RulePornRipperTest extends RippersTest {
+    public void testRip() throws IOException {
+        Tubex6Ripper ripper = new Tubex6Ripper(new URL("https://ruleporn.com/are-you-going-to-fill-my-lil-pussy-up/"));
+        testRipper(ripper);
+    }
+
+    public void testGetGID() throws IOException {
+        URL url = new URL("https://ruleporn.com/are-you-going-to-fill-my-lil-pussy-up/");
+        Tubex6Ripper ripper = new Tubex6Ripper(url);
+        assertEquals("are-you-going-to-fill-my-lil-pussy-up", ripper.getGID(url));
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Ripper and Unit test for RulePorn.com.  Builds and test clean locally.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
