### PR TITLE
Fix CLI displays no infomation if "save logs" is checked

### DIFF
--- a/src/main/resources/log4j.file.properties
+++ b/src/main/resources/log4j.file.properties
@@ -10,7 +10,7 @@ log4j.appender.FILE.layout.ConversionPattern = %d %-5p %c{2} %x.%M() %m%n
 # define the console appender
 log4j.appender.stdout = org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target = System.out
-log4j.appender.stdout.Threshold = warn
+log4j.appender.stdout.Threshold = info
 log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern = %m%n
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #471)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Change Threshold of console appender when Save Logs is on (Using log4j.file.properties instead of log4j.properties)


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
