### PR TITLE
Update e621 ripper to pull videos, flash files, and fullsize images

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/E621Ripper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/E621Ripper.java
@@ -56,7 +56,19 @@ public class E621Ripper extends AbstractHTMLRipper{
 
 	private String getFullSizedImage(String url) {
 	    try {
-            return Http.url("https://e621.net" + url).get().select("div > img#image").attr("src");
+                Document page = Http.url("https://e621.net" + url).get();
+                Elements video = page.select("video > source");
+                Elements flash = page.select("embed");
+                Elements image = page.select("a#highres");
+                if (video.size() > 0) {
+                    return video.attr("src");
+                } else if (flash.size() > 0) {
+                    return flash.attr("src");
+                } else if (image.size() > 0) {
+                    return image.attr("href");
+                } else {
+                    throw new IOException();
+                }
         } catch (IOException e) {
 	        logger.error("Unable to get full sized image from " + url);
 	        return null;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Previous version was only pulling sample images, and ignoring any videos or flash files. Now it looks for a video, then a flash, then the image link, as pulled from the fullsize link in the sidebar.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
