### PR TITLE
Instagram ripper no longer throws JSONObject["end_cursor"] not a stri…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -224,8 +224,13 @@ public class InstagramRipper extends AbstractJSONRipper {
                     .getJSONObject("graphql").getJSONObject("user")
                     .getJSONObject("edge_owner_to_timeline_media").getJSONObject("page_info").getString("end_cursor");
         } catch (JSONException e) {
-            return json.getJSONObject("data").getJSONObject("user")
-                    .getJSONObject("edge_owner_to_timeline_media").getJSONObject("page_info").getString("end_cursor");
+            // This is here so that when the user rips the last page they don't get a "end_cursor not a string" error
+            try {
+                return json.getJSONObject("data").getJSONObject("user")
+                        .getJSONObject("edge_owner_to_timeline_media").getJSONObject("page_info").getString("end_cursor");
+            } catch (JSONException t) {
+                return "";
+            }
         }
     }
 


### PR DESCRIPTION
…ng when finishing a rip

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #982)


# Description

If end_cursor is not a string getAfter returns an empty string 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
