### PR TITLE
Motherless ripper now ignores gallery 404 pages

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MotherlessRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MotherlessRipper.java
@@ -83,31 +83,32 @@ public class MotherlessRipper extends AlbumRipper {
                                .get();
             Elements errorPage = doc.select("div.error-page");
             if (!errorPage.isEmpty()) {
-                break;
+                LOGGER.warn("[!] 404 received from " + nextURL);
             }
-            for (Element thumb : doc.select("div.thumb a.img-container")) {
-                if (isStopped()) {
-                    break;
-                }
-                String thumbURL = thumb.attr("href");
-                if (thumbURL.contains("pornmd.com")) {
-                    continue;
-                }
-                URL url;
-                if (!thumbURL.startsWith("http")) {
-                    url = new URL("http://" + DOMAIN + thumbURL);
-                }
-                else {
-                    url = new URL(thumbURL);
-                }
-                index += 1;
+            else {
+                for (Element thumb : doc.select("div.thumb a.img-container")) {
+                    if (isStopped()) {
+                        break;
+                    }
+                    String thumbURL = thumb.attr("href");
+                    if (thumbURL.contains("pornmd.com")) {
+                        continue;
+                    }
+                    URL url;
+                    if (!thumbURL.startsWith("http")) {
+                        url = new URL("http://" + DOMAIN + thumbURL);
+                    } else {
+                        url = new URL(thumbURL);
+                    }
+                    index += 1;
 
-                // Create thread for finding image at "url" page
-                MotherlessImageThread mit = new MotherlessImageThread(url, index);
-                motherlessThreadPool.addThread(mit);
+                    // Create thread for finding image at "url" page
+                    MotherlessImageThread mit = new MotherlessImageThread(url, index);
+                    motherlessThreadPool.addThread(mit);
 
-                if (isThisATest()) {
-                    break;
+                    if (isThisATest()) {
+                        break;
+                    }
                 }
             }
             if (isThisATest()) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MotherlessRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MotherlessRipper.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 
 import com.rarchives.ripme.ripper.AlbumRipper;
 import com.rarchives.ripme.ripper.DownloadThreadPool;
@@ -80,6 +81,10 @@ public class MotherlessRipper extends AlbumRipper {
             Document doc = Http.url(nextURL)
                                .referrer("http://motherless.com")
                                .get();
+            Elements errorPage = doc.select("div.error-page");
+            if (!errorPage.isEmpty()) {
+                break;
+            }
             for (Element thumb : doc.select("div.thumb a.img-container")) {
                 if (isStopped()) {
                     break;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MotherlessRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MotherlessRipperTest.java
@@ -8,7 +8,7 @@ import com.rarchives.ripme.ripper.rippers.MotherlessRipper;
 public class MotherlessRipperTest extends RippersTest {
     // https://github.com/RipMeApp/ripme/issues/238 - MotherlessRipperTest is flaky on Travis CI
     public void testMotherlessAlbumRip() throws IOException {
-        MotherlessRipper ripper = new MotherlessRipper(new URL("https://motherless.com/G1168D90"));
+        MotherlessRipper ripper = new MotherlessRipper(new URL("https://motherless.com/GIAB5CB01"));
         testRipper(ripper);
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix ([#1318](https://github.com/RipMeApp/ripme/issues/1318))
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Just a tiny tweak to check if the gallery response is a 404 error page before attempting to download media.

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
I don't know how to do this.  I'm new to Java and could barely code the tweak itself.
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
