### PR TITLE
Change to a proper Try with Resources.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -872,10 +872,9 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 LOGGER.error("Error while getting selected path: ", e);
                 return;
             }
-            try {
-                BufferedReader br = new BufferedReader(new FileReader(chosenPath));
+            try (BufferedReader br = new BufferedReader(new FileReader(chosenPath))) {
                 for (String line = br.readLine(); line != null; line = br.readLine()) {
-                    if (line.startsWith("http")) {
+                    if (line.trim().startsWith("http")) {
                         MainWindow.addUrlToQueue(line);
                     } else {
                         LOGGER.error("Skipping url " + line + " because it looks malformed (doesn't start with http)");


### PR DESCRIPTION
Trim the line input to avoid problems with whitespace on each line.

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Regarding the Download URL List functionality:

Properly handle the closing of a BufferedReader by using a Try with Resources, as it stands it is not closed. And trim each line of the input to avoid white-space issues.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.

Tested with a text file with these contents:
```
# Subreddits
	https://www.reddit.com/r/18_19/
  https://www.reddit.com/r/60fpsporn/
...

// Users

		       			https://www.reddit.com/user/AliceNice          			     
					https://www.reddit.com/user/BambooFever			   		 	 	 	
...

```