### PR TITLE
Improved luscious ripper fixed incomplete albums ripping.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/LusciousRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/LusciousRipper.java
@@ -13,79 +13,110 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.ripper.DownloadThreadPool;
 import com.rarchives.ripme.utils.Http;
 
 public class LusciousRipper extends AbstractHTMLRipper {
+	private static final int RETRY_COUNT = 5; // Keeping it high for read timeout exception.
 
-    public LusciousRipper(URL url) throws IOException {
-    super(url);
-    }
+	private Pattern p = Pattern.compile("^https?://(?:members.)?luscious\\.net/albums/([-_.0-9a-zA-Z]+).*$");
+	private DownloadThreadPool lusciousThreadPool = new DownloadThreadPool("lusciousThreadPool");
 
-    @Override
-    public String getDomain() {
-        return "luscious.net";
-    }
+	public LusciousRipper(URL url) throws IOException {
+		super(url);
+	}
 
-    @Override
-    public String getHost() {
-        return "luscious";
-    }
+	@Override
+	public String getDomain() {
+		return "luscious.net";
+	}
 
-    @Override
-    public Document getFirstPage() throws IOException {
-        // "url" is an instance field of the superclass
-        Document page = Http.url(url).get();
-        URL firstUrl = new URL("https://luscious.net" +  page.select("div > div.item.thumbnail.ic_container > a").first().attr("href"));
-        LOGGER.info("First page is " + "https://luscious.net" +  page.select("div > div.album_cover_item > a").first().attr("href"));
-        return Http.url(firstUrl).get();
-    }
+	@Override
+	public String getHost() {
+		return "luscious";
+	}
 
-    @Override
-    public List<String> getURLsFromPage(Document page) {
-        List<String> urls = new ArrayList<>();
-        Elements urlElements = page.select(".icon-download");
-        for (Element e : urlElements) {
-            urls.add(e.attr("href"));
-        }
-        
-        // This is here for pages with mp4s instead of images
-        String video_image = "";
-        video_image = page.select("div > video > source").attr("src");
-        if (!video_image.equals("")) {
-            urls.add(video_image);
-        }
-        return urls;
-    }
+	@Override
+	public Document getFirstPage() throws IOException {
+		// "url" is an instance field of the superclass
+		Document page = Http.url(url).get();
+		LOGGER.info("First page is " + url);
+		return page;
+	}
 
-    @Override
-    public Document getNextPage(Document doc) throws IOException {
-        // Find next page
-        String nextPageUrl = "https://luscious.net" + doc.select("a.image_link[rel=next]").attr("href");
-        // The more_like_this is here so we don't try to download the page that comes after the end of an album
-        if (nextPageUrl == "https://luscious.net" ||
-        nextPageUrl.contains("more_like_this")) {
-            throw new IOException("No more pages");
-        }
+	@Override
+	public List<String> getURLsFromPage(Document page) {
+		List<String> urls = new ArrayList<>();
+		Elements urlElements = page.select("div.item.thumbnail.ic_container > a");
+		for (Element e : urlElements) {
+			urls.add(e.attr("abs:href"));
+		}
 
-        return Http.url(nextPageUrl).get();
-    }
+		return urls;
+	}
 
-    @Override
-    public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern
-                .compile("^https?://luscious\\.net/albums/([-_.0-9a-zA-Z]+).*$");
-        Matcher m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return m.group(1);
-        }
-        throw new MalformedURLException("Expected luscious.net URL format: "
-                + "luscious.net/albums/albumname  - got " + url
-                + " instead");
-    }
+	@Override
+	public Document getNextPage(Document doc) throws IOException {
+		// luscious sends xhr requests to nextPageUrl and appends new set of images to the current page while in browser.
+		// Simply GET the nextPageUrl also works. Therefore, we do this...
+		Element nextPageElement = doc.select("div#next_page > div > a").first();
+		if (nextPageElement == null) {
+			throw new IOException("No next page found.");
+		}
 
-    @Override
-    public void downloadURL(URL url, int index) {
-        addURLToDownload(url, getPrefix(index));
-    }
+		return Http.url(nextPageElement.attr("abs:href")).get();
+	}
 
