### PR TITLE
Fixed FuskatorRipper not ripping images.

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuskatorRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuskatorRipperTest.java
@@ -1,15 +1,15 @@
-//package com.rarchives.ripme.tst.ripper.rippers;
-//
-//import java.io.IOException;
-//import java.net.URL;
-//
-//import com.rarchives.ripme.ripper.rippers.FuskatorRipper;
-//
-//public class FuskatorRipperTest extends RippersTest {
-//    public void testFuskatorAlbum() throws IOException {
-//        FuskatorRipper ripper = new FuskatorRipper(new URL("https://fuskator.com/thumbs/hqt6pPXAf9z/Shaved-Blonde-Babe-Katerina-Ambre.html"));
-//        testRipper(ripper);
-//    }
-//}
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.FuskatorRipper;
+
+public class FuskatorRipperTest extends RippersTest {
+    public void testFuskatorAlbum() throws IOException {
+        FuskatorRipper ripper = new FuskatorRipper(new URL("https://fuskator.com/thumbs/hqt6pPXAf9z/Shaved-Blonde-Babe-Katerina-Ambre.html"));
+        testRipper(ripper);
+    }
+}
 
 // Disabled because of https://github.com/RipMeApp/ripme/issues/393


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1175 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
* FuskatorRipper failed to rip images due to changes in the website. Fixed by minor changes in the `getURLsFromPage()` method.
`getURLsFromPage()` method now sends a GET request to receive a JSONObject and retun image urls from it.
* FuskatorRipperTest has been un-commented to check if its still failing in travis-ci (#393 )

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
