### PR TITLE
Porncomix.one Ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PorncomixDotOneRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PorncomixDotOneRipper.java
@@ -1,0 +1,64 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class PorncomixDotOneRipper extends AbstractHTMLRipper {
+
+    public PorncomixDotOneRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "porncomix";
+    }
+
+    @Override
+    public String getDomain() {
+        return "porncomix.one";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https?://www.porncomix.one/gallery/([a-zA-Z0-9_\\-]*)/?$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected proncomix URL format: " +
+                "porncomix.one/gallery/comic - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        for (Element el : doc.select(".dgwt-jg-gallery > a")) {
+            result.add(el.attr("href"));
+
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PorncomixDotOneRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PorncomixDotOneRipper.java
@@ -50,8 +50,12 @@ public class PorncomixDotOneRipper extends AbstractHTMLRipper {
     @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
+        // We have 2 loops here to cover all the different album types
         for (Element el : doc.select(".dgwt-jg-gallery > a")) {
             result.add(el.attr("href"));
+        }
+        for (Element el : doc.select(".unite-gallery > img")) {
+            result.add(el.attr("data-image"));
 
         }
         return result;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PorncomixDotOneRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PorncomixDotOneRipperTest.java
@@ -1,0 +1,13 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.PorncomixDotOneRipper;
+
+public class PorncomixDotOneRipperTest extends RippersTest {
+    public void testPorncomixAlbum() throws IOException {
+        PorncomixDotOneRipper ripper = new PorncomixDotOneRipper(new URL("https://www.porncomix.one/gallery/blacknwhite-make-america-great-again"));
+        testRipper(ripper);
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [x] a new Ripper



# Description

Added a ripper for porncomix.one


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
