### PR TITLE
Functional regex for getting image url list (MeituriRipper)

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MeituriRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MeituriRipper.java
@@ -35,11 +35,11 @@ public class MeituriRipper extends AbstractHTMLRipper {
     @Override
     public String getGID(URL url) throws MalformedURLException {
         // without escape
-        // ^https?://[w.]*meituri\.com/a/([0-9]+)/([0-9\.html]+)*$
+        // ^https?://[w.]*meituri\.com/a/([0-9]+)/([0-9]+\.html)*$
         // https://www.meituri.com/a/14449/
         // also matches https://www.meituri.com/a/14449/3.html etc.
         // group 1 is 14449
-        Pattern p = Pattern.compile("^https?://[w.]*meituri\\.com/a/([0-9]+)/([0-9\\.html]+)*$");
+        Pattern p = Pattern.compile("^https?://[w.]*meituri\\.com/a/([0-9]+)/([0-9]+\\.html)*$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             albumID = m.group(1);
@@ -59,27 +59,22 @@ public class MeituriRipper extends AbstractHTMLRipper {
         List<String> imageURLs = new ArrayList<>();
         // Get number of images from the page
         // Then generate links according to that
-        String numOfImages = "";
-        // A very ugly way of getting "图片数量： 55P" from paragraphs
-        // 3rd p in div.tuji
-        int n = 0;
+        int numOfImages = 1;
+        Pattern p = Pattern.compile("^<p>图片数量： ([0-9]+)P</p>$");
         for (Element para : doc.select("div.tuji > p")) {
-            // 图片数量： 55P
-            if (n == 2) {
-                numOfImages = para.toString();
+            // <p>图片数量： 55P</p>
+            Matcher m = p.matcher(para.toString());
+            if (m.matches()) {
+                // 55
+                numOfImages = Integer.parseInt(m.group(1));
             }
-            n++;
         }
-        // ["<p>图片数量：", "55P</p>"]
-        String[] splitNumOfImages = numOfImages.split(" ");
-        // "55P</p>" -> "55" -> 55
-        int actualNumOfImages = Integer.parseInt(splitNumOfImages[1].replace("P</p>", ""));
 
         // Base URL: http://ii.hywly.com/a/1/albumid/imgnum.jpg
         String baseURL = "http://ii.hywly.com/a/1/" + albumID + "/";
 
         // Loop through and add images to the URL list
-        for (int i = 1; i <= actualNumOfImages; i++) {
+        for (int i = 1; i <= numOfImages; i++) {
             imageURLs.add(baseURL + i + ".jpg");
         }
         return imageURLs;


### PR DESCRIPTION
Also change website regex like I mentioned in a comment in #1360

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

On some pages number of images that I gathered from the page, that I needed to generate image links were displayed on 2nd row instead of 3rd. My method of getting number of images were ugly and looked at the 3rd row all the time regardless of what's there. This new method actually looks for the info I need (number of images) using regex and not arbitrary places on the page hoping for the info I need.

I've also changed the website regex a tiny bit as I mentioned in my comment in #1360.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
