### PR TITLE
Hentaicafefixes

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiCafeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiCafeRipper.java
@@ -44,7 +44,12 @@ public class HentaiCafeRipper extends AbstractHTMLRipper {
         public Document getFirstPage() throws IOException {
             // "url" is an instance field of the superclass
             Document tempDoc = Http.url(url).get();
-            return Http.url(tempDoc.select("div.last > p > a.x-btn").attr("href")).get();
+            String firstPageUrl = tempDoc.select("div.last > p > a.x-btn").attr("href");
+            // workaround for https://github.com/RipMeApp/ripme/issues/1083
+            if (firstPageUrl.contains("<br />")) {
+                firstPageUrl = firstPageUrl.replaceAll("<br />", "");
+            }
+            return Http.url(firstPageUrl).get();
         }
 
         @Override

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaicafeRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaicafeRipperTest.java
@@ -10,4 +10,10 @@ public class HentaicafeRipperTest extends RippersTest {
         HentaiCafeRipper ripper = new HentaiCafeRipper(new URL("https://hentai.cafe/kikuta-the-oni-in-the-room/"));
         testRipper(ripper);
     }
+    // This album has a line break (<br />) in the url. Test it to make sure ripme can handle these invalid urls
+    public void testAlbumWithInvalidChars() throws IOException {
+        HentaiCafeRipper ripper = new HentaiCafeRipper(new URL("https://hentai.cafe/chobipero-club/"));
+        testRipper(ripper);
+
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1083)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Ripper now can handle urls with line breaks in them


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
