### PR TITLE
Added support for optional retweet downloads.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
@@ -26,6 +26,7 @@ public class TwitterRipper extends AlbumRipper {
             HOST = "twitter";
 
     private static final int MAX_REQUESTS = Utils.getConfigInteger("twitter.max_requests", 10);
+    private static final boolean RIP_RETWEETS = Utils.getConfigBoolean("twitter.rip_retweets", true);
     private static final int WAIT_TIME = 2000;
 
     // Base 64 of consumer key : consumer secret
@@ -175,6 +176,11 @@ public class TwitterRipper extends AlbumRipper {
         int parsedCount = 0;
         if (!tweet.has("extended_entities")) {
             LOGGER.error("XXX Tweet doesn't have entitites");
+            return 0;
+        }
+        
+        if (!RIP_RETWEETS && tweet.has("retweeted_status")) {
+            LOGGER.info("Skipping a retweet as twitter.rip_retweet is set to false.");
             return 0;
         }
 

--- a/src/main/resources/rip.properties
+++ b/src/main/resources/rip.properties
@@ -26,6 +26,7 @@ tumblr.auth = JFNLu3CbINQjRdUvZibXW9VpSEVYYtiPJ86o8YmvgLZIoKyuNX
 gw.api = gonewild
 
 twitter.max_requests = 10
+twitter.rip_retweets = false
 
 clipboard.autorip = false
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature (fixes #1221, fixes #784, fixes #1049)


# Description
* Added a boolean  config option `twitter.rip_retweets` in rip.properties. The default value is set to `true` as not to change the behaviour of the TwitterRipper unless needed.
* TwitterRipper does not use the `include_rts` parameter, instead uses the `retweeted_status` attribute for the `tweet object`. 
API description for `retweeted_status` :
`Retweets can be distinguished from typical Tweets by the existence of a retweeted_status attribute. This attribute contains a representation of the original Tweet that was retweeted.`
* Minor changes were required in `parseTweet()` and `RIP_RETWEETS` constant in TwitterRipper.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
