### PR TITLE
Fixed EightmusesRipper so titles on disk no longer include ---

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -150,28 +150,14 @@ public class EightmusesRipper extends AbstractHTMLRipper {
         return imageURLs;
     }
 
-    private String getFullSizeImage(String imageUrl) throws IOException {
-        sendUpdate(STATUS.LOADING_RESOURCE, imageUrl);
-        LOGGER.info("Getting full sized image from " + imageUrl);
-        Document doc = new Http(imageUrl).get(); // Retrieve the webpage  of the image URL
-        String imageName = doc.select("div.photo > a > img").attr("src");
-        return "https://www.8muses.com/image/fl/" + imageName;
-    }
-
-    private String getTitle(String albumTitle) {
-        albumTitle = albumTitle.replace("A huge collection of free porn comics for adults. Read ", "");
-        albumTitle = albumTitle.replace(" online for free at 8muses.com", "");
-        albumTitle = albumTitle.replace(" ", "_");
-        return albumTitle;
-    }
-
-    private String getSubdir(String rawHref) {
+    public String getSubdir(String rawHref) {
         LOGGER.info("Raw title: " + rawHref);
         String title = rawHref;
         title = title.replaceAll("8muses - Sex and Porn Comics", "");
-        title = title.replaceAll("\t\t", "");
+        title = title.replaceAll("\\s+", " ");
         title = title.replaceAll("\n", "");
         title = title.replaceAll("\\| ", "");
+        title = title.replace(" - ", "-");
         title = title.replace(" ", "-");
         LOGGER.info(title);
         return title;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EightmusesRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EightmusesRipperTest.java
@@ -21,7 +21,6 @@ public class EightmusesRipperTest extends RippersTest {
     public void testGID() throws IOException {
         EightmusesRipper ripper = new EightmusesRipper(new URL("https://www.8muses.com/comix/album/Affect3D-Comics/TheDude3DX/Lust-Unleashed-The-Urge-To-Explore"));
         assertEquals("Affect3D-Comics", ripper.getGID(new URL("https://www.8muses.com/comics/album/Affect3D-Comics/TheDude3DX/Lust-Unleashed-The-Urge-To-Explore")));
-        assertEquals("Affect3D-Comics", ripper.getSubdir("After Party - Issue 1"));
     }
 
     public void testGetSubdir() throws IOException {

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EightmusesRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EightmusesRipperTest.java
@@ -21,5 +21,11 @@ public class EightmusesRipperTest extends RippersTest {
     public void testGID() throws IOException {
         EightmusesRipper ripper = new EightmusesRipper(new URL("https://www.8muses.com/comix/album/Affect3D-Comics/TheDude3DX/Lust-Unleashed-The-Urge-To-Explore"));
         assertEquals("Affect3D-Comics", ripper.getGID(new URL("https://www.8muses.com/comics/album/Affect3D-Comics/TheDude3DX/Lust-Unleashed-The-Urge-To-Explore")));
+        assertEquals("Affect3D-Comics", ripper.getSubdir("After Party - Issue 1"));
+    }
+
+    public void testGetSubdir() throws IOException {
+        EightmusesRipper ripper = new EightmusesRipper(new URL("https://www.8muses.com/comix/album/Affect3D-Comics/TheDude3DX/Lust-Unleashed-The-Urge-To-Explore"));
+        assertEquals("After-Party-Issue-1", ripper.getSubdir("After Party - Issue 1"));
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #950)



# Description

Fix getSubDir so it no longer adds 2 extra dashes to comic issues 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
