### PR TITLE
Updater now works on java 9 and 10

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -198,7 +198,7 @@ public class UpdateUtils {
     }
 
     // Code take from https://stackoverflow.com/a/30925550
-    private static String createSha256(File file)  {
+    public static String createSha256(File file)  {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             InputStream fis = new FileInputStream(file);
@@ -210,8 +210,14 @@ public class UpdateUtils {
                     digest.update(buffer, 0, n);
                 }
             }
+            byte[] hash = digest.digest();
+            StringBuilder sb = new StringBuilder(2 * hash.length);
+            for (byte b : hash) {
+                sb.append("0123456789ABCDEF".charAt((b & 0xF0) >> 4));
+                sb.append("0123456789ABCDEF".charAt((b & 0x0F)));
+            }
             // As patch.py writes the hash in lowercase this must return the has in lowercase
-            return new HexBinaryAdapter().marshal(digest.digest()).toLowerCase();
+            return sb.toString().toLowerCase();
         } catch (NoSuchAlgorithmException e) {
             logger.error("Got error getting file hash " + e.getMessage());
         } catch (FileNotFoundException e) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1017)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Now uses a loop to get the string sha256 hash instead of HexBinaryAdapter (Which is not a default part of java 9 or 10)


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
