### PR TITLE
Fixed EromeRipper and added new test to EromerRipperTest.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
@@ -124,13 +124,18 @@ public class EromeRipper extends AbstractHTMLRipper {
     private List<String> getMediaFromPage(Document doc) {
         List<String> results = new ArrayList<>();
         for (Element el : doc.select("img.img-front")) {
-            if (el.attr("src").startsWith("https:")) {
-                results.add(el.attr("src"));
-            }
-            else {
-                results.add("https:" + el.attr("src"));
-            }
-        }
+			if (el.hasAttr("src")) {
+				if (el.attr("src").startsWith("https:")) {
+					results.add(el.attr("src"));
+				} else {
+					results.add("https:" + el.attr("src"));
+				}
+			} else if (el.hasAttr("data-src")) {
+				//to add images that are not loaded( as all images are lasyloaded as we scroll).
+				results.add(el.attr("data-src"));
+			}
+
+		}
         for (Element el : doc.select("source[label=HD]")) {
             if (el.attr("src").startsWith("https:")) {
                 results.add(el.attr("src"));

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -245,6 +245,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         Utils.setConfigBoolean("descriptions.save", configSaveDescriptions.isSelected());
         Utils.setConfigBoolean("prefer.mp4", configPreferMp4.isSelected());
         Utils.setConfigBoolean("remember.url_history", configURLHistoryCheckbox.isSelected());
+        Utils.setConfigString("lang", configSelectLangComboBox.getSelectedItem().toString());
         saveWindowPosition(mainFrame);
         saveHistory();
         Utils.saveConfig();
@@ -517,6 +518,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
         configLogLevelCombobox = new JComboBox<>(new String[] {"Log level: Error", "Log level: Warn", "Log level: Info", "Log level: Debug"});
         configSelectLangComboBox = new JComboBox<>(supportedLanges);
+        configSelectLangComboBox.setSelectedItem(rb.getLocale().toString());
         configLogLevelCombobox.setSelectedItem(Utils.getConfigString("log.level", "Log level: Debug"));
         setLogLevel(configLogLevelCombobox.getSelectedItem().toString());
         configSaveDirLabel = new JLabel();

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EromeRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EromeRipperTest.java
@@ -1,40 +1,47 @@
 package com.rarchives.ripme.tst.ripper.rippers;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.EromeRipper;
 
 public class EromeRipperTest extends RippersTest {
 
-    public void testGetGIDProfilePage() throws IOException {
-        URL url = new URL("https://www.erome.com/Jay-Jenna");
-        EromeRipper ripper = new EromeRipper(url);
-        assertEquals("Jay-Jenna", ripper.getGID(url));
-    }
+	public void testGetGIDProfilePage() throws IOException {
+		URL url = new URL("https://www.erome.com/Jay-Jenna");
+		EromeRipper ripper = new EromeRipper(url);
+		assertEquals("Jay-Jenna", ripper.getGID(url));
+	}
 
-    public void testGetGIDAlbum() throws IOException {
-        URL url = new URL("https://www.erome.com/a/KbDAM1XT");
-        EromeRipper ripper = new EromeRipper(url);
-        assertEquals("KbDAM1XT", ripper.getGID(url));
-    }
+	public void testGetGIDAlbum() throws IOException {
+		URL url = new URL("https://www.erome.com/a/KbDAM1XT");
+		EromeRipper ripper = new EromeRipper(url);
+		assertEquals("KbDAM1XT", ripper.getGID(url));
+	}
 
-    public void testGetAlbumsToQueue() throws IOException {
-        URL url = new URL("https://www.erome.com/Jay-Jenna");
-        EromeRipper ripper = new EromeRipper(url);
-        assert(2 >= ripper.getAlbumsToQueue(ripper.getFirstPage()).size());
-    }
+	public void testGetAlbumsToQueue() throws IOException {
+		URL url = new URL("https://www.erome.com/Jay-Jenna");
+		EromeRipper ripper = new EromeRipper(url);
+		assert (2 >= ripper.getAlbumsToQueue(ripper.getFirstPage()).size());
+	}
 
-    public void testPageContainsAlbums() throws IOException {
-        URL url = new URL("https://www.erome.com/Jay-Jenna");
-        EromeRipper ripper = new EromeRipper(url);
-        assert(ripper.pageContainsAlbums(url));
-        assert(!ripper.pageContainsAlbums(new URL("https://www.erome.com/a/KbDAM1XT")));
-    }
+	public void testPageContainsAlbums() throws IOException {
+		URL url = new URL("https://www.erome.com/Jay-Jenna");
+		EromeRipper ripper = new EromeRipper(url);
+		assert (ripper.pageContainsAlbums(url));
+		assert (!ripper.pageContainsAlbums(new URL("https://www.erome.com/a/KbDAM1XT")));
+	}
 
-    public void testRip() throws IOException {
-        URL url = new URL("https://www.erome.com/a/vlefBdsg");
-        EromeRipper ripper = new EromeRipper(url);
-        testRipper(ripper);
-    }
+	public void testRip() throws IOException {
+		URL url = new URL("https://www.erome.com/a/vlefBdsg");
+		EromeRipper ripper = new EromeRipper(url);
+		testRipper(ripper);
+	}
+
+	public void testGetURLsFromPage() throws IOException {
+		URL url = new URL("https://www.erome.com/a/Tak8F2h6");
+		EromeRipper ripper = new EromeRipper(url);
+		assert (35 == ripper.getURLsFromPage(ripper.getFirstPage()).size());
+	}
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix RipMeApp/ripme/issues/1104)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
Minor changes to EromeRipper which would capture blank image urls before, now captures required image urls (if present).
Added a test to verify the above change.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
