### PR TITLE
Fix history when rip using -u

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -9,8 +9,12 @@ import java.io.FileNotFoundException;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.List;
+import java.util.Collections;
+import java.util.Date;
 
 import javax.swing.SwingUtilities;
 
@@ -97,6 +101,21 @@ public class App {
         AbstractRipper ripper = AbstractRipper.getRipper(url);
         ripper.setup();
         ripper.rip();
+
+        String u = ripper.getURL().toExternalForm();
+        Date date = new Date();
+        if (HISTORY.containsURL(u)) {
+            HistoryEntry entry = HISTORY.getEntryByURL(u);
+            entry.modifiedDate = date;
+        } else {
+            HistoryEntry entry = new HistoryEntry();
+            entry.url = u;
+            entry.dir = ripper.getWorkingDir().getAbsolutePath();
+            try {
+                entry.title = ripper.getAlbumTitle(ripper.getURL());
+            } catch (MalformedURLException e) { }
+            HISTORY.add(entry);
+        }
     }
 
     /**
@@ -146,13 +165,17 @@ public class App {
         //Re-rip <i>all</i> previous albums
         if (cl.hasOption('r')) {
             // Re-rip all via command-line
-            List<String> history = Utils.getConfigList("download.history");
-            for (String urlString : history) {
+            loadHistory();
+            if (HISTORY.toList().isEmpty()) {
+                logger.error("There are no history entries to re-rip. Rip some albums first");
+                System.exit(-1);
+            }
+            for (HistoryEntry entry : HISTORY.toList()) {
                 try {
-                    URL url = new URL(urlString.trim());
-                    rip(url);
+                    URL url = new URL(entry.url);
+                     rip(url);
                 } catch (Exception e) {
-                    logger.error("[!] Failed to rip URL " + urlString, e);
+                    logger.error("[!] Failed to rip URL " + entry.url, e);
                     continue;
                 }
                 try {
@@ -244,6 +267,7 @@ public class App {
 
         //The URL to rip.
         if (cl.hasOption('u')) {
+            loadHistory();
             String url = cl.getOptionValue('u').trim();
             ripURL(url, !cl.hasOption("n"));
         }
@@ -263,14 +287,7 @@ public class App {
         try {
             URL url = new URL(targetURL);
             rip(url);
-            List<String> history = Utils.getConfigList("download.history");
-            if (!history.contains(url.toExternalForm())) {//if you haven't already downloaded the file before
-                history.add(url.toExternalForm());//add it to history so you won't have to redownload
-                Utils.setConfigList("download.history", Arrays.asList(history.toArray()));
-                if (saveConfig) {
-                    Utils.saveConfig();
-                }
-            }
+            saveHistory();
         } catch (MalformedURLException e) {
             logger.error("[!] Given URL is not valid. Expected URL format is http://domain.com/...");
             // System.exit(-1);
@@ -324,6 +341,7 @@ public class App {
 
     /**
      * Loads history from history file into memory.
+     * @see MainWindow.loadHistory
      */
     private static void loadHistory() {
         File historyFile = new File(Utils.getConfigDir() + File.separator + "history.json");
@@ -357,6 +375,24 @@ public class App {
                     }
                 }
             }
+        }
+    }
+
+    /* 
+    * @see MainWindow.saveHistory
+    */
+    private static void saveHistory() {
+        Path historyFile = Paths.get(Utils.getConfigDir() + File.separator + "history.json");
+        try {
+            if (!Files.exists(historyFile)) {
+                Files.createDirectories(historyFile.getParent());
+                Files.createFile(historyFile);
+            }
+
+            HISTORY.toFile(historyFile.toString());
+            Utils.setConfigList("download.history", Collections.emptyList());
+        } catch (IOException e) {
+            logger.error("Failed to save history to file " + historyFile, e);
         }
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #1195, #1230)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fix history when rip using -u
Fix history load when using -r. Now it's load from history.json instead of rip.properties


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
