### PR TITLE
fixed image albums failing to download any images (giving "already do…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -51,15 +51,6 @@ public abstract class AlbumRipper extends AbstractRipper {
      * Queues multiple URLs of single images to download from a single Album URL
      */
     public boolean addURLToDownload(URL url, File saveAs, String referrer, Map<String,String> cookies, Boolean getFileExtFromMIME) {
-        // Don't re-add the url if it was downloaded in a previous rip
-        if (Utils.getConfigBoolean("remember.url_history", true) && !isThisATest()) {
-            if (hasDownloadedURL(url.toExternalForm())) {
-                sendUpdate(STATUS.DOWNLOAD_WARN, "Already downloaded " + url.toExternalForm());
-                alreadyDownloadedUrls += 1;
-                return false;
-            }
-        }
-
             // Only download one file if this is a test.
         if (super.isThisATest() &&
                 (itemsPending.size() > 0 || itemsCompleted.size() > 0 || itemsErrored.size() > 0)) {
@@ -96,14 +87,7 @@ public abstract class AlbumRipper extends AbstractRipper {
             }
             threadPool.addThread(dft);
         }
-        if (Utils.getConfigBoolean("remember.url_history", true) && !isThisATest()) {
-            LOGGER.info("Writing " + url.toExternalForm() + " to file");
-            try {
-                writeDownloadedURL(url.toExternalForm() + "\n");
-            } catch (IOException e) {
-                LOGGER.debug("Unable to write URL history file");
-            }
-        }
+
         return true;
     }
 


### PR DESCRIPTION
…wnloaded" for every url) fixes #1135 and fixes #1134

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Change: 
Deleted the checking and writing to url_history.txt in the AlbumRipper class.

Rationale:
The checking of url_history.txt (for duplicate urls) and the writing to url_history.txt (of the current url) both happen twice. 
First in AbstractRipper.addURLToDownload, second in AlbumRipper.addURLToDownload (which is called by AbstractRipper.addURLToDownload). 
This means the check in AlbumRipper always finds the duplicate url and aborts before downloading.




# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
