### PR TITLE
Fix issue with Photobucket downloads containing watermark.

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PhotobucketRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PhotobucketRipperTest.java
@@ -26,18 +26,9 @@ public class PhotobucketRipperTest extends RippersTest {
         String baseURL = "http://s1255.photobucket.com/user/mimajki/library/Movie%20gifs?sort=6&page=1";
         URL url = new URL(baseURL);
         PhotobucketRipper ripper = new PhotobucketRipper(url);
-        org.jsoup.nodes.Document page = null;
-        try {
-            // I'm not sure it makes much sense that getFirstPage()
-            // is not public while getNextPage() is.
-            java.lang.reflect.Method method = ripper.getClass()
-                                                    .getDeclaredMethod("getFirstPage");
-            method.setAccessible(true);
-            page = (org.jsoup.nodes.Document) method.invoke(ripper);
-        } catch (Exception e){
-            e.printStackTrace();
-            fail("Calling getFirstPage() failed");
-        }
+        org.jsoup.nodes.Document page = ripper.getFirstPage();
+        // NOTE: number of pages remaining includes the subalbums
+        // of the current album
         int numPagesRemaining = 38;
         for (int idx = 0; idx < numPagesRemaining; idx++){
             page = ripper.getNextPage(page);


### PR DESCRIPTION
Also make getFirstPage() public, if getNextPage() already is
(and it is used in the commented-out unit test).

Also minor style fixes.

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1067)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fixed #1067 caused by not passing referrer and cookies to addURLToDownload() method.

Also some other (mostly style) fixes.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
- Well... TubeX6Ripper did fail both in the CI build and when running `mvn test` locally. I haven't found an issue about it, but as it is completely independent from Photobucket ripper, it's probably unrelated to these changes.
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

- The whole unit test for Photobucket ripper was uncommented when running `mvn test` locally. It was  successful.

Optional but recommended:
* [ ] I've added a unit test to cover my change.

