### PR TITLE
Now uses Absolute file paths on linux to fix #1111

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -283,8 +283,7 @@ public class UpdateUtils {
                 script = "#!/bin/sh\n"
                         + "sleep 1" + "\n"
                         + "cd " + new File(mainFileName).getAbsoluteFile().getParent() + "\n"
-                        + "cp -f " + updateFileName + " " + mainFileName + "\n"
-                        + "rm -f " + updateFileName + "\n"
+                        + "mv -f " +new File(updateFileName).getAbsoluteFile() + " " + new File(mainFileName).getAbsoluteFile() + "\n"
                         + "java -jar \"" + new File(mainFileName).getAbsolutePath() + "\" &\n"
                         + "sleep 1" + "\n"
                         + "rm -f " + batchPath + "\n";

--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -279,11 +279,12 @@ public class UpdateUtils {
             } else {
                 // Mac / Linux
                 batchFile = "update_ripme.sh";
+                String currentFilePath = new File(System.getProperty("java.class.path")).getAbsolutePath();
                 String batchPath = new File(batchFile).getAbsolutePath();
                 script = "#!/bin/sh\n"
                         + "sleep 1" + "\n"
                         + "cd " + new File(mainFileName).getAbsoluteFile().getParent() + "\n"
-                        + "mv -f " +new File(updateFileName).getAbsoluteFile() + " " + new File(mainFileName).getAbsoluteFile() + "\n"
+                        + "mv -f " +new File(updateFileName).getAbsolutePath() + " " + new File(currentFilePath).getAbsolutePath() + "\n"
                         + "java -jar \"" + new File(mainFileName).getAbsolutePath() + "\" &\n"
                         + "sleep 1" + "\n"
                         + "rm -f " + batchPath + "\n";


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1111)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Upates are now downloaded to the dir ripme was run from and replace the old ripme.jar


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
