### PR TITLE
Added support for tumblr like pages; now respects download.save_order

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -240,7 +240,6 @@ public class TumblrRipper extends AlbumRipper {
 
         if (albumType == ALBUM_TYPE.LIKED) {
             posts = json.getJSONObject("response").getJSONArray("liked_posts");
-
         } else {
             posts = json.getJSONObject("response").getJSONArray("posts");
         }
@@ -373,6 +372,15 @@ public class TumblrRipper extends AlbumRipper {
         }
         // Likes url
         p = Pattern.compile("https?://([a-z0-9_-]+).tumblr.com/likes");
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            this.albumType = ALBUM_TYPE.LIKED;
+            this.subdomain = m.group(1);
+            return this.subdomain + "_liked";
+        }
+
+        // Likes url different format
+        p = Pattern.compile("https://www.tumblr.com/liked/by/([a-z0-9_-]+)");
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             this.albumType = ALBUM_TYPE.LIKED;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


# Description

The ripper now respects download.save_order and can rip from liked pages (USERNAME.tumblr.com/likes, https://www.tumblr.com/liked/by/USERNAME)


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
