### PR TITLE
Added an else block so the pdf download unit test wouldn't fail

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
@@ -40,7 +40,7 @@ public class HentaifoundryRipper extends AbstractHTMLRipper {
         Pattern p = Pattern.compile("^.*hentai-foundry\\.com/(pictures|stories)/user/([a-zA-Z0-9\\-_]+).*$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
-            return m.group(1);
+            return m.group(2);
         }
         throw new MalformedURLException(
                 "Expected hentai-foundry.com gallery format: "

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
@@ -135,6 +135,7 @@ public class HentaifoundryRipper extends AbstractHTMLRipper {
         // this if is for ripping pdf stories
         if (url.toExternalForm().contains("/stories/")) {
             for (Element pdflink : doc.select("a.pdfLink")) {
+                LOGGER.info("grabbing " + "http://www.hentai-foundry.com" + pdflink.attr("href"));
                 imageURLs.add("http://www.hentai-foundry.com" + pdflink.attr("href"));
             }
             return imageURLs;
@@ -177,8 +178,9 @@ public class HentaifoundryRipper extends AbstractHTMLRipper {
         // When downloading pdfs you *NEED* to end the cookies with the request or you just get the consent page
         if (url.toExternalForm().endsWith(".pdf")) {
             addURLToDownload(url, getPrefix(index), "", this.url.toExternalForm(), cookies);
+        } else {
+            addURLToDownload(url, getPrefix(index));
         }
-        addURLToDownload(url, getPrefix(index));
     }
 
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaifoundryRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaifoundryRipperTest.java
@@ -11,6 +11,12 @@ public class HentaifoundryRipperTest extends RippersTest {
         testRipper(ripper);
     }
 
+    public void testHentaifoundryGetGID() throws IOException {
+        HentaifoundryRipper ripper = new HentaifoundryRipper(new URL("https://www.hentai-foundry.com/stories/user/Rakked"));
+        testRipper(ripper);
+        assertEquals("Rakked", ripper.getGID(new URL("https://www.hentai-foundry.com/stories/user/Rakked")));
+    }
+
     public void testHentaifoundryPdfRip() throws IOException {
         HentaifoundryRipper ripper = new HentaifoundryRipper(new URL("https://www.hentai-foundry.com/stories/user/Rakked"));
         testRipper(ripper);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1144)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Add an else block to an if so files wouldn't be added to the download queue twice 

I also fixed the getGID and added a unit test for it


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
