### PR TITLE
Remove HexBinaryAdapter import remnant.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -6,7 +6,6 @@ import java.security.NoSuchAlgorithmException;
 
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
-import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
 
 import org.apache.log4j.Logger;
 import org.json.JSONArray;


### PR DESCRIPTION
# Category

This change is exactly one of the following:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

The relevant code was changed back in #1032 (de773db4f4c60c85c4b54fe70c2ed996f3999a83) but the import line still remained in the code.
By removing that line I was able to compile with Java 11.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
```[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test (default-test) on project ripme:
Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test failed:
The forked VM terminated without saying properly goodbye. VM crash or System.exit called ? -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test (default-test) on project ripme:
Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.12.4:test failed:
The forked VM terminated without saying properly goodbye. VM crash or System.exit called ?
```
🤷