### PR TITLE
Changes furaffinityRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
@@ -219,16 +219,21 @@ public class FuraffinityRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern
-                .compile("^https?://www\\.furaffinity\\.net/gallery/([-_.0-9a-zA-Z]+).*$");
+        // Gallery
+        Pattern p = Pattern.compile("^https?://www\\.furaffinity\\.net/gallery/([-_.0-9a-zA-Z]+).*$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);
         }
 
-        throw new MalformedURLException("Expected furaffinity.net URL format: "
-                + "www.furaffinity.net/gallery/username  - got " + url
-                + " instead");
+        //Scraps
+        p = Pattern.compile("^https?://www\\.furaffinity\\.net/scraps/([-_.0-9a-zA-Z]+).*$");
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+
+        throw new MalformedURLException("Unable to find images in" + url);
     }
 
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuraffinityRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuraffinityRipperTest.java
@@ -6,8 +6,14 @@ import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.FuraffinityRipper;
 
 public class FuraffinityRipperTest extends RippersTest {
+
     public void testFuraffinityAlbum() throws IOException {
         FuraffinityRipper ripper = new FuraffinityRipper(new URL("https://www.furaffinity.net/gallery/spencerdragon/"));
+        testRipper(ripper);
+    }
+
+    public void testFuraffinityScrap() throws IOException {
+        FuraffinityRipper ripper = new FuraffinityRipper(new URL("http://www.furaffinity.net/scraps/sssonic2/"));
         testRipper(ripper);
     }
 


### PR DESCRIPTION
Hi, i saw that furaffinity ripper was only able to download https://www.furaffinity.net/gallery
I have add the posibility to donwload  https://www.furaffinity.net/scraps. I had seen a issue posted like 13 days ago, but now seems is deleted.

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


# Description

I have add a getGid Pattern  to scraps. 
I have add a unitTest to check that works correctly.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x ] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.

Sorry for my english and if something related to a good pull request is not good enough. It's my first pull request on github. 
