### PR TITLE
Port MulemaxRipper to AbstractSingleFileRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MulemaxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MulemaxRipper.java
@@ -1,18 +1,22 @@
-package com.rarchives.ripme.ripper.rippers.video;
+package com.rarchives.ripme.ripper.rippers;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
 import com.rarchives.ripme.ripper.VideoRipper;
 import com.rarchives.ripme.utils.Http;
 
-public class MulemaxRipper extends VideoRipper {
+public class MulemaxRipper extends AbstractSingleFileRipper {
 
     private static final String HOST = "mulemax";
 
@@ -22,7 +26,17 @@ public class MulemaxRipper extends VideoRipper {
 
     @Override
     public String getHost() {
-        return HOST;
+        return "mulemax";
+    }
+
+    @Override
+    public String getDomain() {
+        return "mulemax.com";
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        return Http.url(url).get();
     }
 
     @Override
@@ -52,15 +66,14 @@ public class MulemaxRipper extends VideoRipper {
     }
 
     @Override
-    public void rip() throws IOException {
-        LOGGER.info("Retrieving " + this.url);
-        Document doc = Http.url(url).get();
-        Elements videos = doc.select(".video-js > source");
-        if (videos.isEmpty()) {
-            throw new IOException("Could not find Embed code at " + url);
-        }
-        String vidUrl = videos.attr("src");
-        addURLToDownload(new URL(vidUrl), HOST + "_" + getGID(this.url));
-        waitForThreads();
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        result.add(doc.select(".video-js > source").attr("src"));
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
     }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MulemaxRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MulemaxRipperTest.java
@@ -3,16 +3,14 @@ package com.rarchives.ripme.tst.ripper.rippers;
 import java.io.IOException;
 import java.net.URL;
 
-import com.rarchives.ripme.ripper.rippers.video.MulemaxRipper;
+import com.rarchives.ripme.ripper.rippers.MulemaxRipper;
 import com.rarchives.ripme.utils.Utils;
 
 public class MulemaxRipperTest extends RippersTest {
     
     public void testMulemaxVideo() throws IOException {
-        // This test fails on the CI - possibly due to checking for a file before it's written - so we're skipping it
-        if (Utils.getConfigBoolean("test.run_flaky_tests", false)) {
-            MulemaxRipper ripper = new MulemaxRipper(new URL("https://mulemax.com/video/1720/emma-and-her-older-sissy-are-home-for-a-holiday-break"));  //pick any video from the front page
-            testRipper(ripper);
-        }
+        MulemaxRipper ripper = new MulemaxRipper(new URL("https://mulemax.com/video/1720/emma-and-her-older-sissy-are-home-for-a-holiday-break"));  //pick any video from the front page
+        testRipper(ripper);
     }
+
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [x] a refactoring



# Description

Ported the MulemaxRipper to AbstractSingleFileRipper


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
