### PR TITLE
Fix: #892 DeviantArt not ripping full sized images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.rarchives.ripme</groupId>
   <artifactId>ripme</artifactId>
   <packaging>jar</packaging>
-  <version>1.7.67</version>
+  <version>1.7.68-Q0-1.0.0</version>
   <name>ripme</name>
   <url>http://rip.rarchives.com</url>
   <properties>

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
@@ -267,6 +267,8 @@ public class DeviantartRipper extends AbstractJSONRipper {
             try {
                 String imageURL = doc.select("span").first().attr("data-super-full-img");
                 if (!imageURL.isEmpty() && imageURL.startsWith("http")) {
+                    String page = doc.select("span").first().attr("href");
+                    imageURL = smallToFull(imageURL,page);
                     imageURLs.add(imageURL);
                 }
             } catch (NullPointerException e) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X ] a bug fix (Fix #892)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

I've fixed and enabled the full size image download for Deviantart



# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors). - Additional Regression testing is needed.
* [ X] I've verified that this change works as intended.
  * [X ] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [ X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
