### PR TITLE
Adding support for CLI option to change history file path.

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -120,7 +120,6 @@ public class App {
             String historyLocation = cl.getOptionValue('z').trim();
             Utils.setConfigString("history.location", historyLocation);
             logger.info("Set history file to " + historyLocation);
-            logger.info(args['z']);
         }
 
         //Allow file overwriting

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -241,6 +241,10 @@ public class App {
                 logger.error("[!] Failed reading file containing list of URLs. Cannot continue.");
             }
         }
+        
+        if (cl.hasOption('H')) {
+            String historylocation = cl.getOptionValue('H');
+        }
 
         //The URL to rip.
         if (cl.hasOption('u')) {
@@ -303,6 +307,7 @@ public class App {
         opts.addOption("p", "proxy-server", true, "Use HTTP Proxy server ([user:password]@host[:port])");
         opts.addOption("j", "update", false, "Update ripme");
         opts.addOption("a","append-to-folder", true, "Append a string to the output folder name");
+        opts.addOption("H", "history", false, "Set history file location.");
         return opts;
     }
 

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -117,8 +117,8 @@ public class App {
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
 
         //Set history file
-        if (cl.hasOption("z")) {
-            String historyLocation = cl.getOptionValue("z").trim();
+        if (cl.hasOption('z')) {
+            String historyLocation = cl.getOptionValue('z');
             Utils.setConfigString("history.location", historyLocation);
             logger.info("Set history file to " + historyLocation);
         }

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -117,8 +117,8 @@ public class App {
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
 
         //Set history file
-        if (cl.hasOption('z')) {
-            String historyLocation = cl.getOptionValue('z');
+        if (cl.hasOption('H')) {
+            String historyLocation = cl.getOptionValue('H');
             Utils.setConfigString("history.location", historyLocation);
             logger.info("Set history file to " + historyLocation);
         }
@@ -310,7 +310,7 @@ public class App {
         opts.addOption("p", "proxy-server", true, "Use HTTP Proxy server ([user:password]@host[:port])");
         opts.addOption("j", "update", false, "Update ripme");
         opts.addOption("a","append-to-folder", true, "Append a string to the output folder name");
-        opts.addOption("z", "history", true, "Set history file location.");
+        opts.addOption("H", "history", true, "Set history file location.");
         return opts;
     }
 

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -117,9 +117,10 @@ public class App {
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
         
         if (cl.hasOption('z')) {
-            String historyLocation = cl.getOption('z').trim();
+            String historyLocation = cl.getOptionValue('z').trim();
             Utils.setConfigString("history.location", historyLocation);
             logger.info("Set history file to " + historyLocation);
+            logger.info(args['z']);
         }
 
         //Allow file overwriting

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -310,7 +310,7 @@ public class App {
         opts.addOption("p", "proxy-server", true, "Use HTTP Proxy server ([user:password]@host[:port])");
         opts.addOption("j", "update", false, "Update ripme");
         opts.addOption("a","append-to-folder", true, "Append a string to the output folder name");
-        opts.addOption("z", "history", false, "Set history file location.");
+        opts.addOption("z", "history", true, "Set history file location.");
         return opts;
     }
 

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -115,6 +115,10 @@ public class App {
 
         Utils.configureLogger();
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
+        
+        if (cl.hasOption('H')) {
+            Utils.setConfigString("history.location", cl.getOptionValue('H'))
+        }
 
         //Allow file overwriting
         if (cl.hasOption('w')) {
@@ -240,10 +244,6 @@ public class App {
             } catch (IOException ioe) {
                 logger.error("[!] Failed reading file containing list of URLs. Cannot continue.");
             }
-        }
-        
-        if (cl.hasOption('H')) {
-            String historylocation = cl.getOptionValue('H');
         }
 
         //The URL to rip.

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -117,7 +117,7 @@ public class App {
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
         
         if (cl.hasOption('z')) {
-            String historyLocation = cl.getOptionValue('z');
+            String historyLocation = cl.getOption('z');
             Utils.setConfigString("history.location", historyLocation);
             logger.info("Set history file to " + historyLocation);
         }

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -118,7 +118,7 @@ public class App {
         
         if (cl.hasOption('H')) {
             Utils.setConfigString("history.location", cl.getOptionValue('H'));
-            System.out.print(cl.getOptionValue('H'));
+            logger.info("Set history file to " + cl.getOptionValue('H'));
         }
 
         //Allow file overwriting

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -118,6 +118,7 @@ public class App {
         
         if (cl.hasOption('H')) {
             Utils.setConfigString("history.location", cl.getOptionValue('H'));
+            System.out.print(cl.getOptionValue('H'));
         }
 
         //Allow file overwriting

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -69,12 +69,6 @@ public class App {
             logger.info(cl.getOptionValue("a"));
             stringToAppendToFoldername = cl.getOptionValue("a");
         }
-        
-        if (cl.hasOption('z')) {
-            String historyLocation = cl.getOptionValue('z').trim();
-            Utils.setConfigString("history.location", historyLocation);
-            logger.info("Set history file to " + historyLocation);
-        }
 
         if (GraphicsEnvironment.isHeadless() || args.length > 0) {
             handleArguments(args);
@@ -122,6 +116,13 @@ public class App {
         Utils.configureLogger();
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
 
+        //Set history file
+        if (cl.hasOption("z")) {
+            String historyLocation = cl.getOptionValue("z").trim();
+            Utils.setConfigString("history.location", historyLocation);
+            logger.info("Set history file to " + historyLocation);
+        }
+        
         //Allow file overwriting
         if (cl.hasOption('w')) {
             Utils.setConfigBoolean("file.overwrite", true);

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -69,6 +69,12 @@ public class App {
             logger.info(cl.getOptionValue("a"));
             stringToAppendToFoldername = cl.getOptionValue("a");
         }
+        
+        if (cl.hasOption('z')) {
+            String historyLocation = cl.getOptionValue('z').trim();
+            Utils.setConfigString("history.location", historyLocation);
+            logger.info("Set history file to " + historyLocation);
+        }
 
         if (GraphicsEnvironment.isHeadless() || args.length > 0) {
             handleArguments(args);
@@ -115,12 +121,6 @@ public class App {
 
         Utils.configureLogger();
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
-        
-        if (cl.hasOption('z')) {
-            String historyLocation = cl.getOptionValue('z').trim();
-            Utils.setConfigString("history.location", historyLocation);
-            logger.info("Set history file to " + historyLocation);
-        }
 
         //Allow file overwriting
         if (cl.hasOption('w')) {

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -117,7 +117,7 @@ public class App {
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
         
         if (cl.hasOption('H')) {
-            Utils.setConfigString("history.location", cl.getOptionValue('H'))
+            Utils.setConfigString("history.location", cl.getOptionValue('H'));
         }
 
         //Allow file overwriting

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -117,8 +117,9 @@ public class App {
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
         
         if (cl.hasOption('z')) {
-            Utils.setConfigString("history.location", cl.getOptionValue('z'));
-            logger.info("Set history file to " + cl.getOptionValue('z'));
+            String historyLocation = cl.getOptionValue('z');
+            Utils.setConfigString("history.location", historyLocation);
+            logger.info("Set history file to " + historyLocation);
         }
 
         //Allow file overwriting
@@ -308,7 +309,7 @@ public class App {
         opts.addOption("p", "proxy-server", true, "Use HTTP Proxy server ([user:password]@host[:port])");
         opts.addOption("j", "update", false, "Update ripme");
         opts.addOption("a","append-to-folder", true, "Append a string to the output folder name");
-        opts.addOption("H", "history", false, "Set history file location.");
+        opts.addOption("z", "history", false, "Set history file location.");
         return opts;
     }
 

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -116,9 +116,9 @@ public class App {
         Utils.configureLogger();
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
         
-        if (cl.hasOption('H')) {
-            Utils.setConfigString("history.location", cl.getOptionValue('H'));
-            logger.info("Set history file to " + cl.getOptionValue('H'));
+        if (cl.hasOption('z')) {
+            Utils.setConfigString("history.location", cl.getOptionValue('z'));
+            logger.info("Set history file to " + cl.getOptionValue('z'));
         }
 
         //Allow file overwriting

--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -117,7 +117,7 @@ public class App {
         logger.info("Initialized ripme v" + UpdateUtils.getThisJarVersion());
         
         if (cl.hasOption('z')) {
-            String historyLocation = cl.getOption('z');
+            String historyLocation = cl.getOption('z').trim();
             Utils.setConfigString("history.location", historyLocation);
             logger.info("Set history file to " + historyLocation);
         }

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -42,6 +42,7 @@ public class Utils {
     private static final String OS = System.getProperty("os.name").toLowerCase();
     private static final Logger LOGGER = Logger.getLogger(Utils.class);
     private static final int SHORTENED_PATH_LENGTH = 12;
+    private static final String HISTORY_FILE = "";
 
     private static PropertiesConfiguration config;
     private static HashMap<String, HashMap<String, String>> cookieCache;

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -272,7 +272,7 @@ public class Utils {
         if(getConfigString("history.location", "").length()==0) {
             return getConfigDir() + File.separator + "url_history.txt";
         }else{
-            return getConfigString("history.location");
+            return getConfigString("history.location", "");
         }
     }
 

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -42,7 +42,6 @@ public class Utils {
     private static final String OS = System.getProperty("os.name").toLowerCase();
     private static final Logger LOGGER = Logger.getLogger(Utils.class);
     private static final int SHORTENED_PATH_LENGTH = 12;
-    private static final String HISTORY_FILE = "";
 
     private static PropertiesConfiguration config;
     private static HashMap<String, HashMap<String, String>> cookieCache;
@@ -270,10 +269,10 @@ public class Utils {
      * Return the path of the url history file
      */
     public static String getURLHistoryFile() {
-        if(HISTORY_FILE.length()==0) {
+        if(getConfigString("history.location", "").length()==0) {
             return getConfigDir() + File.separator + "url_history.txt";
         }else{
-            return HISTORY_FILE;
+            return getConfigString("history.location");
         }
     }
 

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -270,7 +270,11 @@ public class Utils {
      * Return the path of the url history file
      */
     public static String getURLHistoryFile() {
-        return getConfigDir() + File.separator + "url_history.txt";
+        if(HISTORY_FILE.length()==0) {
+            return getConfigDir() + File.separator + "url_history.txt";
+        }else{
+            return HISTORY_FILE;
+        }
     }
 
     /**


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


# Description

Added ability to set history filename and path on the CLI using -H or --history. Defaults to the usual url_history.txt file.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
