### PR TITLE
Added support for Hentai foundry stories

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
@@ -37,7 +37,7 @@ public class HentaifoundryRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^.*hentai-foundry\\.com/pictures/user/([a-zA-Z0-9\\-_]+).*$");
+        Pattern p = Pattern.compile("^.*hentai-foundry\\.com/(pictures|stories)/user/([a-zA-Z0-9\\-_]+).*$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);
@@ -132,6 +132,13 @@ public class HentaifoundryRipper extends AbstractHTMLRipper {
     @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> imageURLs = new ArrayList<>();
+        // this if is for ripping pdf stories
+        if (url.toExternalForm().contains("/stories/")) {
+            for (Element pdflink : doc.select("a.pdfLink")) {
+                imageURLs.add("http://www.hentai-foundry.com" + pdflink.attr("href"));
+            }
+            return imageURLs;
+        }
         Pattern imgRegex = Pattern.compile(".*/user/([a-zA-Z0-9\\-_]+)/(\\d+)/.*");
         for (Element thumb : doc.select("div.thumb_square > a.thumbLink")) {
             if (isStopped()) {
@@ -167,6 +174,10 @@ public class HentaifoundryRipper extends AbstractHTMLRipper {
 
     @Override
     public void downloadURL(URL url, int index) {
+        // When downloading pdfs you *NEED* to end the cookies with the request or you just get the consent page
+        if (url.toExternalForm().endsWith(".pdf")) {
+            addURLToDownload(url, getPrefix(index), "", this.url.toExternalForm(), cookies);
+        }
         addURLToDownload(url, getPrefix(index));
     }
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaifoundryRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaifoundryRipperTest.java
@@ -7,7 +7,12 @@ import com.rarchives.ripme.ripper.rippers.HentaifoundryRipper;
 
 public class HentaifoundryRipperTest extends RippersTest {
     public void testHentaifoundryRip() throws IOException {
-        HentaifoundryRipper ripper = new HentaifoundryRipper(new URL("http://www.hentai-foundry.com/pictures/user/personalami"));
+        HentaifoundryRipper ripper = new HentaifoundryRipper(new URL("https://www.hentai-foundry.com/pictures/user/personalami"));
+        testRipper(ripper);
+    }
+
+    public void testHentaifoundryPdfRip() throws IOException {
+        HentaifoundryRipper ripper = new HentaifoundryRipper(new URL("https://www.hentai-foundry.com/stories/user/Rakked"));
         testRipper(ripper);
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1098)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Added the ability to rip pdfs from hentai foundry 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
