### PR TITLE
Users can now add chan site by adding a line in the config

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -117,7 +117,9 @@ public class ChanRipper extends AbstractHTMLRipper {
     @Override
     public boolean canRip(URL url) {
         explicit_domains.addAll(bakedin_explicit_domains);
-        explicit_domains.addAll(user_give_explicit_domains);
+        if (user_give_explicit_domains != null) {
+            explicit_domains.addAll(user_give_explicit_domains);
+        }
         for (ChanSite _chanSite : explicit_domains) {
             if (_chanSite.domains.contains(url.getHost())) {
                 return true;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ripperhelpers/ChanSite.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ripperhelpers/ChanSite.java
@@ -57,4 +57,11 @@ public class ChanSite {
         domains = Domains;
         cdnDomains = Domains;
     }
+    public List<String> getDomains() {
+        return domains;
+    }
+
+    public List<String> getCdns() {
+        return cdnDomains;
+    }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ChanRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ChanRipperTest.java
@@ -4,9 +4,11 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.rarchives.ripme.ripper.rippers.ChanRipper;
+import com.rarchives.ripme.ripper.rippers.ripperhelpers.ChanSite;
 import com.rarchives.ripme.utils.Http;
 import org.jsoup.nodes.Document;
 
@@ -40,6 +42,21 @@ public class ChanRipperTest extends RippersTest {
                           ripper.getWorkingDir());
             deleteDir(ripper.getWorkingDir());
         }
+    }
+
+    public void testChanStringParsing() throws IOException {
+        List<String> site1 = Arrays.asList("site1.com");
+        List<String> site1Cdns = Arrays.asList("cnd1.site1.com", "cdn2.site2.biz");
+
+        List<String> site2 = Arrays.asList("site2.co.uk");
+        List<String> site2Cdns = Arrays.asList("cdn.site2.co.uk");
+        ChanRipper ripper = new ChanRipper(new URL("http://desuchan.net/v/res/7034.html"));
+        List<ChanSite> chansFromConfig = ripper.getChansFromConfig("site1.com[cnd1.site1.com|cdn2.site2.biz],site2.co.uk[cdn.site2.co.uk]");
+        assertEquals(chansFromConfig.get(0).getDomains(), site1);
+        assertEquals(chansFromConfig.get(0).getCdns(), site1Cdns);
+
+        assertEquals(chansFromConfig.get(1).getDomains(), site2);
+        assertEquals(chansFromConfig.get(1).getCdns(), site2Cdns);
     }
 
     public void testChanRipper() throws IOException {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1005)



# Description

Users can now add new chan sites to ripme by editing/adding the chans.chan_sites config value.

The format for this value is "site.domain([sitecdn.domain|sitecdn2.domain})"

Examples

For 4chan you'd add "boards.4chan.org[4cdn.org|is.4chan.org|is2.4chan.org|is3.4chan.org]"

For desuchan you'd add "desuchan.net" leaving out the [] because desuchan.net doesn't have any cdn domains

To add both 4chan and desuchan.net you'd add "boards.4chan.org[4cdn.org|is.4chan.org|is2.4chan.org|is3.4chan.org],desuchan.net"

This PR is currently lacking a unit test, which it needs before it can be merged


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
