### PR TITLE
Rewrote ClipboardUtils regex (Fixes #1350)

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/ClipboardUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/ClipboardUtils.java
@@ -56,18 +56,7 @@ class AutoripThread extends Thread {
                 // Check clipboard
                 String clipboard = ClipboardUtils.getClipboardString();
                 if (clipboard != null) {
-                    Pattern p = Pattern.compile(
-                            // TODO: This regex is a monster and doesn't match all links; It needs to be rewritten
-                            "\\b(((ht|f)tp(s?)://|~/|/)|www.)" +
-                            "(\\w+:\\w+@)?(([-\\w]+\\.)+(com|org|net|gov" +
-                            "|mil|biz|info|mobi|name|aero|jobs|museum" +
-                            "|travel|cafe|[a-z]{2}))(:[\\d]{1,5})?" +
-                            "(((/([-\\w~!$+|.,=]|%[a-f\\d]{2})+)+|/)+|\\?|#)?" +
-                            "((\\?([-\\w~!$+|.,*:]|%[a-f\\d{2}])+=?" +
-                            "([-\\w~!$+|.,*:=]|%[a-f\\d]{2})*)" +
-                            "(&(?:[-\\w~!$+|.,*:]|%[a-f\\d{2}])+=?" +
-                            "([-\\w~!$+|.,*:=]|%[a-f\\d]{2})*)*)*" +
-                            "(#([-\\w~!$+|.,*:=]|%[a-f\\d]{2})*)?\\b");
+                    Pattern p = Pattern.compile("^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]");
                     Matcher m = p.matcher(clipboard);
                     while (m.find()) {
                         String url = m.group();


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1350)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Can now rip links including @ from the clipboard 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
