### PR TITLE
Instagram ripper no long throws an error when it can't find the qhash…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -159,7 +159,8 @@ public class InstagramRipper extends AbstractJSONRipper {
         Document p = resp.parse();
         // Get the query hash so we can download the next page
         qHash = getQHash(p);
-        if (qHash == null) {
+        // The qHash is not needed if ripping a single post
+        if (qHash == null && !url.toExternalForm().contains("/p/")) {
             throw new IOException("Unable to extract qhash from page");
         }
         return getJSONFromPage(p);


### PR DESCRIPTION
… on single posts

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1343)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

This PR fixes ripping single posts (pages wiht /p/ in the url) from instagram 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
