### PR TITLE
Disabled old test for sinnercomics

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SinnercomicsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SinnercomicsRipperTest.java
@@ -32,11 +32,6 @@ public class SinnercomicsRipperTest extends RippersTest {
         ripper = new SinnercomicsRipper(url);
         assertEquals("beyond-the-hotel", ripper.getGID(url));
 
-        // Homepage test
-        url = new URL("https://sinnercomics.com/page/2/");
-        ripper = new SinnercomicsRipper(url);
-        assertEquals("homepage", ripper.getGID(url));
-
         // Comic test
         url = new URL("https://sinnercomics.com/elza-frozen-2/#comments");
         ripper = new SinnercomicsRipper(url);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Disabled a test for the url https://sinnercomics.com/page/2/ as there are no longer any images at the url


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
