### PR TITLE
Fixed ManganeloRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ManganeloRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ManganeloRipper.java
@@ -39,7 +39,7 @@ public class ManganeloRipper extends AbstractHTMLRipper {
             return m.group(1);
         }
 
-        p = Pattern.compile("http://manganelo.com/chapter/([\\S]+)/([\\S]+)/?$");
+        p = Pattern.compile("https?://manganelo.com/chapter/([\\S]+)/([\\S_\\-]+)/?$");
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);
@@ -65,14 +65,11 @@ public class ManganeloRipper extends AbstractHTMLRipper {
     }
 
     private List<String> getURLsFromChap(String url) {
-        LOGGER.debug("Getting urls from " + url);
         List<String> result = new ArrayList<>();
         try {
             Document doc = Http.url(url).get();
-            for (Element el : doc.select("img.img_content")) {
-                result.add(el.attr("src"));
-            }
-            return result;
+
+            return getURLsFromChap(doc);
         } catch (IOException e) {
             return null;
         }
@@ -80,9 +77,9 @@ public class ManganeloRipper extends AbstractHTMLRipper {
     }
 
     private List<String> getURLsFromChap(Document doc) {
-        LOGGER.debug("Getting urls from " + url);
+        LOGGER.debug("Getting urls from " + doc.location());
         List<String> result = new ArrayList<>();
-        for (Element el : doc.select("img.img_content")) {
+        for (Element el : doc.select(".vung-doc > img")) {
             result.add(el.attr("src"));
         }
         return result;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1070)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Change the css parsing so the ripper can now find the images to rip


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
