### PR TITLE
Tumblr ripper now puts date in name of files when ripping from tags

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -250,6 +250,7 @@ public class TumblrRipper extends AlbumRipper {
 
         for (int i = 0; i < posts.length(); i++) {
             post = posts.getJSONObject(i);
+            String date = post.getString("date");
             if (post.has("photos")) {
                 photos = post.getJSONArray("photos");
                 for (int j = 0; j < photos.length(); j++) {
@@ -259,10 +260,10 @@ public class TumblrRipper extends AlbumRipper {
 
                         m = p.matcher(fileURL.toString());
                         if (m.matches()) {
-                            downloadURL(fileURL);
+                            downloadURL(fileURL, date);
                         } else {
                             URL redirectedURL = Http.url(fileURL).ignoreContentType().response().url();
-                            downloadURL(redirectedURL);
+                            downloadURL(redirectedURL, date);
                         }
                     } catch (Exception e) {
                         LOGGER.error("[!] Error while parsing photo in " + photo, e);
@@ -271,7 +272,7 @@ public class TumblrRipper extends AlbumRipper {
             } else if (post.has("video_url")) {
                 try {
                     fileURL = new URL(post.getString("video_url").replaceAll("http:", "https:"));
-                    downloadURL(fileURL);
+                    downloadURL(fileURL, date);
                 } catch (Exception e) {
                     LOGGER.error("[!] Error while parsing video in " + post, e);
                     return true;
@@ -280,7 +281,7 @@ public class TumblrRipper extends AlbumRipper {
                 Document d = Jsoup.parse(post.getString("body"));
                 if (!d.select("img").attr("src").isEmpty()) {
                     try {
-                        downloadURL(new URL(d.select("img").attr("src")));
+                        downloadURL(new URL(d.select("img").attr("src")), date);
                     } catch (MalformedURLException e) {
                         LOGGER.error("[!] Error while getting embedded image at " + post, e);
                         return true;
@@ -399,7 +400,11 @@ public class TumblrRipper extends AlbumRipper {
         return prefix;
     }
 
-    public void downloadURL(URL url) {
+    public void downloadURL(URL url, String date) {
+        LOGGER.info(albumType);
+        if (albumType == ALBUM_TYPE.TAG) {
+            addURLToDownload(url, date + " ");
+        }
         addURLToDownload(url, getPrefix(index));
         index++;
     }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Turns out that the tumblr ripper returns item out of order which makes it a pain to download comics from from tags. This PR fixes that by putting the date in the image name when ripping from tags 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
