### PR TITLE
replaceAll takes a regex, escape newline to replace it with <br>

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -131,10 +131,10 @@ public class UpdateUtils {
             JEditorPane changeListPane = new JEditorPane("text/html", String.format(
 					"<html><font color=\"green\">New version (%s) is available!</font>" + "<br><br>Recent changes: %s"
 							+ "<br><br>Do you want to download and run the newest version?</html>",
-					latestVersion, changeList.replaceAll("\n", "<br><br>")));
+					latestVersion, changeList.replaceAll("\\n", "<br><br>")));
 			changeListPane.setEditable(false);
 			JScrollPane changeListScrollPane = new JScrollPane(changeListPane);
-			changeListScrollPane.setPreferredSize(new Dimension(250, 200));
+			changeListScrollPane.setPreferredSize(new Dimension(300, 300));
 			int result = JOptionPane.showConfirmDialog(null, changeListScrollPane, "RipMe Updater",
 					JOptionPane.YES_NO_OPTION);
             if (result != JOptionPane.YES_OPTION) {


### PR DESCRIPTION
This fixes the download box displaying only one line for all versions
and their fix descriptsion out of ripme.json.

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #715)

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).
