### PR TITLE
Added ripper for Erofus.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -236,7 +236,7 @@ public abstract class AbstractRipper
         // Bit of a hack but this lets us pass a bool using a map<string,String>
         boolean useMIME = options.getOrDefault("getFileExtFromMIME", "false").toLowerCase().equals("true");
         return addURLToDownload(url, options.getOrDefault("prefix", ""), options.getOrDefault("subdirectory", ""), options.getOrDefault("referrer", null),
-                cookies, options.getOrDefault("fileName", ""), options.getOrDefault("extension", null), useMIME);
+                cookies, options.getOrDefault("fileName", null), options.getOrDefault("extension", null), useMIME);
     }
 
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ErofusRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ErofusRipper.java
@@ -1,0 +1,134 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.ui.RipStatusMessage;
+import com.rarchives.ripme.utils.Http;
+import org.json.JSONObject;
+import org.jsoup.Connection;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ErofusRipper extends AbstractHTMLRipper {
+
+    private Document albumDoc = null;
+    private Map<String,String> cookies = new HashMap<>();
+    // TODO put up a wiki page on using maps to store titles
+    // the map for storing the title of each album when downloading sub albums
+    private Map<URL,String> urlTitles = new HashMap<>();
+
+    private Boolean rippingSubalbums = false;
+
+    public ErofusRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public boolean hasASAPRipping() {
+        return true;
+    }
+
+    @Override
+    public String getHost() {
+        return "erofus";
+    }
+
+    @Override
+    public String getDomain() {
+        return "erofus.com";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https://www.erofus.com/comics/([a-zA-Z0-9\\-_]+).*$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (!m.matches()) {
+            throw new MalformedURLException("Expected URL format: http://www.8muses.com/index/category/albumname, got: " + url);
+        }
+        return m.group(m.groupCount());
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        if (albumDoc == null) {
+            Connection.Response resp = Http.url(url).response();
+            cookies.putAll(resp.cookies());
+            albumDoc = resp.parse();
+        }
+        return albumDoc;
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document page) {
+        LOGGER.info(page);
+        List<String> imageURLs = new ArrayList<>();
+        int x = 1;
+        if (pageContainsImages(page)) {
+            LOGGER.info("Page contains images");
+            imageURLs.addAll(ripAlbum(page));
+        } else {
+            // This contains the thumbnails of all images on the page
+            Elements pageImages = page.select("a.a-click");
+            for (Element pageLink : pageImages) {
+                if (super.isStopped()) break;
+                if (pageLink.attr("href").contains("comics")) {
+                    String subUrl = "https://erofus.com" + pageLink.attr("href");
+                    try {
+                        LOGGER.info("Retrieving " + subUrl);
+                        sendUpdate(RipStatusMessage.STATUS.LOADING_RESOURCE, subUrl);
+                        Document subPage = Http.url(subUrl).get();
+                        List<String> subalbumImages = getURLsFromPage(subPage);
+                    } catch (IOException e) {
+                        LOGGER.warn("Error while loading subalbum " + subUrl, e);
+                    }
+                }
+                if (isThisATest()) break;
+            }
+        }
+
+
+        return imageURLs;
+    }
+
+    public List<String> ripAlbum(Document page) {
+        int x = 1;
+        List<String> imageURLs = new ArrayList<>();
+        Elements thumbs = page.select("a.a-click > div.thumbnail > img");
+        for (Element thumb : thumbs) {
+            String image = "https://www.erofus.com" + thumb.attr("src").replaceAll("thumb", "medium");
+            imageURLs.add(image);
+            try {
+                addURLToDownload(new URL(image), getPrefix(x));
+            } catch (MalformedURLException e) {
+                LOGGER.info(e.getMessage());
+            }
+            x++;
+        }
+        return imageURLs;
+    }
+
+    private boolean pageContainsImages(Document page) {
+        Elements pageImages = page.select("a.a-click");
+        for (Element pageLink : pageImages) {
+            if (pageLink.attr("href").contains("/pic/")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index), "", this.url.toExternalForm(), cookies);
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ErofusRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ErofusRipper.java
@@ -3,8 +3,6 @@ package com.rarchives.ripme.ripper.rippers;
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import com.rarchives.ripme.ui.RipStatusMessage;
 import com.rarchives.ripme.utils.Http;
-import org.json.JSONObject;
-import org.jsoup.Connection;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -20,14 +18,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ErofusRipper extends AbstractHTMLRipper {
-
-    private Document albumDoc = null;
-    private Map<String,String> cookies = new HashMap<>();
-    // TODO put up a wiki page on using maps to store titles
-    // the map for storing the title of each album when downloading sub albums
-    private Map<URL,String> urlTitles = new HashMap<>();
-
-    private Boolean rippingSubalbums = false;
 
     public ErofusRipper(URL url) throws IOException {
         super(url);
@@ -60,12 +50,7 @@ public class ErofusRipper extends AbstractHTMLRipper {
 
     @Override
     public Document getFirstPage() throws IOException {
-        if (albumDoc == null) {
-            Connection.Response resp = Http.url(url).response();
-            cookies.putAll(resp.cookies());
-            albumDoc = resp.parse();
-        }
-        return albumDoc;
+        return Http.url(url).get();
     }
 
     @Override
@@ -129,6 +114,6 @@ public class ErofusRipper extends AbstractHTMLRipper {
 
     @Override
     public void downloadURL(URL url, int index) {
-        addURLToDownload(url, getPrefix(index), "", this.url.toExternalForm(), cookies);
+        addURLToDownload(url, getPrefix(index));
     }
 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ErofusRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ErofusRipper.java
@@ -75,7 +75,7 @@ public class ErofusRipper extends AbstractHTMLRipper {
         int x = 1;
         if (pageContainsImages(page)) {
             LOGGER.info("Page contains images");
-            imageURLs.addAll(ripAlbum(page));
+            ripAlbum(page);
         } else {
             // This contains the thumbnails of all images on the page
             Elements pageImages = page.select("a.a-click");
@@ -100,21 +100,21 @@ public class ErofusRipper extends AbstractHTMLRipper {
         return imageURLs;
     }
 
-    public List<String> ripAlbum(Document page) {
+    public void ripAlbum(Document page) {
         int x = 1;
-        List<String> imageURLs = new ArrayList<>();
         Elements thumbs = page.select("a.a-click > div.thumbnail > img");
         for (Element thumb : thumbs) {
             String image = "https://www.erofus.com" + thumb.attr("src").replaceAll("thumb", "medium");
-            imageURLs.add(image);
             try {
-                addURLToDownload(new URL(image), getPrefix(x));
+                Map<String,String> opts = new HashMap<String, String>();
+                opts.put("subdirectory", page.title().replaceAll(" \\| Erofus - Sex and Porn Comics", "").replaceAll(" ", "_"));
+                opts.put("prefix", getPrefix(x));
+                addURLToDownload(new URL(image), opts);
             } catch (MalformedURLException e) {
                 LOGGER.info(e.getMessage());
             }
             x++;
         }
-        return imageURLs;
     }
 
     private boolean pageContainsImages(Document page) {

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ErofusRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ErofusRipperTest.java
@@ -1,0 +1,13 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.ErofusRipper;
+
+public class CfakeRipperTest extends RippersTest {
+    public void testRip() throws IOException {
+        ErofusRipper ripper = new ErofusRipper(new URL("https://www.erofus.com/comics/be-story-club-comics/a-kiss/issue-1"));
+        testRipper(ripper);
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ErofusRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ErofusRipperTest.java
@@ -10,4 +10,9 @@ public class ErofusRipperTest extends RippersTest {
         ErofusRipper ripper = new ErofusRipper(new URL("https://www.erofus.com/comics/be-story-club-comics/a-kiss/issue-1"));
         testRipper(ripper);
     }
+
+    public void testGetGID() throws IOException {
+        ErofusRipper ripper = new ErofusRipper(new URL("https://www.erofus.com/comics/be-story-club-comics/a-kiss/issue-1"));
+        assertEquals("be-story-club-comics", ripper.getGID(new URL("https://www.erofus.com/comics/be-story-club-comics/a-kiss/issue-1")));
+    }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ErofusRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ErofusRipperTest.java
@@ -5,7 +5,7 @@ import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.ErofusRipper;
 
-public class CfakeRipperTest extends RippersTest {
+public class ErofusRipperTest extends RippersTest {
     public void testRip() throws IOException {
         ErofusRipper ripper = new ErofusRipper(new URL("https://www.erofus.com/comics/be-story-club-comics/a-kiss/issue-1"));
         testRipper(ripper);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Adds basic support for erofus.com


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