+	@Override
+	public String getGID(URL url) throws MalformedURLException {
+		Matcher m = p.matcher(url.toExternalForm());
+		if (m.matches()) {
+			return m.group(1);
+		}
+		throw new MalformedURLException("Expected luscious.net URL format: "
+				+ "luscious.net/albums/albumname \n members.luscious.net/albums/albumname  - got " + url + " instead.");
+	}
+
+	@Override
+	public void downloadURL(URL url, int index) {
+		lusciousThreadPool.addThread(new LusciousDownloadThread(url, index));
+	}
+
+	@Override
+	public DownloadThreadPool getThreadPool() {
+		return lusciousThreadPool;
+	}
+
+	public class LusciousDownloadThread extends Thread {
+		private URL url;
+		private int index;
+
+		public LusciousDownloadThread(URL url, int index) {
+			this.url = url;
+			this.index = index;
+		}
+
+		@Override
+		public void run() {
+			try {
+				Document page = Http.url(url).retries(RETRY_COUNT).get();
+
+				String downloadUrl = page.select(".icon-download").attr("abs:href");
+				if (downloadUrl.equals("")) {
+					// This is here for pages with mp4s instead of images.
+					downloadUrl = page.select("div > video > source").attr("src");
+					if (!downloadUrl.equals("")) {
+						throw new IOException("Could not find download url for image or video.");
+					}
+				}
+
+				//If a valid download url was found.
+				addURLToDownload(new URL(downloadUrl), getPrefix(index));
+
+			} catch (IOException e) {
+				LOGGER.error("Error downloadiong url " + url, e);
+			}
+		}
+
+	}
 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/LusciousRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/LusciousRipper.java
@@ -17,106 +17,106 @@ import com.rarchives.ripme.ripper.DownloadThreadPool;
 import com.rarchives.ripme.utils.Http;
 
 public class LusciousRipper extends AbstractHTMLRipper {
-	private static final int RETRY_COUNT = 5; // Keeping it high for read timeout exception.
+    private static final int RETRY_COUNT = 5; // Keeping it high for read timeout exception.
 
-	private Pattern p = Pattern.compile("^https?://(?:members.)?luscious\\.net/albums/([-_.0-9a-zA-Z]+).*$");
-	private DownloadThreadPool lusciousThreadPool = new DownloadThreadPool("lusciousThreadPool");
+    private Pattern p = Pattern.compile("^https?://(?:members.)?luscious\\.net/albums/([-_.0-9a-zA-Z]+).*$");
+    private DownloadThreadPool lusciousThreadPool = new DownloadThreadPool("lusciousThreadPool");
 
-	public LusciousRipper(URL url) throws IOException {
-		super(url);
-	}
+    public LusciousRipper(URL url) throws IOException {
+        super(url);
+    }
 
-	@Override
-	public String getDomain() {
-		return "luscious.net";
-	}
+    @Override
+    public String getDomain() {
+        return "luscious.net";
+    }
 
-	@Override
-	public String getHost() {
-		return "luscious";
-	}
+    @Override
+    public String getHost() {
+        return "luscious";
+    }
 
-	@Override
-	public Document getFirstPage() throws IOException {
-		// "url" is an instance field of the superclass
-		Document page = Http.url(url).get();
-		LOGGER.info("First page is " + url);
-		return page;
-	}
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        Document page = Http.url(url).get();
+        LOGGER.info("First page is " + url);
+        return page;
+    }
 
-	@Override
-	public List<String> getURLsFromPage(Document page) {
-		List<String> urls = new ArrayList<>();
-		Elements urlElements = page.select("div.item.thumbnail.ic_container > a");
-		for (Element e : urlElements) {
-			urls.add(e.attr("abs:href"));
-		}
+    @Override
+    public List<String> getURLsFromPage(Document page) {
+        List<String> urls = new ArrayList<>();
+        Elements urlElements = page.select("div.item.thumbnail.ic_container > a");
+        for (Element e : urlElements) {
+            urls.add(e.attr("abs:href"));
+        }
 
-		return urls;
-	}
+        return urls;
+    }
 
-	@Override
-	public Document getNextPage(Document doc) throws IOException {
-		// luscious sends xhr requests to nextPageUrl and appends new set of images to the current page while in browser.
-		// Simply GET the nextPageUrl also works. Therefore, we do this...
-		Element nextPageElement = doc.select("div#next_page > div > a").first();
-		if (nextPageElement == null) {
-			throw new IOException("No next page found.");
-		}
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        // luscious sends xhr requests to nextPageUrl and appends new set of images to the current page while in browser.
+        // Simply GET the nextPageUrl also works. Therefore, we do this...
+        Element nextPageElement = doc.select("div#next_page > div > a").first();
+        if (nextPageElement == null) {
+            throw new IOException("No next page found.");
+        }
 
-		return Http.url(nextPageElement.attr("abs:href")).get();
-	}
+        return Http.url(nextPageElement.attr("abs:href")).get();
+    }
 
