### PR TITLE
Youporn ripper port

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/YoupornRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/YoupornRipper.java
@@ -1,11 +1,14 @@
-package com.rarchives.ripme.ripper.rippers.video;
+package com.rarchives.ripme.ripper.rippers;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -13,9 +16,8 @@ import org.jsoup.select.Elements;
 import com.rarchives.ripme.ripper.VideoRipper;
 import com.rarchives.ripme.utils.Http;
 
-public class YoupornRipper extends VideoRipper {
+public class YoupornRipper extends AbstractSingleFileRipper {
 
-    private static final String HOST = "youporn";
 
     public YoupornRipper(URL url) throws IOException {
         super(url);
@@ -23,7 +25,12 @@ public class YoupornRipper extends VideoRipper {
 
     @Override
     public String getHost() {
-        return HOST;
+        return "youporn";
+    }
+
+    @Override
+    public String getDomain() {
+        return "youporn.com";
     }
 
     @Override
@@ -34,9 +41,20 @@ public class YoupornRipper extends VideoRipper {
     }
 
     @Override
-    public URL sanitizeURL(URL url) throws MalformedURLException {
-        return url;
+    public Document getFirstPage() throws IOException {
+        return Http.url(this.url).get();
     }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> results = new ArrayList<>();
+        Elements videos = doc.select("video");
+
+        Element video = videos.get(0);
+        results.add(video.attr("src"));
+        return results;
+    }
+
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
@@ -53,16 +71,7 @@ public class YoupornRipper extends VideoRipper {
     }
 
     @Override
-    public void rip() throws IOException {
-        LOGGER.info("    Retrieving " + this.url);
-        Document doc = Http.url(this.url).get();
-        Elements videos = doc.select("video");
-        if (videos.isEmpty()) {
-            throw new IOException("Could not find Embed code at " + url);
-        }
-        Element video = videos.get(0);
-        String vidUrl = video.attr("src");
-        addURLToDownload(new URL(vidUrl), HOST + "_" + getGID(this.url));
-        waitForThreads();
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
     }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VideoRippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VideoRippersTest.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 import com.rarchives.ripme.ripper.VideoRipper;
 import com.rarchives.ripme.ripper.rippers.video.PornhubRipper;
-import com.rarchives.ripme.ripper.rippers.video.YoupornRipper;
+import com.rarchives.ripme.ripper.rippers.YoupornRipper;
 import com.rarchives.ripme.ripper.rippers.video.YuvutuRipper;
 
 public class VideoRippersTest extends RippersTest {
@@ -55,14 +55,6 @@ public class VideoRippersTest extends RippersTest {
         }
     }
 
-    public void testYoupornRipper() throws IOException {
-        List<URL> contentURLs = new ArrayList<>();
-        contentURLs.add(new URL("http://www.youporn.com/watch/7669155/mrs-li-amateur-69-orgasm/?from=categ"));
-        for (URL url : contentURLs) {
-            YoupornRipper ripper = new YoupornRipper(url);
-            videoTestHelper(ripper);
-        }
-    }
     
     public void testYuvutuRipper() throws IOException {
         List<URL> contentURLs = new ArrayList<>();

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/YoupornRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/YoupornRipperTest.java
@@ -1,0 +1,19 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import com.rarchives.ripme.ripper.rippers.YoupornRipper;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+public class YoupornRipperTest  extends RippersTest {
+    public void testYoupornRipper() throws IOException {
+        List<URL> contentURLs = new ArrayList<>();
+        contentURLs.add(new URL("http://www.youporn.com/watch/7669155/mrs-li-amateur-69-orgasm/?from=categ"));
+        for (URL url : contentURLs) {
+            YoupornRipper ripper = new YoupornRipper(url);
+            testRipper(ripper);
+        }
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [x] a refactoring



# Description

Ported the youporn ripper to AbstractSingleFileRipper


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
