### PR TITLE
history.end_rip_after_already_seen now works even if remember.url_his…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -96,6 +96,7 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
         }
 
         while (doc != null) {
+            LOGGER.info("AHR: alreadyDownloadedUrls = " + alreadyDownloadedUrls + " history.end_rip_after_already_seen = " + Utils.getConfigInteger("history.end_rip_after_already_seen", 1000000000));
             if (alreadyDownloadedUrls >= Utils.getConfigInteger("history.end_rip_after_already_seen", 1000000000) && !isThisATest()) {
                 sendUpdate(STATUS.DOWNLOAD_COMPLETE_HISTORY, "Already seen the last " + alreadyDownloadedUrls + " images ending rip");
                 break;

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -46,7 +46,7 @@ public abstract class AbstractRipper
     public abstract String getGID(URL url) throws MalformedURLException;
     public boolean hasASAPRipping() { return false; }
     // Everytime addUrlToDownload skips a already downloaded url this increases by 1
-    public int alreadyDownloadedUrls = 0;
+    public static int alreadyDownloadedUrls = 0;
     private boolean shouldStop = false;
     private static boolean thisIsATest = false;
 

--- a/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
@@ -82,6 +82,8 @@ class DownloadFileThread extends Thread {
         }
         if (saveAs.exists() && !observer.tryResumeDownload() && !getFileExtFromMIME ||
                 Utils.fuzzyExists(new File(saveAs.getParent()), saveAs.getName()) && getFileExtFromMIME && !observer.tryResumeDownload()) {
+            AbstractRipper.alreadyDownloadedUrls += 1;
+            logger.info("alreadyDownloadedUrls = " + AbstractRipper.alreadyDownloadedUrls);
             if (Utils.getConfigBoolean("file.overwrite", false)) {
                 logger.info("[!] " + rb.getString("deleting.existing.file") + prettySaveAs);
                 saveAs.delete();
@@ -217,7 +219,6 @@ class DownloadFileThread extends Thread {
                             String fileExt = saveAsSplit[saveAsSplit.length - 1];
                             // The max limit for filenames on Linux with Ext3/4 is 255 bytes, on windows it's 256 chars so rather than
                             // bother with code with both platforms we just cut the file name down to 254 chars
-                            logger.info(saveAs.getName().substring(0, 254 - fileExt.length()) + fileExt);
                             String filename = saveAs.getName().substring(0, 254 - fileExt.length()) + "." + fileExt;
                             // We can't just use the new file name as the saveAs because the file name doesn't include the
                             // users save path, so we get the user save path from the old saveAs


### PR DESCRIPTION
…tory is false

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1013)



# Description

I added line in DownloadFileThread.java that check if the file being downloaded exists on disk and if so adds 1 to alreadyDownloadedUrls

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
