### PR TITLE
Handle File name too long file system errors

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
@@ -213,9 +213,14 @@ class DownloadFileThread extends Thread {
                             logger.error("The filename " + saveAs.getName() + " is to long to be saved on this file system.");
                             logger.info("Shortening filename");
                             String[] saveAsSplit = saveAs.getName().split("\\.");
+                            // Get the file extension so when we shorten the file name we don't cut off the file extension
                             String fileExt = saveAsSplit[saveAsSplit.length - 1];
+                            // The max limit for filenames on Linux with Ext3/4 is 255 bytes, on windows it's 256 chars so rather than
+                            // bother with code with both platforms we just cut the file name down to 254 chars
                             logger.info(saveAs.getName().substring(0, 254 - fileExt.length()) + fileExt);
                             String filename = saveAs.getName().substring(0, 254 - fileExt.length()) + "." + fileExt;
+                            // We can't just use the new file name as the saveAs because the file name doesn't include the
+                            // users save path, so we get the user save path from the old saveAs
                             saveAs = new File(saveAs.getParentFile().getAbsolutePath() + "/" + filename);
                             fos = new FileOutputStream(saveAs);
                         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -252,11 +252,6 @@ public class RedditRipper extends AlbumRipper {
                 addURLToDownload(parseRedditVideoMPD(urls.get(0).toExternalForm()), new File(savePath));
             }
             else {
-                // File names longer than this won't work on ext4 file systems
-                if (title.length() >= 235) {
-                    LOGGER.info("File name is more than 254 chars, shortening");
-                    title = title.substring(0,235);
-                }
                 addURLToDownload(urls.get(0), id + title, "", theUrl, null);
             }
         } else if (urls.size() > 1) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -252,6 +252,11 @@ public class RedditRipper extends AlbumRipper {
                 addURLToDownload(parseRedditVideoMPD(urls.get(0).toExternalForm()), new File(savePath));
             }
             else {
+                // File names longer than this won't work on ext4 file systems
+                if (title.length() >= 235) {
+                    LOGGER.info("File name is more than 254 chars, shortening");
+                    title = title.substring(0,235);
+                }
                 addURLToDownload(urls.get(0), id + title, "", theUrl, null);
             }
         } else if (urls.size() > 1) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #996)



# Description

If when creating a fileOutputStream ripme gets a "File name too long" error ripme will now shorten the file name to just under 255 bytes (The max file name length for ext file systems). 

This is a bit hackish ~~and assumes that the user is on Linux, with an Ext3 or 4 file system and is using UTF-8 encodings, if any of these things aren't true then the user will likely run into a File name too long even with these changes~~

After a bit of reading it looks like this should work on Windows as well


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