-	@Override
-	public String getGID(URL url) throws MalformedURLException {
-		Matcher m = p.matcher(url.toExternalForm());
-		if (m.matches()) {
-			return m.group(1);
-		}
-		throw new MalformedURLException("Expected luscious.net URL format: "
-				+ "luscious.net/albums/albumname \n members.luscious.net/albums/albumname  - got " + url + " instead.");
-	}
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected luscious.net URL format: "
+                + "luscious.net/albums/albumname \n members.luscious.net/albums/albumname  - got " + url + " instead.");
+    }
 
-	@Override
-	public void downloadURL(URL url, int index) {
-		lusciousThreadPool.addThread(new LusciousDownloadThread(url, index));
-	}
+    @Override
+    public void downloadURL(URL url, int index) {
+        lusciousThreadPool.addThread(new LusciousDownloadThread(url, index));
+    }
 
-	@Override
-	public DownloadThreadPool getThreadPool() {
-		return lusciousThreadPool;
-	}
+    @Override
+    public DownloadThreadPool getThreadPool() {
+        return lusciousThreadPool;
+    }
 
-	public class LusciousDownloadThread extends Thread {
-		private URL url;
-		private int index;
+    public class LusciousDownloadThread extends Thread {
+        private URL url;
+        private int index;
 
-		public LusciousDownloadThread(URL url, int index) {
-			this.url = url;
-			this.index = index;
-		}
+        public LusciousDownloadThread(URL url, int index) {
+            this.url = url;
+            this.index = index;
+        }
 
-		@Override
-		public void run() {
-			try {
-				Document page = Http.url(url).retries(RETRY_COUNT).get();
+        @Override
+        public void run() {
+            try {
+                Document page = Http.url(url).retries(RETRY_COUNT).get();
 
-				String downloadUrl = page.select(".icon-download").attr("abs:href");
-				if (downloadUrl.equals("")) {
-					// This is here for pages with mp4s instead of images.
-					downloadUrl = page.select("div > video > source").attr("src");
-					if (!downloadUrl.equals("")) {
-						throw new IOException("Could not find download url for image or video.");
-					}
-				}
+                String downloadUrl = page.select(".icon-download").attr("abs:href");
+                if (downloadUrl.equals("")) {
+                    // This is here for pages with mp4s instead of images.
+                    downloadUrl = page.select("div > video > source").attr("src");
+                    if (!downloadUrl.equals("")) {
+                        throw new IOException("Could not find download url for image or video.");
+                    }
+                }
 
-				//If a valid download url was found.
-				addURLToDownload(new URL(downloadUrl), getPrefix(index));
+                //If a valid download url was found.
+                addURLToDownload(new URL(downloadUrl), getPrefix(index));
 
-			} catch (IOException e) {
-				LOGGER.error("Error downloadiong url " + url, e);
-			}
-		}
+            } catch (IOException e) {
+                LOGGER.error("Error downloadiong url " + url, e);
+            }
+        }
 
-	}
+    }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LusciousRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LusciousRipperTest.java
@@ -6,30 +6,30 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.LusciousRipper;
 
 public class LusciousRipperTest extends RippersTest {
-	public void testPahealRipper() throws IOException {
-		// a photo set
-		LusciousRipper ripper = new LusciousRipper(
-				new URL("https://luscious.net/albums/h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609/"));
-		testRipper(ripper);
-	}
+    public void testPahealRipper() throws IOException {
+        // a photo set
+        LusciousRipper ripper = new LusciousRipper(
+                new URL("https://luscious.net/albums/h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609/"));
+        testRipper(ripper);
+    }
 
-	public void testGetGID() throws IOException {
-		URL url = new URL("https://luscious.net/albums/h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609/");
-		LusciousRipper ripper = new LusciousRipper(url);
-		assertEquals("h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609", ripper.getGID(url));
-	}
+    public void testGetGID() throws IOException {
+        URL url = new URL("https://luscious.net/albums/h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609/");
+        LusciousRipper ripper = new LusciousRipper(url);
+        assertEquals("h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609", ripper.getGID(url));
+    }
 
-	public void testGetNextPage() throws IOException {
-		URL multiPageAlbumUrl = new URL("https://luscious.net/albums/women-of-color_58/");
-		LusciousRipper multiPageRipper = new LusciousRipper(multiPageAlbumUrl);
-		assert (multiPageRipper.getNextPage(multiPageRipper.getFirstPage()) != null);
+    public void testGetNextPage() throws IOException {
+        URL multiPageAlbumUrl = new URL("https://luscious.net/albums/women-of-color_58/");
+        LusciousRipper multiPageRipper = new LusciousRipper(multiPageAlbumUrl);
+        assert (multiPageRipper.getNextPage(multiPageRipper.getFirstPage()) != null);
 
-		URL singlePageAlbumUrl = new URL("https://members.luscious.net/albums/bakaneko-navidarks_332097/");
-		LusciousRipper singlePageRipper = new LusciousRipper(singlePageAlbumUrl);
-		try {
-			singlePageRipper.getNextPage(singlePageRipper.getFirstPage());
-		} catch (IOException e) {
-			assertEquals("No next page found.", e.getMessage());
-		}
-	}
+        URL singlePageAlbumUrl = new URL("https://members.luscious.net/albums/bakaneko-navidarks_332097/");
+        LusciousRipper singlePageRipper = new LusciousRipper(singlePageAlbumUrl);
+        try {
+            singlePageRipper.getNextPage(singlePageRipper.getFirstPage());
+        } catch (IOException e) {
+            assertEquals("No next page found.", e.getMessage());
+        }
+    }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LusciousRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LusciousRipperTest.java
@@ -6,9 +6,30 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.LusciousRipper;
 
 public class LusciousRipperTest extends RippersTest {
-    public void testPahealRipper() throws IOException {
-        // a photo set
-        LusciousRipper ripper = new LusciousRipper(new URL("https://luscious.net/albums/h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609/"));
-        testRipper(ripper);
-    }
+	public void testPahealRipper() throws IOException {
+		// a photo set
+		LusciousRipper ripper = new LusciousRipper(
+				new URL("https://luscious.net/albums/h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609/"));
+		testRipper(ripper);
+	}
+
+	public void testGetGID() throws IOException {
+		URL url = new URL("https://luscious.net/albums/h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609/");
+		LusciousRipper ripper = new LusciousRipper(url);
+		assertEquals("h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609", ripper.getGID(url));
+	}
+
+	public void testGetNextPage() throws IOException {
+		URL multiPageAlbumUrl = new URL("https://luscious.net/albums/women-of-color_58/");
+		LusciousRipper multiPageRipper = new LusciousRipper(multiPageAlbumUrl);
+		assert (multiPageRipper.getNextPage(multiPageRipper.getFirstPage()) != null);
+
+		URL singlePageAlbumUrl = new URL("https://members.luscious.net/albums/bakaneko-navidarks_332097/");
+		LusciousRipper singlePageRipper = new LusciousRipper(singlePageAlbumUrl);
+		try {
+			singlePageRipper.getNextPage(singlePageRipper.getFirstPage());
+		} catch (IOException e) {
+			assertEquals("No next page found.", e.getMessage());
+		}
+	}
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix. Fixes #1152, fixes #1119, fixes #1094 and fixes #404 
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Improved luscious ripper for faster multi threaded download.
- `getURLsFromPage()` now returns all the image urls from the page( unlike the previous implementation which returned the download url of the single image).
- `getNextPage()` now returns the next page of the album( Previous implementation returned next image url).
- `getGID()` now accepts 2 url formats, `luscious.net/albums/albumname`  and `members.luscious.net/albums/albumname`
- Added `LusciousDownloadThread` to download images/ videos from image urls with high retry count( to counter read timeout).

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.

# Bugs
For issue #404 and issue #977 with `remember.url_history =  true` and `
file.overwrite = true` RipMe does not re-download the files.
This can be reproduced by keeping both options true, ripping a url and stopping mid rip.
Re ripping the same url does not redownload the incomplete images.
Deleting the rip folder and re-ripping the same url also does not work, showing already downloaded for deleted images.

This can be fixed by an addtional check for file.overwrite [here](https://github.com/RipMeApp/ripme/blob/b76b930d62002f09cabb30d1b421e736cf7d486d/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java#L239)