### PR TITLE
Tumblr ripper downloads highest quality available

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -29,7 +29,7 @@ public class TumblrRipper extends AlbumRipper {
 
     private static final String DOMAIN = "tumblr.com",
             HOST   = "tumblr",
-            IMAGE_PATTERN = "([^\\s]+(\\.(?i)(jpg|png|gif|bmp))$)";
+            IMAGE_PATTERN = "([^\\s]+(\\.(?i)(?:jpg|png|gif|bmp))$)";
 
     private enum ALBUM_TYPE {
         SUBDOMAIN,
@@ -262,9 +262,7 @@ public class TumblrRipper extends AlbumRipper {
                     try {
                         fileLocation = photo.getJSONObject("original_size").getString("url").replaceAll("http:", "https:");
                         qualM = qualP.matcher(fileLocation);
-                        if (qualM.matches()) {
-                            fileLocation = fileLocation.replaceFirst("_[0-9]+\\.(jpg|png|gif|bmp)$", "_1280." + qualM.group(1));
-                        }
+                        fileLocation = qualM.replaceFirst("_1280.$1");
                         fileURL = new URL(fileLocation);
 
                         m = p.matcher(fileURL.toString());
@@ -294,9 +292,7 @@ public class TumblrRipper extends AlbumRipper {
                         // Set maximum quality, tumblr doesn't go any further
                         // If the image is any smaller, it will still get the largest available size
                         qualM = qualP.matcher(imgSrc);
-                        if (qualM.matches()) {
-                            imgSrc = imgSrc.replaceFirst("_[0-9]+\\.(jpg|png|gif|bmp)$", "_1280." + qualM.group(1));
-                        }
+                        imgSrc = qualM.replaceFirst("_1280.$1");
                         downloadURL(new URL(imgSrc), date);
                     } catch (MalformedURLException e) {
                         LOGGER.error("[!] Error while getting embedded image at " + post, e);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #974 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Now adds _1280 to all images in order to rip highest quality available, as explained in #974


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
