### PR TITLE
Ripme now counts files as already download (for the history.end_rip_a…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -46,7 +46,7 @@ public abstract class AbstractRipper
     public abstract String getGID(URL url) throws MalformedURLException;
     public boolean hasASAPRipping() { return false; }
     // Everytime addUrlToDownload skips a already downloaded url this increases by 1
-    public int alreadyDownloadedUrls = 0;
+    public static int alreadyDownloadedUrls = 0;
     private boolean shouldStop = false;
     private static boolean thisIsATest = false;
 

--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -158,6 +158,7 @@ public abstract class AlbumRipper extends AbstractRipper {
         itemsPending.remove(url);
         itemsCompleted.put(url, file);
         observer.update(this, new RipStatusMessage(STATUS.DOWNLOAD_WARN, url + " already saved as " + file.getAbsolutePath()));
+        AbstractRipper.alreadyDownloadedUrls += 1;
 
         checkIfComplete();
     }


### PR DESCRIPTION
…fter_already_seen feature) if they appear on disk and not in the url history file

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

This change allows ripme to count files that exist on disk but were never added to the url history file to be counted as already downloaded. 

This allows user to use the history.end_ripe_after_already_seen feature without needing to save a list of all files the user has downloaded


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
