### PR TITLE
Update userRegex, fixes #1063

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FlickrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FlickrRipper.java
@@ -129,7 +129,7 @@ public class FlickrRipper extends AbstractHTMLRipper {
         // Album: https://www.flickr.com/photos/115858035@N04/sets/72157644042355643/
 
         final String domainRegex = "https?://[wm.]*flickr.com";
-        final String userRegex = "[a-zA-Z0-9@]+";
+        final String userRegex = "[a-zA-Z0-9@_-]+";
         // Album
         p = Pattern.compile("^" + domainRegex + "/photos/(" + userRegex + ")/(sets|albums)/([0-9]+)/?.*$");
         m = p.matcher(url);
@@ -168,7 +168,7 @@ public class FlickrRipper extends AbstractHTMLRipper {
         // Album: https://www.flickr.com/photos/115858035@N04/sets/72157644042355643/
 
         final String domainRegex = "https?://[wm.]*flickr.com";
-        final String userRegex = "[a-zA-Z0-9@]+";
+        final String userRegex = "[a-zA-Z0-9@_-]+";
         // Album
         p = Pattern.compile("^" + domainRegex + "/photos/(" + userRegex + ")/sets/([0-9]+)/?.*$");
         m = p.matcher(url.toExternalForm());


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1063 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Added the two unsupported symbols to the regex.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
  I didn't, but I noticed the relevant test was still disabled and re-enabled it. I didn't add this change since you closed #243 just recently and I don't know if it's intentional.