### PR TITLE
DA ripper now takes fav urls again

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DeviantartRipper.java
@@ -65,6 +65,10 @@ public class DeviantartRipper extends AbstractJSONRipper {
         String u = url.toExternalForm();
         if (u.contains("/gallery/")) {
             return url;
+        } else if (u.contains("/favourites")) {
+            return url;
+        } else if (u.contains("/favorites")) {
+            return url;
         }
 
         if (!u.endsWith("/gallery/") && !u.endsWith("/gallery")) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

The DA ripper now takes favorite galleries 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
