### PR TITLE
Added ripper for Myreadingmanga.info

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyreadingmangaRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyreadingmangaRipper.java
@@ -1,0 +1,66 @@
+
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+public class MyreadingmangaRipper extends AbstractHTMLRipper {
+
+    public MyreadingmangaRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "myreadingmanga";
+    }
+
+    @Override
+    public String getDomain() {
+        return "myreadingmanga.info";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https://myreadingmanga.info/([a-zA-Z_\\-0-9]+)/?$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+
+        throw new MalformedURLException("Expected myreadingmanga.info URL format: "
+                + "myreadingmanga.info/title - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        LOGGER.info(doc);
+        List<String> result = new ArrayList<>();
+        for (Element el : doc.select("div.separator > img")) {
+            String imageSource = el.attr("data-lazy-src");
+            result.add(imageSource);
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyreadingmangaRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyreadingmangaRipper.java
@@ -49,7 +49,6 @@ public class MyreadingmangaRipper extends AbstractHTMLRipper {
 
     @Override
     public List<String> getURLsFromPage(Document doc) {
-        LOGGER.info(doc);
         List<String> result = new ArrayList<>();
         for (Element el : doc.select("div.separator > img")) {
             String imageSource = el.attr("data-lazy-src");

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MyreadingmangaRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MyreadingmangaRipperTest.java
@@ -1,4 +1,13 @@
 package com.rarchives.ripme.tst.ripper.rippers;
 
-public class MyreadingmangaRipperTest {
+import java.io.IOException;
+import java.net.URL;
+import com.rarchives.ripme.ripper.rippers.MyreadingmangaRipper;
+
+
+public class MyreadingmangaRipperTest extends RippersTest {
+    public void testRip() throws IOException {
+        MyreadingmangaRipper ripper = new MyreadingmangaRipper(new URL("https://myreadingmanga.info/zelo-lee-brave-lover-dj-slave-market-jp/"));
+        testRipper(ripper);
+    }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MyreadingmangaRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MyreadingmangaRipperTest.java
@@ -1,0 +1,4 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+public class MyreadingmangaRipperTest {
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [X] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

A ripper and unit test for Myreadingmanga.info


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
