### PR TITLE
Thechive gif fix

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ThechiveRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ThechiveRipper.java
@@ -1,4 +1,3 @@
-
 package com.rarchives.ripme.ripper.rippers;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
@@ -17,7 +16,7 @@ import org.jsoup.nodes.Element;
 public class ThechiveRipper extends AbstractHTMLRipper {
 
     public ThechiveRipper(URL url) throws IOException {
-    super(url);
+        super(url);
     }
 
     @Override
@@ -38,8 +37,8 @@ public class ThechiveRipper extends AbstractHTMLRipper {
             boolean isTag = false;
             return m.group(1);
         }
-        throw new MalformedURLException("Expected thechive.com URL format: " +
-                        "thechive.com/YEAR/MONTH/DAY/POSTTITLE/ - got " + url + " instead");
+        throw new MalformedURLException("Expected thechive.com URL format: "
+                + "thechive.com/YEAR/MONTH/DAY/POSTTITLE/ - got " + url + " instead");
     }
 
     @Override
@@ -52,11 +51,19 @@ public class ThechiveRipper extends AbstractHTMLRipper {
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         for (Element el : doc.select("img.attachment-gallery-item-full")) {
-            String imageSource = el.attr("src");
+            String imageSource;
+            if (el.attr("data-gifsrc").isEmpty()) { //If it's not a gif
+                imageSource = el.attr("src");
+            } else { //If it is a gif
+                imageSource = el.attr("data-gifsrc") //from data-gifsrc attribute
+                        .replaceAll("\\?w=\\d{3}", ""); //remove the width modifier at the end to get highest resolution
+                //May need to replace the regex's {3} later on if website starts giving higher-res photos by default.
+            }
+
             // We replace thumbs with resizes so we can the full sized images
             imageSource = imageSource.replace("thumbs", "resizes");
             result.add(imageSource);
-                }
+        }
         return result;
     }
 
@@ -64,6 +71,5 @@ public class ThechiveRipper extends AbstractHTMLRipper {
     public void downloadURL(URL url, int index) {
         addURLToDownload(url, getPrefix(index));
     }
-
 
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ThechiveRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ThechiveRipperTest.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Kevin Jiang <kevin51jiang (at) email.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import com.rarchives.ripme.ripper.rippers.ThechiveRipper;
+import java.io.IOException;
+import java.net.URL;
+import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Tag;
+
+/**
+ *
+ * @author Kevin Jiang <kevin51jiang (at) email.com>
+ */
+public class ThechiveRipperTest extends RippersTest {
+
+    /**
+     * Tests general ripping for The Chive
+     *
+     * @throws IOException
+     */
+    public void theChiveRip() throws IOException {
+        ThechiveRipper ripper = new ThechiveRipper(new URL("https://thechive.com/2018/10/03/the-definitive-list-of-the-hottest-horror-movie-babes/"));
+        testRipper(ripper);
+    }
+
+    /*
+    
+    //If anyone figures out how to get JSOUP Elements mocked up, we can use the following methods to test both jpeg + gif ripping.
+    
+    public void testGifRip() throws IOException {
+        String elementInString = "<img width=\"500\" height=\"305\" \n"
+                + "src=\"https://thechive.files.wordpress.com/2018/10/american_mary_crimson_quill-111.jpg?quality=85&amp;strip=info\" \n"
+                + "class=\"attachment-gallery-item-full size-gallery-item-full gif-animate\" \n"
+                + "alt=\"american mary crimson quill 111 The hottest horror movie villains ever according to science (18 Photos)\" \n"
+                + "title=\"\" data-gifsrc=\"https://thechive.files.wordpress.com/2018/10/american_mary_crimson_quill-1.gif?w=500\">"
+        
+        Element el = new Element(
+                new Tag("img"),
+                "",//URI
+                new Attributes());
+        String URL = ThechiveRipper.getImageSource(el);
+        assertTrue(URL.equals("https://thechive.files.wordpress.com/2018/10/american_mary_crimson_quill-1.gif"));
+    }
+
+    public void testGifRip() throws IOException {
+        String elementInString = "<img width=\"600\" height=\"409\" src=\"https://thechive.files.wordpress.com/2018/10/the-definitive-list-of-the-hottest-horror-movie-babes-11.jpg?quality=85&amp;strip=info&amp;w=600\" \n"
+                + "class=\"attachment-gallery-item-full size-gallery-item-full\" \n"
+                + "alt=\"the definitive list of the hottest horror movie babes 11 The hottest horror movie villains ever according to science (18 Photos)\" title=\"\">";
+        Element el = new Element(
+                new Tag("img"),
+                "",//URI
+                new Attributes());
+        String URL = ThechiveRipper.getImageSource(el);
+        assertTrue(URL.equals("https://thechive.files.wordpress.com/2018/10/the-definitive-list-of-the-hottest-horror-movie-babes-11.jpg"));
+    }
+     */
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #997 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Changed it so that it will download images from `data-gifsrc` if possible.

# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
