### PR TITLE
Updating Jab Archives ripper to add image title

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/JabArchivesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/JabArchivesRipper.java
@@ -96,12 +96,6 @@ public class JabArchivesRipper extends AbstractHTMLRipper {
 
     @Override
     public void downloadURL(URL url, int index) {
-        String prefix = "";
-        if (itemPrefixes.containsKey(url.toString())) {
-            System.out.println("Found matching prefix:");
-            prefix = itemPrefixes.get(url.toString());
-            System.out.println(prefix);
-        }
-        addURLToDownload(url, prefix);
+        addURLToDownload(url, itemPrefixes.get(url.toString()));
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following:
* [ ] a bug fix
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


# Description

This will now include the image title in the saved filename when writing
the final text files, which fixes duplicate files and naming conflicts from
downloading the same gallery multiple times.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
