### PR TITLE
Added a ripper for Xcartx.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XcartxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XcartxRipper.java
@@ -1,0 +1,74 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class XcartxRipper extends AbstractHTMLRipper {
+    private Map<String,String> cookies = new HashMap<>();
+
+
+    public XcartxRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "xcartx";
+    }
+    @Override
+    public String getDomain() {
+        return "xcartx.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https?://xcartx.com/([a-zA-Z0-9_\\-]+).html");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected URL format: http://xcartx.com/comic, got: " + url);
+
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        return Http.url(url).get();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document page) {
+        List<String> imageURLs = new ArrayList<>();
+        Elements albumElements = page.select("a.highslide");
+        for (Element imageBox : albumElements) {
+            String imageUrl = imageBox.attr("href");
+
+            imageURLs.add(imageUrl);
+        }
+        return imageURLs;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index), "", this.url.toExternalForm(), cookies);
+    }
+
+    @Override
+    public String getPrefix(int index) {
+        return String.format("%03d_", index);
+    }
+
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XcartxRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XcartxRipperTest.java
@@ -1,0 +1,14 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+
+import com.rarchives.ripme.ripper.rippers.XcartxRipper;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class XcartxRipperTest extends RippersTest {
+    public void testAlbum() throws IOException {
+        XcartxRipper ripper = new XcartxRipper(new URL("http://xcartx.com/4937-tokimeki-nioi.html"));
+        testRipper(ripper);
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Added a ripper and unit test for Xcartx.com


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
