### PR TITLE
Fixed issue #968

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -563,10 +563,6 @@ public abstract class AbstractRipper
             LOGGER.error("Got exception while running ripper:", e);
             waitForThreads();
             sendUpdate(STATUS.RIP_ERRORED, "HTTP status code " + e.getStatusCode() + " for URL " + e.getUrl());
-        }catch(NullPointerException e){
-            LOGGER.error("Got null pointer exception while running ripper:", e);
-            waitForThreads();
-            sendUpdate(STATUS.NO_ALBUM_OR_USER, "Album or user doesn't exist!");
         } catch (Exception e) {
             LOGGER.error("Got exception while running ripper:", e);
             waitForThreads();

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -563,6 +563,10 @@ public abstract class AbstractRipper
             LOGGER.error("Got exception while running ripper:", e);
             waitForThreads();
             sendUpdate(STATUS.RIP_ERRORED, "HTTP status code " + e.getStatusCode() + " for URL " + e.getUrl());
+        }catch(NullPointerException e){
+            LOGGER.error("Got null pointer exception while running ripper:", e);
+            waitForThreads();
+            sendUpdate(STATUS.NO_ALBUM_OR_USER, "Album or user doesn't exist!");
         } catch (Exception e) {
             LOGGER.error("Got exception while running ripper:", e);
             waitForThreads();

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -171,6 +171,10 @@ public class TumblrRipper extends AlbumRipper {
                         HttpStatusException status = (HttpStatusException)cause;
                         if (status.getStatusCode() == HttpURLConnection.HTTP_UNAUTHORIZED && !useDefaultApiKey) {
                             retry = true;
+                        } else if (status.getStatusCode() == 404) {
+                            LOGGER.error("No user or album found!");
+                            sendUpdate(STATUS.NO_ALBUM_OR_USER, "Album or user doesn't exist!");
+                            break;
                         } else if (status.getStatusCode() == 429) {
                             LOGGER.error("Tumblr rate limit has been exceeded");
                             sendUpdate(STATUS.DOWNLOAD_ERRORED,"Tumblr rate limit has been exceeded");

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1404,6 +1404,17 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         case TOTAL_BYTES:
             // Update total bytes
             break;
+        case NO_ALBUM_OR_USER:
+            if (LOGGER.isEnabledFor(Level.ERROR)) {
+                appendLog((String) msg.getObject(), Color.RED);
+            }
+            stopButton.setEnabled(false);
+            statusProgress.setValue(0);
+            statusProgress.setVisible(false);
+            openButton.setVisible(false);
+            pack();
+            statusWithColor("Error: " + msg.getObject(), Color.RED);
+            break;
         }
     }
 

--- a/src/main/java/com/rarchives/ripme/ui/RipStatusMessage.java
+++ b/src/main/java/com/rarchives/ripme/ui/RipStatusMessage.java
@@ -15,7 +15,8 @@ public class RipStatusMessage {
         DOWNLOAD_WARN("Download problem"),
         TOTAL_BYTES("Total bytes"),
         COMPLETED_BYTES("Completed bytes"),
-        RIP_ERRORED("Rip Errored");
+        RIP_ERRORED("Rip Errored"),
+        NO_ALBUM_OR_USER("No album or user");
 
         String value;
         STATUS(String value) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fixed problem with showing message when ripping album or user which does not exist.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
