### PR TITLE
Fix erome ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
@@ -124,13 +124,28 @@ public class EromeRipper extends AbstractHTMLRipper {
     private List<String> getMediaFromPage(Document doc) {
         List<String> results = new ArrayList<>();
         for (Element el : doc.select("img.img-front")) {
-            results.add("https:" + el.attr("src"));
+            if (el.attr("src").startsWith("https:")) {
+                results.add(el.attr("src"));
+            }
+            else {
+                results.add("https:" + el.attr("src"));
+            }
         }
         for (Element el : doc.select("source[label=HD]")) {
-            results.add("https:" + el.attr("src"));
+            if (el.attr("src").startsWith("https:")) {
+                results.add(el.attr("src"));
+            }
+            else {
+                results.add("https:" + el.attr("src"));
+            }
         }
         for (Element el : doc.select("source[label=SD]")) {
-            results.add("https:" + el.attr("src"));
+            if (el.attr("src").startsWith("https:")) {
+                results.add(el.attr("src"));
+            }
+            else {
+                results.add("https:" + el.attr("src"));
+            }
         }
         return results;
     }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

In some cases the Erome ripper would grab urls with protocol ("https:") already in it, but it would try to re-add it anyways, resulting in a URL with a double protocol, eg. "https:https://s101.erome.com/..." which would then fail to download.



# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
