### PR TITLE
Fixed minor issue where if a user didn't exist tumblr ripper would ou…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -130,7 +130,8 @@ public class TumblrRipper extends AlbumRipper {
     @Override
     public void rip() throws IOException {
         String[] mediaTypes;
-        boolean exceededRateLimit = false;
+        // If true the rip loop won't be run
+        boolean shouldStopRipping = false;
         if (albumType == ALBUM_TYPE.POST) {
             mediaTypes = new String[] { "post" };
         } else {
@@ -142,7 +143,7 @@ public class TumblrRipper extends AlbumRipper {
                 break;
             }
 
-            if (exceededRateLimit) {
+            if (shouldStopRipping) {
                 break;
             }
             offset = 0;
@@ -151,7 +152,7 @@ public class TumblrRipper extends AlbumRipper {
                     break;
                 }
 
-                if (exceededRateLimit) {
+                if (shouldStopRipping) {
                     break;
                 }
 
@@ -174,11 +175,12 @@ public class TumblrRipper extends AlbumRipper {
                         } else if (status.getStatusCode() == 404) {
                             LOGGER.error("No user or album found!");
                             sendUpdate(STATUS.NO_ALBUM_OR_USER, "Album or user doesn't exist!");
+                            shouldStopRipping = true;
                             break;
                         } else if (status.getStatusCode() == 429) {
                             LOGGER.error("Tumblr rate limit has been exceeded");
                             sendUpdate(STATUS.DOWNLOAD_ERRORED,"Tumblr rate limit has been exceeded");
-                            exceededRateLimit = true;
+                            shouldStopRipping = true;
                             break;
                         }
                     }


### PR DESCRIPTION
…tput error message twice

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fixes a minor bug what caused the message "Album or user doesn't exist!" to be outputed twice if a tumble album or user didn't exist


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
