### PR TITLE
Pornhub upsell fix

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/video/PornhubRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/video/PornhubRipper.java
@@ -69,10 +69,12 @@ public class PornhubRipper extends VideoRipper {
                 int bestQual = 0;
                 for (int i = 0; i < mediaDef.length(); i++) {
                     JSONObject e = (JSONObject) mediaDef.get(i);
-                    int quality = Integer.parseInt((String)e.get("quality"));
-                    if (quality > bestQual) {
-                        bestQual = quality;
-                        vidUrl = (String)e.get("videoUrl");
+                    if (!"upsell".equals(e.getString("format"))) {
+                        int quality = Integer.parseInt((String)e.get("quality"));
+                        if (quality > bestQual) {
+                            bestQual = quality;
+                            vidUrl = (String)e.get("videoUrl");
+                        }
                     }
                 }
                 if (vidUrl == null) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1288, Fix #1329)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Download was failing on some Pornhub videos due to the upsell format being used.  These are blank unless you pay for them.  Fix was to ignore any quality entries that had the upsell format.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
