### PR TITLE
8muses ripper no longer makes unneeded requests

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EightmusesRipper.java
@@ -115,27 +115,23 @@ public class EightmusesRipper extends AbstractHTMLRipper {
                 String image = null;
                 if (thumb.hasAttr("data-cfsrc")) {
                     image = thumb.attr("data-cfsrc");
-                }
-                else {
+                } else {
                     // Deobfustace the json data
                     String rawJson = deobfuscateJSON(page.select("script#ractive-public").html()
                             .replaceAll("&gt;", ">").replaceAll("&lt;", "<").replace("&amp;", "&"));
+                    LOGGER.info(rawJson);
                     JSONObject json = new JSONObject(rawJson);
                     try {
                         for (int i = 0; i != json.getJSONArray("pictures").length(); i++) {
                             image = "https://www.8muses.com/image/fl/" + json.getJSONArray("pictures").getJSONObject(i).getString("publicUri");
                             URL imageUrl = new URL(image);
-                            if (Utils.getConfigBoolean("8muses.use_short_names", false)) {
-                                addURLToDownload(imageUrl, getPrefixShort(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies, "", null, true);
-                            } else {
-                                addURLToDownload(imageUrl, getPrefixLong(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies, "", null, true);
-                            }
+                            addURLToDownload(imageUrl, getPrefixShort(x), getSubdir(page.select("title").text()), this.url.toExternalForm(), cookies, "", null, true);
                             // X is our page index
                             x++;
                         }
-
-                    } catch (IOException e) {
-                        continue;
+                        return imageURLs;
+                    } catch (MalformedURLException e) {
+                        LOGGER.error("\"" + image + "\" is malformed");
                     }
                 }
                 if (!image.contains("8muses.com")) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #1254)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fixed bug that caused ripme to request files multiple times per 8muses rip 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
