### PR TITLE
Added ripper for Mangadex.org

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MangadexRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MangadexRipper.java
@@ -51,7 +51,7 @@ public class MangadexRipper extends AbstractJSONRipper {
     }
 
     private String getChapterID(String url) {
-        Pattern p = Pattern.compile("https://mangadex.org/chapter/([\\d]+)");
+        Pattern p = Pattern.compile("https://mangadex.org/chapter/([\\d]+)/?");
         Matcher m = p.matcher(url);
         if (m.matches()) {
             return m.group(1);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MangadexRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MangadexRipper.java
@@ -1,0 +1,92 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractJSONRipper;
+import com.rarchives.ripme.utils.Http;
+import com.rarchives.ripme.utils.Utils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.jsoup.Connection;
+import org.jsoup.nodes.Document;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class MangadexRipper extends AbstractJSONRipper {
+    private String chapterApiEndPoint = "https://mangadex.org/api/chapter/";
+
+    private String getImageUrl(String chapterHash, String imageName) {
+        return "https://mangadex.org/data/" + chapterHash + "/" + imageName;
+    }
+
+    public MangadexRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "mangadex";
+    }
+    @Override
+    public String getDomain() {
+        return "mangadex.org";
+    }
+
+    @Override
+    public boolean canRip(URL url) {
+        return (url.getHost().endsWith("mangadex.org"));
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        String capID = getChapterID(url.toExternalForm());
+        if (capID != null) {
+            return capID;
+        }
+        throw new MalformedURLException("Unable to get chapter ID from" + url);
+    }
+
+    private String getChapterID(String url) {
+        Pattern p = Pattern.compile("https://mangadex.org/chapter/([\\d]+)");
+        Matcher m = p.matcher(url);
+        if (m.matches()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+    @Override
+    public JSONObject getFirstPage() throws IOException {
+        // Get the chapter ID
+        String chapterID = getChapterID(url.toExternalForm());
+        return Http.url(new URL(chapterApiEndPoint + chapterID)).getJSON();
+    }
+
+    @Override
+    protected List<String> getURLsFromJSON(JSONObject json) {
+        List<String> assetURLs = new ArrayList<>();
+        JSONArray currentObject;
+
+        String chapterHash = json.getString("hash");
+
+        for (int i = 0; i < json.getJSONArray("page_array").length(); i++) {
+            currentObject = json.getJSONArray("page_array");
+
+            assetURLs.add(getImageUrl(chapterHash, currentObject.getString(i)));
+        }
+
+        return assetURLs;
+    }
+
+    @Override
+    protected void downloadURL(URL url, int index) {
+        // mangadex does not like rippers one bit, so we wait a good long while between requests
+        sleep(1000);
+        addURLToDownload(url, getPrefix(index));
+    }
+
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MangadexRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MangadexRipperTest.java
@@ -1,0 +1,15 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+
+import com.rarchives.ripme.ripper.rippers.MangadexRipper;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class MangadexRipperTest extends RippersTest{
+    public void testRip() throws IOException {
+        MangadexRipper ripper = new MangadexRipper(new URL("https://mangadex.org/chapter/467904/"));
+        testRipper(ripper);
+    }
+
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [x] a new Ripper


# Description

A ripper for Mangadex.org. Currently only chapters are supported


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
