### PR TITLE
Fixed instagram ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -439,6 +439,11 @@ public class InstagramRipper extends AbstractJSONRipper {
                 return el.attr("href");
             }
         }
+        for(Element el : doc.select("link[rel=preload]")) {
+            if (el.attr("href").contains("metro")) {
+                return el.attr("href");
+            }
+        }
         return null;
     }
 
@@ -475,6 +480,12 @@ public class InstagramRipper extends AbstractJSONRipper {
                 m = jsP.matcher(sb.toString());
                 if (m.find()) {
                     return m.group(1);
+                } else {
+                    jsP = Pattern.compile(",u=.([a-zA-Z0-9]+).");
+                    m = jsP.matcher(sb.toString());
+                    if (m.find()) {
+                        return m.group(1);
+                    }
                 }
             }
 
@@ -484,6 +495,7 @@ public class InstagramRipper extends AbstractJSONRipper {
             if (m.find()) {
                 return m.group(1);
             }
+
         }
         LOGGER.error("Could not find query_hash on " + jsFileURL);
         return null;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -39,9 +39,6 @@ public class InstagramRipper extends AbstractJSONRipper {
     private String userID;
     private String rhx_gis = null;
     private String csrftoken;
-    // Run into a weird issue with Jsoup cutting some json pages in half, this is a work around
-    // see https://github.com/RipMeApp/ripme/issues/601
-    private String workAroundJsonString;
 
 
 
@@ -424,7 +421,6 @@ public class InstagramRipper extends AbstractJSONRipper {
 
             }
             in.close();
-            workAroundJsonString = sb.toString();
             return new JSONObject(sb.toString());
 
         } catch (MalformedURLException e) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #1227)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Ripper can get qhash again 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
