### PR TITLE
Added opt to disable prefix for HentaifoundryRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaifoundryRipper.java
@@ -180,7 +180,12 @@ public class HentaifoundryRipper extends AbstractHTMLRipper {
         if (url.toExternalForm().endsWith(".pdf")) {
             addURLToDownload(url, getPrefix(index), "", this.url.toExternalForm(), cookies);
         } else {
-            addURLToDownload(url, getPrefix(index));
+//            If hentai-foundry.use_prefix is false the ripper will not add a numbered prefix to any images
+            if (Utils.getConfigBoolean("hentai-foundry.use_prefix", true)) {
+                addURLToDownload(url, getPrefix(index));
+            } else {
+                addURLToDownload(url, "");
+            }
         }
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


# Description

Added an option to disable file prefix for hentai foundry albums 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
