### PR TITLE
Reduce log spam

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/BatoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/BatoRipper.java
@@ -113,7 +113,6 @@ public class BatoRipper extends AbstractHTMLRipper {
                 s = s.replaceAll("var prevCha = null;", "");
                 s = s.replaceAll("var nextCha = \\.*;", "");
                 String json = s.replaceAll("var images = ", "").replaceAll(";", "");
-                LOGGER.info(s);
                 JSONObject images = new JSONObject(json);
                 for (int i = 1; i < images.length() +1; i++) {
                     result.add(images.getString(Integer.toString(i)));

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -111,7 +111,6 @@ public class ChanRipper extends AbstractHTMLRipper {
 
         String u = url.toExternalForm();
         if (u.contains("/thread/") || u.contains("/res/") || u.contains("yuki.la") || u.contains("55chan.org")) {
-            LOGGER.debug("U: " + u);
             p = Pattern.compile("^.*\\.[a-z]{1,3}/[a-zA-Z0-9]+/(thread|res)/([0-9]+)(\\.html|\\.php)?.*$");
             m = p.matcher(u);
             if (m.matches()) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
@@ -213,7 +213,6 @@ public class DeviantartRipper extends AbstractJSONRipper {
             if (js.html().contains("requestid")) {
                 String json = js.html().replaceAll("window.__initial_body_data=", "").replaceAll("\\);", "")
                         .replaceAll(";__wake\\(.+", "");
-                LOGGER.info("json: " + json);
                 JSONObject j = new JSONObject(json);
                 return j;
             }
@@ -253,7 +252,6 @@ public class DeviantartRipper extends AbstractJSONRipper {
     @Override
     public List<String> getURLsFromJSON(JSONObject json) {
         List<String> imageURLs = new ArrayList<>();
-        LOGGER.info(json);
         JSONArray results = json.getJSONObject("content").getJSONArray("results");
         for (int i = 0; i < results.length(); i++) {
             Document doc = Jsoup.parseBodyFragment(results.getJSONObject(i).getString("html"));

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
@@ -78,7 +78,6 @@ public class FuraffinityRipper extends AbstractHTMLRipper {
     @Override
     public Document getFirstPage() throws IOException {
         setCookies();
-        LOGGER.info(Http.url(url).cookies(cookies).get().html());
         return Http.url(url).cookies(cookies).get();
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HitomiRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HitomiRipper.java
@@ -56,7 +56,6 @@ public class HitomiRipper extends AbstractHTMLRipper {
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
         String json = doc.text().replaceAll("var galleryinfo =", "");
-        LOGGER.info(json);
         JSONArray json_data = new JSONArray(json);
         for (int i = 0; i < json_data.length(); i++) {
             result.add("https://ba.hitomi.la/galleries/" + galleryId + "/" + json_data.getJSONObject(i).getString("name"));

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ZizkiRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ZizkiRipper.java
@@ -79,7 +79,6 @@ public class ZizkiRipper extends AbstractHTMLRipper {
         // Page contains images
         LOGGER.info("Look for images.");
         for (Element thumb : page.select("img")) {
-            LOGGER.info("Img");
             if (super.isStopped()) break;
             // Find thumbnail image source
             String image = null;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ChanRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ChanRipperTest.java
@@ -58,7 +58,6 @@ public class ChanRipperTest extends RippersTest {
     public String getRandomThreadDesuarchive() {
         try {
             Document doc = Http.url(new URL("https://desuarchive.org/wsg/")).get();
-            System.out.println(doc);
             return doc.select("div.post_data > a").first().attr("href");
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Cut down on some unneeded logging so the unit test log is less cluttered 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
