### PR TITLE
Fixed xhamster ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
@@ -214,6 +214,7 @@ class DownloadFileThread extends Thread {
                 }
                 byte[] data = new byte[1024 * 256];
                 int bytesRead;
+                boolean shouldSkipFileDownload = huc.getContentLength() / 10000000 >= 10;
                 while ( (bytesRead = bis.read(data)) != -1) {
                     try {
                         observer.stopCheck();
@@ -228,7 +229,7 @@ class DownloadFileThread extends Thread {
                         observer.sendUpdate(STATUS.COMPLETED_BYTES, bytesDownloaded);
                     }
                     // If this is a test and we're downloading a large file
-                    if (AbstractRipper.isThisATest() && bytesTotal / 10000000 >= 10) {
+                    if (AbstractRipper.isThisATest() && shouldSkipFileDownload) {
                         logger.debug("Not downloading whole file because it is over 10mb and this is a test");
                         bis.close();
                         fos.close();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -124,20 +124,16 @@ public class XhamsterRipper extends AbstractHTMLRipper {
 
     @Override
     public List<String> getURLsFromPage(Document doc) {
+        LOGGER.debug("Checking for urls");
         List<String> result = new ArrayList<>();
-        for (Element thumb : doc.select("div.picture_view > div.pictures_block > div.items > div.item-container > a > div.thumb_container > div.img > img")) {
-            String image = thumb.attr("src");
-            // replace thumbnail urls with the urls to the full sized images
-            image = image.replaceAll(
-                    "https://upt.xhcdn\\.",
-                    "http://up.xhamster.");
-            image = image.replaceAll("ept\\.xhcdn", "ep.xhamster");
-            image = image.replaceAll(
-                    "_160\\.",
-                    "_1000.");
-            // Xhamster has bad cert management and uses invalid certs for some cdns, so we change all our requests to http
-            image = image.replaceAll("https", "http");
-            result.add(image);
+        for (Element page : doc.select("div.items > div.item-container > a.item")) {
+            String pageWithImageUrl = page.attr("href");
+            try {
+                String image = Http.url(new URL(pageWithImageUrl)).get().select("div.picture_container > a > img").attr("src");
+                result.add(image);
+            } catch (IOException e) {
+                LOGGER.error("Was unable to load page " + pageWithImageUrl);
+            }
         }
         return result;
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -26,6 +26,12 @@ public class XhamsterRipper extends AbstractHTMLRipper {
         super(url);
     }
 
+    private int index = 1;
+
+    @Override public boolean hasASAPRipping() {
+        return true;
+    }
+
     @Override
     public String getHost() {
         return "xhamster";
@@ -151,13 +157,14 @@ public class XhamsterRipper extends AbstractHTMLRipper {
               String pageWithImageUrl = page.attr("href");
               try {
                   String image = Http.url(new URL(pageWithImageUrl)).get().select("div.picture_container > a > img").attr("src");
-                  result.add(image);
+                  downloadFile(image);
               } catch (IOException e) {
                   LOGGER.error("Was unable to load page " + pageWithImageUrl);
               }
           }
         } else {
-            result.add(doc.select("div.player-container > a").attr("href"));
+            String imgUrl = doc.select("div.player-container > a").attr("href");
+            downloadFile(imgUrl);
         }
         return result;
     }
@@ -165,6 +172,15 @@ public class XhamsterRipper extends AbstractHTMLRipper {
     @Override
     public void downloadURL(URL url, int index) {
         addURLToDownload(url, getPrefix(index));
+    }
+
+    private void downloadFile(String url) {
+        try {
+            addURLToDownload(new URL(url), getPrefix(index));
+            index = index + 1;
+        } catch (MalformedURLException e) {
+            LOGGER.error("The url \"" + url + "\" is malformed");
+        }
     }
     
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -155,6 +155,7 @@ public class XhamsterRipper extends AbstractHTMLRipper {
               } catch (IOException e) {
                   LOGGER.error("Was unable to load page " + pageWithImageUrl);
               }
+          }
         } else {
             result.add(doc.select("div.player-container > a").attr("href"));
         }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XhamsterRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XhamsterRipperTest.java
@@ -35,7 +35,7 @@ public class XhamsterRipperTest extends RippersTest {
     }
 
     public void testGetNextPage() throws IOException {
-        XhamsterRipper ripper = new XhamsterRipper(new URL("https://pt.xhamster.com/photos/gallery/silvana-7105696"));
+        XhamsterRipper ripper = new XhamsterRipper(new URL("https://pt.xhamster.com/photos/gallery/mega-compil-6-10728626"));
         Document doc = ripper.getFirstPage();
         try {
             ripper.getNextPage(doc);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #983)



# Description

The ripper now visits each page to get the full sized image


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
