### PR TITLE
Xhamster video

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XhamsterRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XhamsterRipperTest.java
@@ -18,6 +18,11 @@ public class XhamsterRipperTest extends RippersTest {
         testRipper(ripper);
     }
 
+    public void testXhamsterVideo() throws IOException {
+        XhamsterRipper ripper = new XhamsterRipper(new URL("https://xhamster.com/videos/brazzers-busty-big-booty-milf-lisa-ann-fucks-her-masseur-1492828"));
+        testRipper(ripper);
+    }
+
     public void testBrazilianXhamster() throws IOException {
         XhamsterRipper ripper = new XhamsterRipper(new URL("https://pt.xhamster.com/photos/gallery/silvana-7105696"));
         testRipper(ripper);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #973)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Readded video ripping support to the xhamster ripper


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
