### PR TITLE
New Chans to ChanRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -29,7 +29,11 @@ public class ChanRipper extends AbstractHTMLRipper {
             new ChanSite("boards.420chan.org"),
             new ChanSite("7chan.org"),
             new ChanSite("desuarchive.org", "desu-usergeneratedcontent.xyz"),
-            new ChanSite("8ch.net", "media.8ch.net")
+            new ChanSite("8ch.net", "media.8ch.net"),
+            new ChanSite("thebarchive.com"),
+            new ChanSite("archiveofsins.com"),
+            new ChanSite("archive.nyafuu.org"),
+            new ChanSite("rbt.asia")
         );
     private static List<ChanSite> user_give_explicit_domains = getChansFromConfig(Utils.getConfigString("chans.chan_sites", null));
     private static List<ChanSite> explicit_domains = new ArrayList<>();
@@ -146,7 +150,7 @@ public class ChanRipper extends AbstractHTMLRipper {
 
         String u = url.toExternalForm();
         if (u.contains("/thread/") || u.contains("/res/") || u.contains("yuki.la") || u.contains("55chan.org")) {
-            p = Pattern.compile("^.*\\.[a-z]{1,3}/[a-zA-Z0-9]+/(thread|res)/([0-9]+)(\\.html|\\.php)?.*$");
+            p = Pattern.compile("^.*\\.[a-z]{1,4}/[a-zA-Z0-9]+/(thread|res)/([0-9]+)(\\.html|\\.php)?.*$");
             m = p.matcher(u);
             if (m.matches()) {
                 return m.group(2);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ChanRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ChanRipperTest.java
@@ -34,6 +34,7 @@ public class ChanRipperTest extends RippersTest {
         passURLs.add(new URL("https://boards.4chan.org/hr/thread/3015701"));
         passURLs.add(new URL("https://boards.420chan.org/420/res/232066.php"));
         passURLs.add(new URL("http://7chan.org/gif/res/25873.html"));
+        passURLs.add(new URL("https://rbt.asia/g/thread/70643087/")); //must work with TLDs with len of 4
         for (URL url : passURLs) {
             ChanRipper ripper = new ChanRipper(url);
             ripper.setup();


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix
* [X] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Add thebarchive.com, archiveofsins.com, archive.nyafuu.org, rbt.asia to ChanRipper as requested in https://github.com/RipMeApp/ripme/issues/38#issuecomment-485391989
Fix regex to allow TLDs with len of 4


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [X] Downloads all relevant content.
  * [X] Downloads content from multiple pages (as necessary or appropriate).
  * [X] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
