### PR TITLE
Duckmovies frontend ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
@@ -1,0 +1,88 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
+import com.rarchives.ripme.utils.Http;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DuckmoviesRipper extends AbstractSingleFileRipper {
+    public DuckmoviesRipper(URL url) throws IOException {
+        super(url);
+    }
+
+
+    private static List<String> explicit_domains = Arrays.asList(
+            "vidporntube.fun",
+            "pornbj.fun"
+    );
+
+    @Override
+    public String getHost() {
+        return url.toExternalForm().split("/")[2];
+    }
+
+    @Override
+    public String getDomain() {
+        return url.toExternalForm().split("/")[2];
+    }
+
+    @Override
+    public boolean canRip(URL url) {
+        String url_name = url.toExternalForm();
+        return explicit_domains.contains(url_name.split("/")[2]);
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        return Http.url(this.url).get();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> results = new ArrayList<>();
+        String duckMoviesUrl = doc.select("iframe").attr("src");
+        try {
+            Document duckDoc = Http.url(new URL(duckMoviesUrl)).get();
+            String videoURL = duckDoc.select("source").attr("src");
+            // remove any white spaces so we can download the movie without a 400 error
+            videoURL = videoURL.replaceAll(" ", "%20");
+            results.add(videoURL);
+        } catch (MalformedURLException e) {
+            LOGGER.error(duckMoviesUrl + " is not a valid url");
+        } catch (IOException e) {
+            LOGGER.error("Unable to load page " + duckMoviesUrl);
+            e.printStackTrace();
+        }
+        return results;
+    }
+
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https://[a-zA-Z0-9]+.fun/([a-zA-Z0-9\\-_]+)/?");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+
+        throw new MalformedURLException(
+                "Expected duckmovies format:"
+                        + "domain.tld/Video-title"
+                        + " Got: " + url);
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
@@ -23,8 +23,16 @@ public class DuckmoviesRipper extends AbstractSingleFileRipper {
 
     private static List<String> explicit_domains = Arrays.asList(
             "vidporntube.fun",
-            "pornbj.fun"
-    );
+            "pornbj.fun",
+            "iwantporn.fun",
+            "neoporn.fun",
+            "yayporn.fun",
+            "freshporn.co",
+            "palapaja.stream",
+            "freshporn.co",
+            "pornvidx.fun",
+            "palapaja.com"
+            );
 
     @Override
     public String getHost() {
@@ -69,7 +77,7 @@ public class DuckmoviesRipper extends AbstractSingleFileRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("https://[a-zA-Z0-9]+.fun/([a-zA-Z0-9\\-_]+)/?");
+        Pattern p = Pattern.compile("https://[a-zA-Z0-9]+\\.[a-zA-Z]+/([a-zA-Z0-9\\-_]+)/?");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);
@@ -85,4 +93,7 @@ public class DuckmoviesRipper extends AbstractSingleFileRipper {
     public void downloadURL(URL url, int index) {
         addURLToDownload(url, getPrefix(index));
     }
+
+    @Override
+    public boolean tryResumeDownload() {return true;}
 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
@@ -1,5 +1,6 @@
 package com.rarchives.ripme.ripper.rippers;
 
+import com.rarchives.ripme.ripper.AbstractRipper;
 import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
 import com.rarchives.ripme.utils.Http;
 import org.jsoup.nodes.Document;
@@ -130,7 +131,7 @@ public class DuckmoviesRipper extends AbstractSingleFileRipper {
 
     @Override
     public void downloadURL(URL url, int index) {
-        addURLToDownload(url, getPrefix(index));
+        addURLToDownload(url, "", "", null, null, AbstractRipper.getFileName(url, null, null).replaceAll("%20", "_"));
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
@@ -27,14 +27,17 @@ public class DuckmoviesRipper extends AbstractSingleFileRipper {
 
     @Override
     public boolean pageContainsAlbums(URL url) {
-        Pattern pa = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/models/([a-zA-Z0-9_-])+/?");
+        Pattern pa = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/(models|category)/([a-zA-Z0-9_-])+/?");
         Matcher ma = pa.matcher(url.toExternalForm());
         if (ma.matches()) {
             return true;
         }
-        pa = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/models/([a-zA-Z0-9_-])+/page/\\d+/?");
+        pa = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/(models|category)/([a-zA-Z0-9_-])+/page/\\d+/?");
         ma = pa.matcher(url.toExternalForm());
-        return ma.matches();
+        if (ma.matches()) {
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -108,12 +111,12 @@ public class DuckmoviesRipper extends AbstractSingleFileRipper {
         if (m.matches()) {
             return m.group(1);
         }
-        p = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/models/([a-zA-Z0-9_-])+/?");
+        p = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/(category|models)/([a-zA-Z0-9_-])+/?");
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);
         }
-        p = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/models/([a-zA-Z0-9_-])+/page/\\d+");
+        p = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/(category|models)/([a-zA-Z0-9_-])+/page/\\d+");
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
@@ -20,6 +20,27 @@ public class DuckmoviesRipper extends AbstractSingleFileRipper {
         super(url);
     }
 
+    @Override
+    public boolean hasQueueSupport() {
+        return true;
+    }
+
+    @Override
+    public boolean pageContainsAlbums(URL url) {
+        Pattern pa = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/models/([a-zA-Z0-9_-])+/?");
+        Matcher ma = pa.matcher(url.toExternalForm());
+        return ma.matches();
+    }
+
+    @Override
+    public List<String> getAlbumsToQueue(Document doc) {
+        List<String> urlsToAddToQueue = new ArrayList<>();
+        for (Element elem : doc.select(".post > li > div > div > a")) {
+            urlsToAddToQueue.add(elem.attr("href"));
+        }
+        return urlsToAddToQueue;
+    }
+
 
     private static List<String> explicit_domains = Arrays.asList(
             "vidporntube.fun",
@@ -79,6 +100,11 @@ public class DuckmoviesRipper extends AbstractSingleFileRipper {
     public String getGID(URL url) throws MalformedURLException {
         Pattern p = Pattern.compile("https://[a-zA-Z0-9]+\\.[a-zA-Z]+/([a-zA-Z0-9\\-_]+)/?");
         Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        p = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/models/([a-zA-Z0-9_-])+/?");
+        m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);
         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DuckmoviesRipper.java
@@ -29,6 +29,11 @@ public class DuckmoviesRipper extends AbstractSingleFileRipper {
     public boolean pageContainsAlbums(URL url) {
         Pattern pa = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/models/([a-zA-Z0-9_-])+/?");
         Matcher ma = pa.matcher(url.toExternalForm());
+        if (ma.matches()) {
+            return true;
+        }
+        pa = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/models/([a-zA-Z0-9_-])+/page/\\d+/?");
+        ma = pa.matcher(url.toExternalForm());
         return ma.matches();
     }
 
@@ -104,6 +109,11 @@ public class DuckmoviesRipper extends AbstractSingleFileRipper {
             return m.group(1);
         }
         p = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/models/([a-zA-Z0-9_-])+/?");
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        p = Pattern.compile("https?://[a-zA-Z0-9]+.[a-zA-Z]+/models/([a-zA-Z0-9_-])+/page/\\d+");
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DuckmoviesRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DuckmoviesRipperTest.java
@@ -1,0 +1,15 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import com.rarchives.ripme.ripper.rippers.DuckmoviesRipper;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class DuckmoviesRipperTest extends RippersTest{
+
+    public void testRip() throws IOException {
+        DuckmoviesRipper ripper = new DuckmoviesRipper(new URL("https://palapaja.com/spyfam-stepbro-gives-in-to-stepsis-asian-persuasion/"));
+        testRipper(ripper);
+    }
+
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:

* [x] a new Ripper



# Description

Added a ripper that supports 

https://vidporntube.fun/
https://pornbj.fun/
https://iwantporn.fun/
https://neoporn.fun/
https://yayporn.fun/
https://freshporn.co/
https://palapaja.stream/
https://freshporn.co/
https://pornvidx.fun/
https://palapaja.com/

Which all seem to be front ends for the same site


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
