### PR TITLE
Fixed instagram ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -463,6 +463,12 @@ public class InstagramRipper extends AbstractJSONRipper {
             Matcher m = jsP.matcher(sb.toString());
             if (m.find()) {
                 return m.group(1);
+            } else {
+                jsP = Pattern.compile("0:s\\.pagination},queryId:.([a-zA-Z0-9]+)");
+                m = jsP.matcher(sb.toString());
+                if (m.find()) {
+                    return m.group(1);
+                }
             }
 
         } else {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1107 Fix #1109)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Changed the regex for finding the Qhash 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
