### PR TITLE
Post skipping message now writes to the UI log instead of to the file…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -174,7 +174,7 @@ public class RedditRipper extends AlbumRipper {
             if (score > maxScore || score < minScore) {
 
                 String message = "Skipping post with score outside specified range of " + minScore + " to " + maxScore;
-                LOGGER.debug(message);
+                sendUpdate(RipStatusMessage.STATUS.DOWNLOAD_WARN, message);
                 return; //Outside specified range, do not download
             }
         }


### PR DESCRIPTION
… log

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


# Description
The reddit ripper has the ability to filter out images by post/comment score. On the initial pull request on cyian's advice I added a log message that indicates when a post is skipped. This pull request moves the location of the log message to the UI so as to more effectively inform the current user.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change. (Not really applicable but eh)
