### PR TITLE
Added support for hqporner videos hosted on flyflv

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HqpornerRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HqpornerRipper.java
@@ -39,6 +39,26 @@ public class HqpornerRipper extends AbstractSingleFileRipper {
             return null;
         }
 
+        private String getVideoFromFlyFlv(String url) {
+            try {
+                logger.info("Downloading " + url);
+                Document page = Http.url(url).referrer(url).get();
+                String[] videoSizes = { "1080p","720p","360p"};
+                for (String videoSize : videoSizes) {
+                    String urlToReturn = page.select("video > source[label=" + videoSize).attr("src");
+                    if (urlToReturn != null && !urlToReturn.equals("")) {
+                        return urlToReturn;
+                    }
+                }
+
+
+
+            } catch (IOException e) {
+                logger.error("Unable to get page with video");
+            }
+            return null;
+        }
+
         private String getVideoName() {
             try {
                 String filename = getGID(url);
@@ -77,8 +97,19 @@ public class HqpornerRipper extends AbstractSingleFileRipper {
 
         @Override
         public List<String> getURLsFromPage(Document doc) {
+            String videoUrl = null;
             List<String> result = new ArrayList<>();
-            result.add("https:" + getVideoFromMyDaddycc("https:" + doc.select("div.videoWrapper > iframe").attr("src")));
+            String videoPageUrl = "https:" + doc.select("div.videoWrapper > iframe").attr("src");
+
+            if (videoPageUrl.contains("mydaddy")) {
+                videoUrl = getVideoFromMyDaddycc(videoPageUrl);
+            } else if (videoPageUrl.contains("flyflv")) {
+                videoUrl = getVideoFromFlyFlv(videoPageUrl);
+            }
+
+            if (videoUrl != null) {
+                result.add("https:" + videoUrl);
+            }
             return result;
         }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


# Description

The hqporner ripper can now rip video hosted on mydaddy.cc and flyflv.com


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
