### PR TITLE
Added support for artstn.co

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ArtstnRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ArtstnRipper.java
@@ -1,0 +1,58 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.jsoup.Connection.Response;
+
+import com.rarchives.ripme.utils.Http;
+
+/*
+ * Ripper for ArtStation's short URL domain.
+ * Example URL: https://artstn.co/p/JlE15Z
+ */
+
+public class ArtstnRipper extends ArtStationRipper {
+	public URL artStationUrl = null;
+
+	public ArtstnRipper(URL url) throws IOException {
+		super(url);
+	}
+
+	@Override
+	public boolean canRip(URL url) {
+		return url.getHost().endsWith("artstn.co");
+	}
+
+	@Override
+	public String getGID(URL url) throws MalformedURLException {
+		if (artStationUrl == null) {
+			// Run only once.
+			try {
+				artStationUrl = getFinalUrl(url);
+				if (artStationUrl == null) {
+					throw new IOException("Null url received.");
+				}
+			} catch (IOException e) {
+				LOGGER.error("Couldnt resolve URL.", e);
+			}
+
+		}
+		return super.getGID(artStationUrl);
+	}
+
+	public URL getFinalUrl(URL url) throws IOException {
+		if (url.getHost().endsWith("artstation.com")) {
+			return url;
+		}
+
+		LOGGER.info("Checking url: " + url);
+		Response response = Http.url(url).connection().followRedirects(false).execute();
+		if (response.statusCode() / 100 == 3 && response.hasHeader("location")) {
+			return getFinalUrl(new URL(response.header("location")));
+		} else {
+			return null;
+		}
+	}
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ArtstnRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ArtstnRipperTest.java
@@ -1,0 +1,19 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.ArtstnRipper;
+
+public class ArtstnRipperTest extends RippersTest {
+
+	public void testSingleProject() throws IOException {
+		URL url = new URL("https://artstn.co/p/JlE15Z");
+		testRipper(new ArtstnRipper(url));
+	}
+
+	public void testUserPortfolio() throws IOException {
+		URL url = new URL("https://artstn.co/m/rv37");
+		testRipper(new ArtstnRipper(url));
+	}
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper https://github.com/RipMeApp/ripme/issues/38#issuecomment-462024850
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
* Added support for artstn.co, short urls  for Artstation.
`ArtstnRipper` extends `ArtStationRipper` with minor changes.

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
