### PR TITLE
Moved if statement outide of loop

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
@@ -214,27 +214,24 @@ class DownloadFileThread extends Thread {
                 }
                 byte[] data = new byte[1024 * 256];
                 int bytesRead;
-                boolean shouldSkipFileDownload = huc.getContentLength() / 10000000 >= 10;
-                while ( (bytesRead = bis.read(data)) != -1) {
-                    try {
-                        observer.stopCheck();
-                    } catch (IOException e) {
-                        observer.downloadErrored(url, rb.getString("download.interrupted"));
-                        return;
-                    }
-                    fos.write(data, 0, bytesRead);
-                    if (observer.useByteProgessBar()) {
-                        bytesDownloaded += bytesRead;
-                        observer.setBytesCompleted(bytesDownloaded);
-                        observer.sendUpdate(STATUS.COMPLETED_BYTES, bytesDownloaded);
-                    }
-                    // If this is a test and we're downloading a large file
-                    if (AbstractRipper.isThisATest() && shouldSkipFileDownload) {
-                        logger.debug("Not downloading whole file because it is over 10mb and this is a test");
-                        bis.close();
-                        fos.close();
-                        break;
-
+                boolean shouldSkipFileDownload = huc.getContentLength() / 10000000 >= 10 && AbstractRipper.isThisATest();
+                // If this is a test rip we skip large downloads
+                if (shouldSkipFileDownload) {
+                    logger.debug("Not downloading whole file because it is over 10mb and this is a test");
+                } else {
+                    while ((bytesRead = bis.read(data)) != -1) {
+                        try {
+                            observer.stopCheck();
+                        } catch (IOException e) {
+                            observer.downloadErrored(url, rb.getString("download.interrupted"));
+                            return;
+                        }
+                        fos.write(data, 0, bytesRead);
+                        if (observer.useByteProgessBar()) {
+                            bytesDownloaded += bytesRead;
+                            observer.setBytesCompleted(bytesDownloaded);
+                            observer.sendUpdate(STATUS.COMPLETED_BYTES, bytesDownloaded);
+                        }
                     }
                 }
                 bis.close();


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a refactoring


# Description

Moved an if statement outside of the download loop so it's only run once instead of for ever few kilobytes of the downloaded file 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
