### PR TITLE
Closes #1143 Added support for score filtering when ripping from reddit

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -118,6 +118,12 @@ public class RedditRipper extends AlbumRipper {
         return nextURL;
     }
 
+    /**
+     * Gets a representation of the specified reddit page as a JSONArray using the reddit API
+     * @param url The url of the desired page
+     * @return A JSONArray object representation of the desired page
+     * @throws IOException If no response is received from the url
+     */
     private JSONArray getJsonArrayFromURL(URL url) throws IOException {
         // Wait 2 seconds before the next request
         long timeDiff = System.currentTimeMillis() - lastRequestTime;
@@ -149,9 +155,28 @@ public class RedditRipper extends AlbumRipper {
         return jsonArray;
     }
 
+    /**
+     * Turns child JSONObject's into usable URLs and hands them off for further processing
+     * Performs filtering checks based on the reddit.
+     * Only called from getAndParseAndReturnNext() while parsing the JSONArray returned from reddit's API
+     * @param child The child to process
+     */
     private void parseJsonChild(JSONObject child) {
         String kind = child.getString("kind");
         JSONObject data = child.getJSONObject("data");
+
+        //Upvote filtering
+        if (Utils.getConfigBoolean("reddit.rip_by_upvote", false)){
+            int score = data.getInt("score");
+            int maxScore = Utils.getConfigInteger("reddit.max_upvotes", Integer.MAX_VALUE);
+            int minScore = Utils.getConfigInteger("reddit.min_upvotes", Integer.MIN_VALUE);
+
+            if (score > maxScore || score < minScore) {
+
+                return; //Outside specified range, do not download
+            }
+        }
+
         if (kind.equals("t1")) {
             // Comment
             handleBody(data.getString("body"), data.getString("id"), "");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -173,6 +173,8 @@ public class RedditRipper extends AlbumRipper {
 
             if (score > maxScore || score < minScore) {
 
+                String message = "Skipping post with score outside specified range of " + minScore + " to " + maxScore;
+                LOGGER.debug(message);
                 return; //Outside specified range, do not download
             }
         }

--- a/src/main/resources/rip.properties
+++ b/src/main/resources/rip.properties
@@ -30,3 +30,17 @@ twitter.max_requests = 10
 clipboard.autorip = false
 
 download.save_order = true
+
+## Reddit ripper configs
+# Determines whether or not to filter reddit ripping by upvote
+# Enables the reddit.min_upvotes and reddit.max_upvotes properties when true
+reddit.rip_by_upvote = false
+
+# Only rips file if the number of upvotes is equal to or greater than this value
+# Requires reddit.rip_by_upvote = true
+reddit.min_upvotes = 0
+
+# Only rips files if the number of upvotes is less than this value
+# Requires reddit.rip_by_upvote = true
+reddit.max_upvotes = 10000
+


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


# Description

Adds support for filtering out post/comments outside of a specific score range from being downloaded. Examples with comments placed in the rip.properties file. Also added some (incomplete, but some is better than none) docs to the RedditRipper


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
Couldn't see a way to test a class with varying entries in the .properties file. If anyone can point me in the right direction I'll be happy to get on that.
