### PR TITLE
Fixed mangadex ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MangadexRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MangadexRipper.java
@@ -19,8 +19,8 @@ import java.util.regex.Pattern;
 public class MangadexRipper extends AbstractJSONRipper {
     private String chapterApiEndPoint = "https://mangadex.org/api/chapter/";
 
-    private String getImageUrl(String chapterHash, String imageName) {
-        return "https://mangadex.org/data/" + chapterHash + "/" + imageName;
+    private String getImageUrl(String chapterHash, String imageName, String server) {
+        return server + chapterHash + "/" + imageName;
     }
 
     public MangadexRipper(URL url) throws IOException {
@@ -72,11 +72,13 @@ public class MangadexRipper extends AbstractJSONRipper {
         JSONArray currentObject;
 
         String chapterHash = json.getString("hash");
+        // Server is the cdn hosting the images.
+        String server = json.getString("server");
 
         for (int i = 0; i < json.getJSONArray("page_array").length(); i++) {
             currentObject = json.getJSONArray("page_array");
 
-            assetURLs.add(getImageUrl(chapterHash, currentObject.getString(i)));
+            assetURLs.add(getImageUrl(chapterHash, currentObject.getString(i), server));
         }
 
         return assetURLs;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1035)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Now downloads image from the cdns


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
