### PR TITLE
Added Ripper for Xlecx

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
@@ -1,5 +1,6 @@
 package com.rarchives.ripme.ripper.rippers;
 
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
@@ -1,6 +1,5 @@
 package com.rarchives.ripme.ripper.rippers;
 
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -11,10 +10,11 @@ import java.util.regex.Pattern;
 
 import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
 import com.rarchives.ripme.utils.Http;
-
+import com.rarchives.ripme.utils.Utils;
 
 public class GfycatRipper extends AbstractSingleFileRipper {
 
@@ -42,7 +42,7 @@ public class GfycatRipper extends AbstractSingleFileRipper {
     @Override
     public URL sanitizeURL(URL url) throws MalformedURLException {
         url = new URL(url.toExternalForm().replace("/gifs/detail", ""));
-        
+
         return url;
     }
 
@@ -64,17 +64,23 @@ public class GfycatRipper extends AbstractSingleFileRipper {
             return m.group(1);
         }
 
-        throw new MalformedURLException(
-                "Expected gfycat.com format:"
-                        + "gfycat.com/id"
-                        + " Got: " + url);
+        throw new MalformedURLException("Expected gfycat.com format:" + "gfycat.com/id" + " Got: " + url);
     }
 
     @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
-        Elements videos = doc.select("source");
+        Elements videos = doc.select("video source");
         String vidUrl = videos.first().attr("src");
+        // Check preference for mp4 over webm/gif.
+        if (Utils.getConfigBoolean("prefer.mp4", false)) {
+            for (Element e : videos) {
+                if (e.hasAttr("src") && e.attr("src").endsWith(".mp4")) {
+                    vidUrl = e.attr("src");
+                    break;
+                }
+            }
+        }
         if (vidUrl.startsWith("//")) {
             vidUrl = "http:" + vidUrl;
         }
@@ -84,22 +90,33 @@ public class GfycatRipper extends AbstractSingleFileRipper {
 
     /**
      * Helper method for retrieving video URLs.
-     * @param url URL to gfycat page
+     * 
+     * @param url
+     *            URL to gfycat page
      * @return URL to video
      * @throws IOException
      */
     public static String getVideoURL(URL url) throws IOException {
         LOGGER.info("Retrieving " + url.toExternalForm());
 
-        //Sanitize the URL first
+        // Sanitize the URL first
         url = new URL(url.toExternalForm().replace("/gifs/detail", ""));
 
         Document doc = Http.url(url).get();
-        Elements videos = doc.select("source");
+        Elements videos = doc.select("video source");
         if (videos.isEmpty()) {
             throw new IOException("Could not find source at " + url);
         }
         String vidUrl = videos.first().attr("src");
+        // Check preference for mp4 over webm/gif.
+        if (Utils.getConfigBoolean("prefer.mp4", false)) {
+            for (Element e : videos) {
+                if (e.hasAttr("src") && e.attr("src").endsWith(".mp4")) {
+                    vidUrl = e.attr("src");
+                    break;
+                }
+            }
+        }
         if (vidUrl.startsWith("//")) {
             vidUrl = "http:" + vidUrl;
         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XcartxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XcartxRipper.java
@@ -52,9 +52,9 @@ public class XcartxRipper extends AbstractHTMLRipper {
     @Override
     public List<String> getURLsFromPage(Document page) {
         List<String> imageURLs = new ArrayList<>();
-        Elements albumElements = page.select("a.highslide");
-        for (Element imageBox : albumElements) {
-            String imageUrl = imageBox.attr("href");
+        Elements imageElements = page.select("div.f-desc img");
+        for (Element image : imageElements) {
+            String imageUrl = image.attr("abs:src");
 
             imageURLs.add(imageUrl);
         }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XlecxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XlecxRipper.java
@@ -1,0 +1,36 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class XlecxRipper extends XcartxRipper {
+
+    private Pattern p = Pattern.compile("^https?://xlecx.com/([a-zA-Z0-9_\\-]+).html");
+
+    public XlecxRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "xlecx";
+    }
+
+    @Override
+    public String getDomain() {
+        return "xlecx.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected URL format: http://xlecx.com/comic, got: " + url);
+
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XlecxRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XlecxRipperTest.java
@@ -1,0 +1,13 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.XlecxRipper;
+
+public class XlecxRipperTest extends RippersTest {
+    public void testAlbum() throws IOException {
+        XlecxRipper ripper = new XlecxRipper(new URL("http://xlecx.com/4937-tokimeki-nioi.html"));
+        testRipper(ripper);
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XlecxRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XlecxRipperTest.java
@@ -7,7 +7,7 @@ import com.rarchives.ripme.ripper.rippers.XlecxRipper;
 
 public class XlecxRipperTest extends RippersTest {
     public void testAlbum() throws IOException {
-        XlecxRipper ripper = new XlecxRipper(new URL("http://xlecx.com/4937-tokimeki-nioi.html"));
+        XlecxRipper ripper = new XlecxRipper(new URL("http://xlecx.com/4274-black-canary-ravished-prey.html"));
         testRipper(ripper);
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper https://github.com/RipMeApp/ripme/issues/38#issuecomment-450998465
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
Added a ripper for xlecx.com.
As **xlecx** is a clone of **xcartx**, XlecxRipper extends from XcartxRipper with some minor changes.

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
