### PR TITLE
Fix Instagram ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -243,7 +243,14 @@ public class InstagramRipper extends AbstractJSONRipper {
 
         // get the rhx_gis value so we can get the next page later on
         if (rhx_gis == null) {
-            rhx_gis = json.getString("rhx_gis");
+            try {
+                rhx_gis = json.getString("rhx_gis");
+            } catch (JSONException ex) {
+                // Instagram has removed this token, but ...
+                LOGGER.error("Error while getting rhx_gis: " + ex.getMessage());                
+                //... if we set it to "", the next page can still be fetched
+                rhx_gis = "";
+            }
         }
         if (!url.toExternalForm().contains("/p/")) {
             JSONArray datas = new JSONArray();


### PR DESCRIPTION

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix RipMeApp/ripme#1314)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

The `rhx_gis` variable was removed by Instagram. It seems like we can still fetch pages without it, so we ignore the error and set `rhx_gis` to an empty string.

I tried re-ripping multible accounts that were downloaded using the previous version, and all files were downloaded and are the same, so I assume that it should work for all accounts & post links.

If needed, the variable could also be removed from the ripper (since it no longer serves any purpose).

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
