### PR TITLE
Can now pass a map of params to addURLToDownload

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -218,10 +218,42 @@ public abstract class AbstractRipper
     protected abstract boolean addURLToDownload(URL url, File saveAs, String referrer, Map<String, String> cookies,
                                                 Boolean getFileExtFromMIME);
 
-
-    protected boolean addURLToDownload(URL url, Map<String, String> options) {
+    /**
+     * Queues image to be downloaded and saved.
+     * @param url
+     *      URL of the file
+     * @param options
+     *      A map<String,String> containing any changes to the default options.
+     *      Options are getFileExtFromMIME, prefix, subdirectory, referrer, fileName, extension, getFileExtFromMIME.
+     *      getFileExtFromMIME should be "true" or "false"
+     * @param cookies
+     *      The cookies to send to the server while downloading this file.
+     * @return
+     *      True if downloaded successfully
+     *      False if failed to download
+     */
+    protected boolean addURLToDownload(URL url, Map<String, String> options, Map<String, String> cookies) {
+        // Bit of a hack but this lets us pass a bool using a map<string,String>
+        boolean useMIME = options.getOrDefault("getFileExtFromMIME", "false").toLowerCase().equals("true");
         return addURLToDownload(url, options.getOrDefault("prefix", ""), options.getOrDefault("subdirectory", ""), options.getOrDefault("referrer", null),
-                null, options.getOrDefault("fileName", ""), options.getOrDefault("extension", null), false);
+                cookies, options.getOrDefault("fileName", ""), options.getOrDefault("extension", null), useMIME);
+    }
+
+
+    /**
+     * Queues image to be downloaded and saved.
+     * @param url
+     *      URL of the file
+     * @param options
+     *      A map<String,String> containing any changes to the default options.
+     *      Options are getFileExtFromMIME, prefix, subdirectory, referrer, fileName, extension, getFileExtFromMIME.
+     *      getFileExtFromMIME should be "true" or "false"
+     * @return
+     *      True if downloaded successfully
+     *      False if failed to download
+     */
+    protected boolean addURLToDownload(URL url, Map<String, String> options) {
+        return addURLToDownload(url, options, null);
     }
 
     /**

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -218,6 +218,12 @@ public abstract class AbstractRipper
     protected abstract boolean addURLToDownload(URL url, File saveAs, String referrer, Map<String, String> cookies,
                                                 Boolean getFileExtFromMIME);
 
+
+    protected boolean addURLToDownload(URL url, Map<String, String> options) {
+        return addURLToDownload(url, options.getOrDefault("prefix", ""), options.getOrDefault("subdirectory", ""), options.getOrDefault("referrer", null),
+                null, options.getOrDefault("fileName", ""), options.getOrDefault("extension", null), false);
+    }
+
     /**
      * Queues image to be downloaded and saved.
      * @param url


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Now instead of having to remember the order of params for addURLToDownload you can just pass a map. Hopefully this will make using addURLToDownload less frustrating 

I used `getOrDefault` so you'd only have to add the params you'd care about and the rest will be sane default values (So no more trying to remember what those sane defaults are when calling addURLToDownload)

Options are getFileExtFromMIME, prefix, subdirectory, referrer, fileName, extension and getFileExtFromMIME.


getFileExtFromMIME should have a value of "true" if you want it to get the file ext from MIME type

Example 

```
Map<String, String> data = new HashMap<String, String>();
data.put("referrer", "example.tld");
data.put("prefix", "001_");

addURLToDownload(url, data);
```





# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
