### PR TITLE
Fixed update dialog going out of screen.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -1,11 +1,14 @@
 package com.rarchives.ripme.ui;
 
+import java.awt.Dimension;
 import java.io.*;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import javax.swing.JEditorPane;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
+import javax.swing.JScrollPane;
 
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
@@ -125,13 +128,15 @@ public class UpdateUtils {
         String latestVersion = ripmeJson.getString("latestVersion");
         if (UpdateUtils.isNewerVersion(latestVersion)) {
             logger.info("Found newer version: " + latestVersion);
-            int result = JOptionPane.showConfirmDialog(
-                    null,
-                    String.format("<html><font color=\"green\">New version (%s) is available!</font>"
-                            + "<br><br>Recent changes: %s"
-                            + "<br><br>Do you want to download and run the newest version?</html>", latestVersion, changeList.replaceAll("\n", "")),
-                    "RipMe Updater",
-                    JOptionPane.YES_NO_OPTION);
+            JEditorPane changeListPane = new JEditorPane("text/html", String.format(
+					"<html><font color=\"green\">New version (%s) is available!</font>" + "<br><br>Recent changes: %s"
+							+ "<br><br>Do you want to download and run the newest version?</html>",
+					latestVersion, changeList.replaceAll("\n", "<br><br>")));
+			changeListPane.setEditable(false);
+			JScrollPane changeListScrollPane = new JScrollPane(changeListPane);
+			changeListScrollPane.setPreferredSize(new Dimension(250, 200));
+			int result = JOptionPane.showConfirmDialog(null, changeListScrollPane, "RipMe Updater",
+					JOptionPane.YES_NO_OPTION);
             if (result != JOptionPane.YES_OPTION) {
                 configUpdateLabel.setText("<html>Current Version: " + getThisJarVersion()
                         + "<br><font color=\"green\">Latest version: " + latestVersion + "</font></html>");


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix RipMeApp/ripme/issues/1026)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fixed the update dialog from going out of screen( by using a JEditorPane of fixed size) and made it scrollable( by wrapping the JEditorPane inside a JScrollPane).


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
