### PR TITLE
some more checks to avoid downloading invaild urls 

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -93,6 +93,7 @@ public abstract class AbstractHTMLRipper extends AlbumRipper {
 
             // We set doc to null here so the while loop below this doesn't fire
             doc = null;
+            LOGGER.debug("Adding items from " + this.url + " to queue");
         }
 
         while (doc != null) {

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -431,7 +431,6 @@ public abstract class AbstractRipper
      * Notifies observers and updates state if all files have been ripped.
      */
     void checkIfComplete() {
-        LOGGER.debug("Checkifcomplete was called");
         if (observer == null) {
             LOGGER.debug("observer is null");
             return;

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -237,6 +237,12 @@ public abstract class AbstractRipper
      *      False if failed to download
      */
     protected boolean addURLToDownload(URL url, String prefix, String subdirectory, String referrer, Map<String, String> cookies, String fileName, String extension, Boolean getFileExtFromMIME) {
+        // A common bug is rippers adding urls that are just "http:". This rejects said urls
+        if (url.toExternalForm().equals("http:") || url.toExternalForm().equals("https:")) {
+            LOGGER.info(url.toExternalForm() + " is a invalid url amd will be changed");
+            return false;
+
+        }
         // Make sure the url doesn't contain any spaces as that can cause a 400 error when requesting the file
         if (url.toExternalForm().contains(" ")) {
             // If for some reason the url with all spaces encoded as %20 is malformed print an error
@@ -425,6 +431,7 @@ public abstract class AbstractRipper
      * Notifies observers and updates state if all files have been ripped.
      */
     void checkIfComplete() {
+        LOGGER.debug("Checkifcomplete was called");
         if (observer == null) {
             LOGGER.debug("observer is null");
             return;

--- a/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
@@ -1,7 +1,6 @@
 package com.rarchives.ripme.ripper;
 
 import java.io.*;
-import java.lang.reflect.Array;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URL;
@@ -14,13 +13,11 @@ import java.util.ResourceBundle;
 import javax.net.ssl.HttpsURLConnection;
 
 import com.rarchives.ripme.ui.MainWindow;
-import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.jsoup.HttpStatusException;
 
 import com.rarchives.ripme.ui.RipStatusMessage.STATUS;
 import com.rarchives.ripme.utils.Utils;
-import static java.lang.Math.toIntExact;
 
 /**
  * Thread for downloading files.
@@ -139,6 +136,7 @@ class DownloadFileThread extends Thread {
 
                 int statusCode = huc.getResponseCode();
                 logger.debug("Status code: " + statusCode);
+                // If the server doesn't allow resuming downloads error out
                 if (statusCode != 206 && observer.tryResumeDownload() && saveAs.exists()) {
                     // TODO find a better way to handle servers that don't support resuming downloads then just erroring out
                     throw new IOException(rb.getString("server.doesnt.support.resuming.downloads"));


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Please add details about your change here.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
