### PR TITLE
Ported the SpankBangRipper to AbstractSingleFileRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SpankbangRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SpankbangRipper.java
@@ -1,24 +1,50 @@
-package com.rarchives.ripme.ripper.rippers.video;
+package com.rarchives.ripme.ripper.rippers;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 
 import com.rarchives.ripme.ripper.VideoRipper;
 import com.rarchives.ripme.utils.Http;
 
-public class SpankbangRipper extends VideoRipper {
+public class SpankbangRipper extends AbstractSingleFileRipper {
 
     private static final String HOST = "spankbang";
 
     public SpankbangRipper(URL url) throws IOException {
         super(url);
     }
+
+    @Override
+    public String getDomain() {
+        return "spankbang.com";
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        return Http.url(url).get();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        Elements videos = doc.select(".video-js > source");
+        if (videos.isEmpty()) {
+            LOGGER.error("Could not find Embed code at " + url);
+            return null;
+        }
+        result.add(videos.attr("src"));
+        return result;
+    }
+
 
     @Override
     public String getHost() {
@@ -52,15 +78,7 @@ public class SpankbangRipper extends VideoRipper {
     }
 
     @Override
-    public void rip() throws IOException {
-        LOGGER.info("Retrieving " + this.url);
-        Document doc = Http.url(url).get();
-        Elements videos = doc.select(".video-js > source");
-        if (videos.isEmpty()) {
-            throw new IOException("Could not find Embed code at " + url);
-        }
-        String vidUrl = videos.attr("src");
-        addURLToDownload(new URL(vidUrl), HOST + "_" + getGID(this.url));
-        waitForThreads();
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
     }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SpankBangRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SpankBangRipperTest.java
@@ -3,16 +3,13 @@ package com.rarchives.ripme.tst.ripper.rippers;
 import java.io.IOException;
 import java.net.URL;
 
-import com.rarchives.ripme.ripper.rippers.video.SpankbangRipper;
-import com.rarchives.ripme.utils.Utils;
+import com.rarchives.ripme.ripper.rippers.SpankbangRipper;
 
 public class SpankBangRipperTest extends RippersTest {
+
     public void testSpankBangVideo() throws IOException {
-        // This test fails on the CI so we skip it unless running locally
-        if (Utils.getConfigBoolean("test.run_flaky_tests", false)) {
-            SpankbangRipper ripper = new SpankbangRipper(new URL("https://spankbang.com/2a7fh/video/mdb901"));  //most popular video of all time on site; should stay up
-            testRipper(ripper);
-        }
+        SpankbangRipper ripper = new SpankbangRipper(new URL("https://spankbang.com/2a7fh/video/mdb901"));  //most popular video of all time on site; should stay up
+        testRipper(ripper);
     }
 
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [x] a refactoring



# Description

Rewrote the ripper so it now use AbstractSingleFileRipper instead of VideoRipper


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
