### PR TITLE
Erome Fixes

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
@@ -129,6 +129,9 @@ public class EromeRipper extends AbstractHTMLRipper {
         for (Element el : doc.select("source[label=HD]")) {
             results.add("https:" + el.attr("src"));
         }
+        for (Element el : doc.select("source[label=SD]")) {
+            results.add("https:" + el.attr("src"));
+        }
         return results;
     }
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EromeRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EromeRipperTest.java
@@ -33,7 +33,7 @@ public class EromeRipperTest extends RippersTest {
     }
 
     public void testRip() throws IOException {
-        URL url = new URL("https://www.erome.com/a/4FqeUxil");
+        URL url = new URL("https://www.erome.com/a/vlefBdsg");
         EromeRipper ripper = new EromeRipper(url);
         testRipper(ripper);
     }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #958 Fix #959)



# Description

The ripper now grabs both HD and SD video, replace 404ing url 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
