### PR TITLE
Patch.py now removes any leading spaces from commit message

### DIFF
--- a/patch.py
+++ b/patch.py
@@ -12,6 +12,9 @@ from hashlib import sha256
 # - commit all changes
 message = input('message: ')
 
+# Strip any spaces that might've been entered before the message
+message.lstrip()
+
 
 def get_ripme_json():
     with open('ripme.json') as dataFile:


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Patch.py now removes any leading spaces from commit messages. 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
