### PR TITLE
Reenabled accidently disabled tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+  - oraclejdk9
   - openjdk8
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk9
   - openjdk8
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,13 @@ language: java
 jdk:
   - oraclejdk9
   - openjdk8
+
+matrix:
+  include:
+  - jdk: openjdk9
+    before_install:
+    - rm "${JAVA_HOME}/lib/security/cacerts"
+    - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
+    
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: java
-jdk:
-  - oraclejdk9
-  - openjdk8
 
 matrix:
   include:
@@ -9,6 +6,7 @@ matrix:
     before_install:
     - rm "${JAVA_HOME}/lib/security/cacerts"
     - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
+  - jdk: openjdk8
 
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ matrix:
     before_install:
     - rm "${JAVA_HOME}/lib/security/cacerts"
     - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
-    
+
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - oraclejdk9
   - openjdk8
 
 matrix:

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ChanRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ChanRipperTest.java
@@ -11,9 +11,10 @@ import com.rarchives.ripme.ripper.rippers.ChanRipper;
 import com.rarchives.ripme.ripper.rippers.ripperhelpers.ChanSite;
 import com.rarchives.ripme.utils.Http;
 import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
 
 public class ChanRipperTest extends RippersTest {
-
+    @Test
     public void testChanURLFailures() throws IOException {
         List<URL> failURLs = new ArrayList<>();
         // URLs that should not work
@@ -26,7 +27,7 @@ public class ChanRipperTest extends RippersTest {
             }
         }
     }
-
+    @Test
     public void testChanURLPasses() throws IOException {
         List<URL> passURLs = new ArrayList<>();
         // URLs that should work
@@ -43,7 +44,7 @@ public class ChanRipperTest extends RippersTest {
             deleteDir(ripper.getWorkingDir());
         }
     }
-
+    @Test
     public void testChanStringParsing() throws IOException {
         List<String> site1 = Arrays.asList("site1.com");
         List<String> site1Cdns = Arrays.asList("cnd1.site1.com", "cdn2.site2.biz");
@@ -59,7 +60,7 @@ public class ChanRipperTest extends RippersTest {
         assertEquals(chansFromConfig.get(1).getDomains(), site2);
         assertEquals(chansFromConfig.get(1).getCdns(), site2Cdns);
     }
-
+    @Test
     public void testChanRipper() throws IOException {
         List<URL> contentURLs = new ArrayList<>();
         contentURLs.add(new URL(getRandomThreadDesuarchive()));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CheveretoRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CheveretoRipperTest.java
@@ -4,13 +4,15 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.CheveretoRipper;
+import org.junit.jupiter.api.Test;
 
 public class CheveretoRipperTest extends RippersTest {
+    @Test
     public void testTagFox() throws IOException {
         CheveretoRipper ripper = new CheveretoRipper(new URL("http://tag-fox.com/album/Thjb"));
         testRipper(ripper);
     }
-
+    @Test
     public void testSubdirAlbum() throws IOException {
         CheveretoRipper ripper = new CheveretoRipper(new URL("https://kenzato.uk/booru/album/TnEc"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ComicextraRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ComicextraRipperTest.java
@@ -3,15 +3,16 @@ package com.rarchives.ripme.tst.ripper.rippers;
 import java.io.IOException;
 import java.net.URL;
 import com.rarchives.ripme.ripper.rippers.ComicextraRipper;
+import org.junit.jupiter.api.Test;
 
 public class ComicextraRipperTest extends RippersTest {
-
+    @Test
     public void testComicUrl() throws IOException {
         URL url = new URL("https://www.comicextra.com/comic/karma-police");
         ComicextraRipper ripper = new ComicextraRipper(url);
         testRipper(ripper);
     }
-
+    @Test
     public void testChapterUrl() throws IOException {
         URL url = new URL("https://www.comicextra.com/v-for-vendetta/chapter-1");
         ComicextraRipper ripper = new ComicextraRipper(url);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DribbbleRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DribbbleRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.DribbbleRipper;
+import org.junit.jupiter.api.Test;
 
 public class DribbbleRipperTest extends RippersTest {
+    @Test
     public void testDribbbleRip() throws IOException {
         DribbbleRipper ripper = new DribbbleRipper(new URL("https://dribbble.com/typogriff"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/E621RipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/E621RipperTest.java
@@ -4,18 +4,19 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.E621Ripper;
+import org.junit.jupiter.api.Test;
 
 public class E621RipperTest extends RippersTest {
     public void testRip() throws IOException {
         E621Ripper ripper = new E621Ripper(new URL("https://e621.net/post/index/1/beach"));
         testRipper(ripper);
     }
-
+    @Test
     public void testFlashOrWebm() throws IOException {
         E621Ripper ripper = new E621Ripper(new URL("https://e621.net/post/index/1/gif"));
         testRipper(ripper);
     }
-
+    @Test
     public void testGetNextPage() throws IOException {
         E621Ripper nextPageRipper = new E621Ripper(new URL("https://e621.net/post/index/1/cosmicminerals"));
         try {

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EhentaiRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EhentaiRipperTest.java
@@ -6,14 +6,17 @@ import java.util.List;
 
 import com.rarchives.ripme.ripper.rippers.EHentaiRipper;
 import com.rarchives.ripme.utils.RipUtils;
+import org.junit.jupiter.api.Test;
 
 public class EhentaiRipperTest extends RippersTest {
+    @Test
     public void testEHentaiAlbum() throws IOException {
         EHentaiRipper ripper = new EHentaiRipper(new URL("https://e-hentai.org/g/1144492/e823bdf9a5/"));
         testRipper(ripper);
     }
 
     // Test the tag black listing
+    @Test
     public void testTagBlackList()  throws IOException {
         URL url = new URL("https://e-hentai.org/g/1228503/1a2f455f96/");
         EHentaiRipper ripper = new EHentaiRipper(url);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EightmusesRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EightmusesRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.EightmusesRipper;
+import org.junit.jupiter.api.Test;
 
 public class EightmusesRipperTest extends RippersTest {
+    @Test
     public void testEightmusesAlbum() throws IOException {
         // A simple image album
         EightmusesRipper ripper = new EightmusesRipper(new URL("https://www.8muses.com/comix/album/Affect3D-Comics/TheDude3DX/Lust-Unleashed-The-Urge-To-Explore"));
@@ -17,12 +19,12 @@ public class EightmusesRipperTest extends RippersTest {
         ripper = new EightmusesRipper(new URL("https://www.8muses.com/comix/album/Blacknwhitecomics_com-Comix/BlacknWhiteComics/The-Mayor"));
         testRipper(ripper);
     }
-
+    @Test
     public void testGID() throws IOException {
         EightmusesRipper ripper = new EightmusesRipper(new URL("https://www.8muses.com/comix/album/Affect3D-Comics/TheDude3DX/Lust-Unleashed-The-Urge-To-Explore"));
         assertEquals("Affect3D-Comics", ripper.getGID(new URL("https://www.8muses.com/comics/album/Affect3D-Comics/TheDude3DX/Lust-Unleashed-The-Urge-To-Explore")));
     }
-
+    @Test
     public void testGetSubdir() throws IOException {
         EightmusesRipper ripper = new EightmusesRipper(new URL("https://www.8muses.com/comix/album/Affect3D-Comics/TheDude3DX/Lust-Unleashed-The-Urge-To-Explore"));
         assertEquals("After-Party-Issue-1", ripper.getSubdir("After Party - Issue 1"));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EromeRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EromeRipperTest.java
@@ -5,27 +5,28 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.EromeRipper;
+import org.junit.jupiter.api.Test;
 
 public class EromeRipperTest extends RippersTest {
-
+	@Test
 	public void testGetGIDProfilePage() throws IOException {
 		URL url = new URL("https://www.erome.com/Jay-Jenna");
 		EromeRipper ripper = new EromeRipper(url);
 		assertEquals("Jay-Jenna", ripper.getGID(url));
 	}
-
+	@Test
 	public void testGetGIDAlbum() throws IOException {
 		URL url = new URL("https://www.erome.com/a/KbDAM1XT");
 		EromeRipper ripper = new EromeRipper(url);
 		assertEquals("KbDAM1XT", ripper.getGID(url));
 	}
-
+	@Test
 	public void testGetAlbumsToQueue() throws IOException {
 		URL url = new URL("https://www.erome.com/Jay-Jenna");
 		EromeRipper ripper = new EromeRipper(url);
 		assert (2 >= ripper.getAlbumsToQueue(ripper.getFirstPage()).size());
 	}
-
+	@Test
 	public void testPageContainsAlbums() throws IOException {
 		URL url = new URL("https://www.erome.com/Jay-Jenna");
 		EromeRipper ripper = new EromeRipper(url);
@@ -38,7 +39,7 @@ public class EromeRipperTest extends RippersTest {
 		EromeRipper ripper = new EromeRipper(url);
 		testRipper(ripper);
 	}
-
+	@Test
 	public void testGetURLsFromPage() throws IOException {
 		URL url = new URL("https://www.erome.com/a/Tak8F2h6");
 		EromeRipper ripper = new EromeRipper(url);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FivehundredpxRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FivehundredpxRipperTest.java
@@ -1,15 +1,16 @@
-//package com.rarchives.ripme.tst.ripper.rippers;
-//
-//import java.io.IOException;
-//import java.net.URL;
-//
-//import com.rarchives.ripme.ripper.rippers.FivehundredpxRipper;
-//
-//public class FivehundredpxRipperTest extends RippersTest {
-//    public void test500pxAlbum() throws IOException {
-//        FivehundredpxRipper ripper = new FivehundredpxRipper(new URL("https://marketplace.500px.com/alexander_hurman"));
-//        testRipper(ripper);
-//    }
-//}
+package com.rarchives.ripme.tst.ripper.rippers;
 
-// Ripper is broken. See https://github.com/RipMeApp/ripme/issues/438
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.FivehundredpxRipper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class FivehundredpxRipperTest extends RippersTest {
+    @Test @Disabled("Ripper is broken. See https://github.com/RipMeApp/ripme/issues/438")
+    public void test500pxAlbum() throws IOException {
+        FivehundredpxRipper ripper = new FivehundredpxRipper(new URL("https://marketplace.500px.com/alexander_hurman"));
+        testRipper(ripper);
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuraffinityRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuraffinityRipperTest.java
@@ -4,14 +4,15 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.FuraffinityRipper;
+import org.junit.jupiter.api.Test;
 
 public class FuraffinityRipperTest extends RippersTest {
-
+    @Test
     public void testFuraffinityAlbum() throws IOException {
         FuraffinityRipper ripper = new FuraffinityRipper(new URL("https://www.furaffinity.net/gallery/spencerdragon/"));
         testRipper(ripper);
     }
-
+    @Test
     public void testFuraffinityScrap() throws IOException {
         FuraffinityRipper ripper = new FuraffinityRipper(new URL("http://www.furaffinity.net/scraps/sssonic2/"));
         testRipper(ripper);
@@ -22,7 +23,7 @@ public class FuraffinityRipperTest extends RippersTest {
         FuraffinityRipper ripper = new FuraffinityRipper(url);
         assertEquals("mustardgas", ripper.getGID(url));
     }
-
+    @Test
     public void testLogin() throws IOException {
         URL url = new URL("https://www.furaffinity.net/gallery/mustardgas/");
         FuraffinityRipper ripper = new FuraffinityRipper(url);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuskatorRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FuskatorRipperTest.java
@@ -4,13 +4,15 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.FuskatorRipper;
+import org.junit.jupiter.api.Test;
 
 public class FuskatorRipperTest extends RippersTest {
+    @Test
     public void testFuskatorAlbum() throws IOException {
         FuskatorRipper ripper = new FuskatorRipper(new URL("https://fuskator.com/thumbs/hqt6pPXAf9z/Shaved-Blonde-Babe-Katerina-Ambre.html"));
         testRipper(ripper);
     }
-    
+    @Test
     public void testUrlsWithTiled() throws IOException {
         FuskatorRipper ripper = new FuskatorRipper(new URL("https://fuskator.com/thumbs/hsrzk~UIFmJ/Blonde-Babe-Destiny-Dixon-Playing-With-Black-Dildo.html"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/GfycatRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/GfycatRipperTest.java
@@ -1,6 +1,8 @@
 package com.rarchives.ripme.tst.ripper.rippers;
 
 import com.rarchives.ripme.ripper.rippers.GfycatRipper;
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 import java.net.URL;
 
@@ -11,6 +13,7 @@ public class GfycatRipperTest extends RippersTest {
      * Rips correctly formatted URL directly from Gfycat
      * @throws IOException 
      */
+    @Test
     public void testGfycatGoodURL() throws IOException{
         GfycatRipper ripper = new GfycatRipper(new URL("https://gfycat.com/TemptingExcellentIchthyosaurs"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/GirlsOfDesireRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/GirlsOfDesireRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.GirlsOfDesireRipper;
+import org.junit.jupiter.api.Test;
 
 public class GirlsOfDesireRipperTest extends RippersTest {
+    @Test
     public void testGirlsofdesireAlbum() throws IOException {
         GirlsOfDesireRipper ripper = new GirlsOfDesireRipper(new URL("http://www.girlsofdesire.org/galleries/krillia/"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HbrowseRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HbrowseRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.HbrowseRipper;
+import org.junit.jupiter.api.Test;
 
 public class HbrowseRipperTest extends RippersTest {
+    @Test
     public void testPahealRipper() throws IOException {
         HbrowseRipper ripper = new HbrowseRipper(new URL("https://www.hbrowse.com/21013/c00001"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/Hentai2readRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/Hentai2readRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.Hentai2readRipper;
+import org.junit.jupiter.api.Test;
 
 public class Hentai2readRipperTest extends RippersTest {
+    @Test
     public void testHentai2readAlbum() throws IOException {
         Hentai2readRipper ripper = new Hentai2readRipper(new URL("https://hentai2read.com/sm_school_memorial/1/"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaicafeRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaicafeRipperTest.java
@@ -4,13 +4,16 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.HentaiCafeRipper;
+import org.junit.jupiter.api.Test;
 
 public class HentaicafeRipperTest extends RippersTest {
+    @Test
     public void testHentaiCafeAlbum() throws IOException {
         HentaiCafeRipper ripper = new HentaiCafeRipper(new URL("https://hentai.cafe/kikuta-the-oni-in-the-room/"));
         testRipper(ripper);
     }
     // This album has a line break (<br />) in the url. Test it to make sure ripme can handle these invalid urls
+    @Test
     public void testAlbumWithInvalidChars() throws IOException {
         HentaiCafeRipper ripper = new HentaiCafeRipper(new URL("https://hentai.cafe/chobipero-club/"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaifoundryRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaifoundryRipperTest.java
@@ -4,19 +4,21 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.HentaifoundryRipper;
+import org.junit.jupiter.api.Test;
 
 public class HentaifoundryRipperTest extends RippersTest {
+    @Test
     public void testHentaifoundryRip() throws IOException {
         HentaifoundryRipper ripper = new HentaifoundryRipper(new URL("https://www.hentai-foundry.com/pictures/user/personalami"));
         testRipper(ripper);
     }
-
+    @Test
     public void testHentaifoundryGetGID() throws IOException {
         HentaifoundryRipper ripper = new HentaifoundryRipper(new URL("https://www.hentai-foundry.com/stories/user/Rakked"));
         testRipper(ripper);
         assertEquals("Rakked", ripper.getGID(new URL("https://www.hentai-foundry.com/stories/user/Rakked")));
     }
-
+    @Test
     public void testHentaifoundryPdfRip() throws IOException {
         HentaifoundryRipper ripper = new HentaifoundryRipper(new URL("https://www.hentai-foundry.com/stories/user/Rakked"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaiimageRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaiimageRipperTest.java
@@ -5,9 +5,10 @@ import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.HentaiimageRipper;
 import com.rarchives.ripme.utils.Utils;
+import org.junit.jupiter.api.Test;
 
 public class HentaiimageRipperTest extends RippersTest {
-
+    @Test
     public void testHentaifoundryRip() throws IOException {
         if (Utils.getConfigBoolean("test.run_flaky_tests", false)) {
             HentaiimageRipper ripper = new HentaiimageRipper(new URL("https://hentai-image.com/image/afrobull-gerudo-ongoing-12/"));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HqpornerRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HqpornerRipperTest.java
@@ -2,6 +2,7 @@ package com.rarchives.ripme.tst.ripper.rippers;
 
 import com.rarchives.ripme.ripper.rippers.HqpornerRipper;
 import com.rarchives.ripme.utils.Utils;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URL;
@@ -21,13 +22,13 @@ public class HqpornerRipperTest extends RippersTest {
         HqpornerRipper ripper = new HqpornerRipper(poolURL);
         assertEquals("84636-pool_lesson_with_a_cheating_husband", ripper.getGID(poolURL));
     }
-
+    @Test
     public void testGetURLsFromPage() throws IOException {
         URL actressUrl = new URL("https://hqporner.com/actress/kali-roses");
         HqpornerRipper ripper = new HqpornerRipper(actressUrl);
         assert (ripper.getURLsFromPage(ripper.getFirstPage()).size() >= 2);
     }
-
+    @Test
     public void testGetNextPage() throws IOException {
         URL multiPageUrl = new URL("https://hqporner.com/category/tattooed");
         HqpornerRipper multiPageRipper = new HqpornerRipper(multiPageUrl);
@@ -41,7 +42,7 @@ public class HqpornerRipperTest extends RippersTest {
             assertEquals(e.getMessage(), "No next page found.");
         }
     }
-
+    @Test
     public void testMyDaddyVideoHost() throws IOException {
         if (Utils.getConfigBoolean("test.run_flaky_tests", false)) {
             URL myDaddyUrl = new URL("https://hqporner.com/hdporn/84636-pool_lesson_with_a_cheating_husband.html");
@@ -49,7 +50,7 @@ public class HqpornerRipperTest extends RippersTest {
             testRipper(myDaddyRipper);
         }
     }
-
+    @Test
     public void testFlyFlvVideoHost() throws IOException {
         if (Utils.getConfigBoolean("test.run_flaky_tests", false)) {
             URL flyFlvUrl = new URL(
@@ -58,7 +59,7 @@ public class HqpornerRipperTest extends RippersTest {
             testRipper(flyFlvRipper);
         }
     }
-
+    @Test
     public void testUnknownVideoHost() throws IOException {
         if (Utils.getConfigBoolean("test.run_flaky_tests", false)) {
             URL unknownHostUrl = new URL("https://hqporner.com/hdporn/79528-Kayden_Kross_-_Serious_Masturbation.html"); // howq.cc

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImagearnRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImagearnRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.ImagearnRipper;
+import org.junit.jupiter.api.Test;
 
 public class ImagearnRipperTest extends RippersTest {
+    @Test
     public void testImagearnRip() throws IOException {
         ImagearnRipper ripper = new ImagearnRipper(new URL("http://imagearn.com//gallery.php?id=578682"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImagebamRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImagebamRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.ImagebamRipper;
+import org.junit.jupiter.api.Test;
 
 public class ImagebamRipperTest extends RippersTest {
+    @Test
     public void testImagebamRip() throws IOException {
         ImagebamRipper ripper = new ImagebamRipper(new URL("http://www.imagebam.com/gallery/488cc796sllyf7o5srds8kpaz1t4m78i"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImagefapRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImagefapRipperTest.java
@@ -6,8 +6,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.rarchives.ripme.ripper.rippers.ImagefapRipper;
+import org.junit.jupiter.api.Test;
 
 public class ImagefapRipperTest extends RippersTest {
+    @Test
     public void testImagefapAlbums() throws IOException {
         Map<URL, String> testURLs = new HashMap<>();
 
@@ -24,6 +26,7 @@ public class ImagefapRipperTest extends RippersTest {
             testRipper(ripper);
         }
     }
+    @Test
     public void testImagefapGetAlbumTitle() throws IOException {
         URL url = new URL("https://www.imagefap.com/gallery.php?gid=7789753");
         ImagefapRipper ripper = new ImagefapRipper(url);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImgboxRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ImgboxRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.ImgboxRipper;
+import org.junit.jupiter.api.Test;
 
 public class ImgboxRipperTest extends RippersTest {
+    @Test
     public void testImgboxRip() throws IOException {
         ImgboxRipper ripper = new ImgboxRipper(new URL("https://imgbox.com/g/FJPF7t26FD"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/InstagramRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/InstagramRipperTest.java
@@ -8,9 +8,11 @@ import java.util.List;
 import java.util.Map;
 
 import com.rarchives.ripme.ripper.rippers.InstagramRipper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class InstagramRipperTest extends RippersTest {
-
+    @Test
     public void testInstagramGID() throws IOException {
         Map<URL, String> testURLs = new HashMap<>();
         testURLs.put(new URL("http://instagram.com/Test_User"), "Test_User");
@@ -31,12 +33,12 @@ public class InstagramRipperTest extends RippersTest {
             deleteDir(ripper.getWorkingDir());
         }
     }
-
+    @Test @Disabled("Fails to rip")
     public void testInstagramAlbums() throws IOException {
         List<URL> contentURLs = new ArrayList<>();
         // This unit test is a bit flaky 
         //contentURLs.add(new URL("https://www.instagram.com/Test_User/"));
-        contentURLs.add(new URL("https://www.instagram.com/p/BZ4egP7njW5/?hl=en"));
+        contentURLs.add(new URL("https://www.instagram.com/p/BaNPpaHn2zU/?hl=en"));
         contentURLs.add(new URL("https://www.instagram.com/p/BaNPpaHn2zU/"));
         for (URL url : contentURLs) {
             InstagramRipper ripper = new InstagramRipper(url);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/JagodibujaRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/JagodibujaRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.JagodibujaRipper;
+import org.junit.jupiter.api.Test;
 
 public class JagodibujaRipperTest extends RippersTest {
+    @Test
     public void testJagodibujaRipper() throws IOException {
         // a photo set
         JagodibujaRipper ripper = new JagodibujaRipper(new URL("http://www.jagodibuja.com/comic-in-me/"));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LusciousRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LusciousRipperTest.java
@@ -4,10 +4,11 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.LusciousRipper;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class LusciousRipperTest extends RippersTest {
-    @Test
+    @Test @Disabled("Flaky in the CI")
     public void testPahealRipper() throws IOException {
         // a photo set
         LusciousRipper ripper = new LusciousRipper(
@@ -20,7 +21,7 @@ public class LusciousRipperTest extends RippersTest {
         LusciousRipper ripper = new LusciousRipper(url);
         assertEquals("h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609", ripper.getGID(url));
     }
-    @Test
+    @Test @Disabled("Flaky in the CI")
     public void testGetNextPage() throws IOException {
         URL multiPageAlbumUrl = new URL("https://luscious.net/albums/women-of-color_58/");
         LusciousRipper multiPageRipper = new LusciousRipper(multiPageAlbumUrl);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LusciousRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LusciousRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.LusciousRipper;
+import org.junit.jupiter.api.Test;
 
 public class LusciousRipperTest extends RippersTest {
+    @Test
     public void testPahealRipper() throws IOException {
         // a photo set
         LusciousRipper ripper = new LusciousRipper(
@@ -18,7 +20,7 @@ public class LusciousRipperTest extends RippersTest {
         LusciousRipper ripper = new LusciousRipper(url);
         assertEquals("h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609", ripper.getGID(url));
     }
-
+    @Test
     public void testGetNextPage() throws IOException {
         URL multiPageAlbumUrl = new URL("https://luscious.net/albums/women-of-color_58/");
         LusciousRipper multiPageRipper = new LusciousRipper(multiPageAlbumUrl);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MotherlessRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MotherlessRipperTest.java
@@ -8,7 +8,6 @@ import com.rarchives.ripme.ripper.rippers.MotherlessRipper;
 import org.junit.jupiter.api.Test;
 
 public class MotherlessRipperTest extends RippersTest {
-    // https://github.com/RipMeApp/ripme/issues/238 - MotherlessRipperTest is flaky on Travis CI
     @Test
     public void testMotherlessAlbumRip() throws IOException {
         MotherlessRipper ripper = new MotherlessRipper(new URL("https://motherless.com/G1168D90"));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MulemaxRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MulemaxRipperTest.java
@@ -4,9 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.MulemaxRipper;
+import org.junit.jupiter.api.Test;
 
 public class MulemaxRipperTest extends RippersTest {
-    
+    @Test
     public void testMulemaxVideo() throws IOException {
         MulemaxRipper ripper = new MulemaxRipper(new URL("https://mulemax.com/video/1720/emma-and-her-older-sissy-are-home-for-a-holiday-break"));  //pick any video from the front page
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MyhentaicomicsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MyhentaicomicsRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.MyhentaicomicsRipper;
+import org.junit.jupiter.api.Test;
 
 public class MyhentaicomicsRipperTest extends RippersTest {
+    @Test
     public void testMyhentaicomicsAlbum() throws IOException {
         MyhentaicomicsRipper ripper = new MyhentaicomicsRipper(new URL("http://myhentaicomics.com/index.php/Nienna-Lost-Tales"));
         testRipper(ripper);
@@ -21,13 +23,13 @@ public class MyhentaicomicsRipperTest extends RippersTest {
         // Test a tag
         assertEquals("2409", ripper.getGID(new URL("http://myhentaicomics.com/index.php/tag/2409/")));
     }
-
+    @Test
     public void testGetAlbumsToQueue() throws IOException {
         URL url = new URL("https://myhentaicomics.com/index.php/tag/3167/");
         MyhentaicomicsRipper ripper = new MyhentaicomicsRipper(url);
         assertEquals(15, ripper.getAlbumsToQueue(ripper.getFirstPage()).size());
     }
-
+    @Test
     public void testPageContainsAlbums() throws IOException {
         URL url = new URL("https://myhentaicomics.com/index.php/tag/3167/");
         URL url2 = new URL("https://myhentaicomics.com/index.php/search?q=test");

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MyhentaigalleryRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MyhentaigalleryRipperTest.java
@@ -4,9 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.MyhentaigalleryRipper;
+import org.junit.jupiter.api.Test;
 
 public class MyhentaigalleryRipperTest extends RippersTest {
-
+    @Test
     public void testMyhentaigalleryAlbum() throws IOException {
         MyhentaigalleryRipper ripper = new MyhentaigalleryRipper(
                 new URL("https://myhentaigallery.com/gallery/thumbnails/9201"));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NewgroundsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NewgroundsRipperTest.java
@@ -1,12 +1,13 @@
 package com.rarchives.ripme.tst.ripper.rippers;
 
 import com.rarchives.ripme.ripper.rippers.NewgroundsRipper;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URL;
 
 public class NewgroundsRipperTest extends RippersTest {
-
+    @Test
     public void testNewgroundsRip() throws IOException {
         NewgroundsRipper ripper = new NewgroundsRipper(new URL("https://zone-sama.newgrounds.com/art"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NewsfilterRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NewsfilterRipperTest.java
@@ -4,9 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.NewsfilterRipper;
+import org.junit.jupiter.api.Test;
 
 public class NewsfilterRipperTest extends RippersTest {
-
+    @Test
     public void testNewsfilterRip() throws IOException {
         NewsfilterRipper ripper = new NewsfilterRipper(new URL("http://newsfilter.org/gallery/he-doubted-she-would-fuck-on-cam-happy-to-be-proven-wrong-216799"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NhentaiRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NhentaiRipperTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import com.rarchives.ripme.ripper.rippers.NhentaiRipper;
 import com.rarchives.ripme.utils.RipUtils;
+import org.junit.jupiter.api.Test;
 
 public class NhentaiRipperTest extends RippersTest {
     public void testRip() throws IOException {
@@ -19,6 +20,7 @@ public class NhentaiRipperTest extends RippersTest {
     }
 
     // Test the tag black listing
+    @Test
     public void testTagBlackList()  throws IOException {
         URL url = new URL("https://nhentai.net/g/233295/");
         NhentaiRipper ripper = new NhentaiRipper(url);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PahealRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PahealRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.PahealRipper;
+import org.junit.jupiter.api.Test;
 
 public class PahealRipperTest extends RippersTest {
+    @Test
     public void testPahealRipper() throws IOException {
         // a photo set
         PahealRipper ripper = new PahealRipper(new URL("http://rule34.paheal.net/post/list/bimbo/1"));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PicstatioRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PicstatioRipperTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.PicstatioRipper;
+import org.junit.jupiter.api.Test;
 
 public class PicstatioRipperTest extends RippersTest {
 
@@ -11,7 +12,7 @@ public class PicstatioRipperTest extends RippersTest {
         PicstatioRipper ripper = new PicstatioRipper(new URL("https://www.picstatio.com/aerial-view-wallpapers"));
         testRipper(ripper);
     }
-
+    @Test
     public void testGID() throws IOException {
         PicstatioRipper ripper = new PicstatioRipper(new URL("https://www.picstatio.com/aerial-view-wallpapers"));
         assertEquals("aerial-view-wallpapers", ripper.getGID(new URL("https://www.picstatio.com/aerial-view-wallpapers")));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PorncomixDotOneRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PorncomixDotOneRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.PorncomixDotOneRipper;
+import org.junit.jupiter.api.Test;
 
 public class PorncomixDotOneRipperTest extends RippersTest {
+    @Test
     public void testPorncomixAlbum() throws IOException {
         PorncomixDotOneRipper ripper = new PorncomixDotOneRipper(new URL("https://www.porncomix.one/gallery/blacknwhite-make-america-great-again"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PornhubRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PornhubRipperTest.java
@@ -7,8 +7,10 @@ import com.rarchives.ripme.ripper.rippers.PornhubRipper;
 import com.rarchives.ripme.utils.Http;
 import com.rarchives.ripme.utils.Utils;
 import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
 
 public class PornhubRipperTest extends RippersTest {
+    @Test
     public void testPornhubRip() throws IOException {
         if (Utils.getConfigBoolean("test.run_flaky_tests", false)) {
             PornhubRipper ripper = new PornhubRipper(new URL("https://www.pornhub.com/album/15680522"));
@@ -25,6 +27,7 @@ public class PornhubRipperTest extends RippersTest {
     }
 
     // alternate album, with only 2 pages: https://www.pornhub.com/album/4771891
+    @Test
     public void testGetNextPage() throws IOException {
         String baseURL = "https://www.pornhub.com/album/15680522";
         PornhubRipper ripper = new PornhubRipper(new URL(baseURL));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/Rule34RipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/Rule34RipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.Rule34Ripper;
+import org.junit.jupiter.api.Test;
 
 public class Rule34RipperTest extends RippersTest {
+    @Test
     public void testShesFreakyRip() throws IOException {
         Rule34Ripper ripper = new Rule34Ripper(new URL("https://rule34.xxx/index.php?page=post&s=list&tags=bimbo"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SinnercomicsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SinnercomicsRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.SinnercomicsRipper;
+import org.junit.jupiter.api.Test;
 
 public class SinnercomicsRipperTest extends RippersTest {
+    @Test
     public void testSinnercomicsAlbum() throws IOException {
         SinnercomicsRipper ripper;
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SpankBangRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SpankBangRipperTest.java
@@ -4,9 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.SpankbangRipper;
+import org.junit.jupiter.api.Test;
 
 public class SpankBangRipperTest extends RippersTest {
-
+    @Test
     public void testSpankBangVideo() throws IOException {
         SpankbangRipper ripper = new SpankbangRipper(new URL("https://spankbang.com/2a7fh/video/mdb901"));  //most popular video of all time on site; should stay up
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TapasticRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TapasticRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.TapasticRipper;
+import org.junit.jupiter.api.Test;
 
 public class TapasticRipperTest extends RippersTest {
+    @Test
     public void testTapasticRip() throws IOException {
         TapasticRipper ripper = new TapasticRipper(new URL("https://tapas.io/series/tsiwbakd-comic"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TeenplanetRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TeenplanetRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.TeenplanetRipper;
+import org.junit.jupiter.api.Test;
 
 public class TeenplanetRipperTest extends RippersTest {
+    @Test
     public void testTeenplanetRip() throws IOException {
         TeenplanetRipper ripper = new TeenplanetRipper(new URL("http://teenplanet.org/galleries/the-perfect-side-of-me-6588.html"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TheyiffgalleryRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TheyiffgalleryRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.TheyiffgalleryRipper;
+import org.junit.jupiter.api.Test;
 
 public class TheyiffgalleryRipperTest extends RippersTest {
+    @Test
     public void testTheyiffgallery() throws IOException {
         TheyiffgalleryRipper ripper = new TheyiffgalleryRipper(new URL("https://theyiffgallery.com/index?/category/4303"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TsuminoRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TsuminoRipperTest.java
@@ -7,14 +7,16 @@ import java.util.List;
 import com.rarchives.ripme.ripper.rippers.TsuminoRipper;
 import com.rarchives.ripme.utils.RipUtils;
 import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
 
 
 public class TsuminoRipperTest extends RippersTest {
+    @Test
     public void testTsuminoRipper() throws IOException {
         TsuminoRipper ripper = new TsuminoRipper(new URL("http://www.tsumino.com/Book/Info/43528/sore-wa-kurokute-suketeita-what-s-tight-and-black-and-sheer-all-over-"));
         testRipper(ripper);
     }
-
+    @Test
     public void testTagBlackList() throws IOException {
         TsuminoRipper ripper = new TsuminoRipper(new URL("http://www.tsumino.com/Book/Info/43528/sore-wa-kurokute-suketeita-what-s-tight-and-black-and-sheer-all-over-"));
         Document doc = ripper.getFirstPage();

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VidbleRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VidbleRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.VidbleRipper;
+import org.junit.jupiter.api.Test;
 
 public class VidbleRipperTest extends RippersTest {
+    @Test
     public void testVidbleRip() throws IOException {
         VidbleRipper ripper = new VidbleRipper(new URL("http://www.vidble.com/album/y1oyh3zd"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ViewcomicRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ViewcomicRipperTest.java
@@ -4,10 +4,11 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.ViewcomicRipper;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class ViewcomicRipperTest extends RippersTest {
-    @Test
+    @Test @Disabled("Ripper broken")
     public void testViewcomicRipper() throws IOException {
         ViewcomicRipper ripper = new ViewcomicRipper(new URL("https://view-comic.com/batman-no-mans-land-vol-1/"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ViewcomicRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ViewcomicRipperTest.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.ViewcomicRipper;
+import org.junit.jupiter.api.Test;
 
 public class ViewcomicRipperTest extends RippersTest {
+    @Test
     public void testViewcomicRipper() throws IOException {
         ViewcomicRipper ripper = new ViewcomicRipper(new URL("https://view-comic.com/batman-no-mans-land-vol-1/"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VkRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VkRipperTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.VkRipper;
+import org.junit.jupiter.api.Test;
 
 public class VkRipperTest extends RippersTest {
     // https://github.com/RipMeApp/ripme/issues/252
@@ -14,14 +15,17 @@ public class VkRipperTest extends RippersTest {
     // EXAMPLE: https://vk.com/album45506334_0 (a single album - profile pictures)
     // EXAMPLE: https://vk.com/album45506334_00?rev=1 (a single album - wall pictures)
     // EXAMPLE: https://vk.com/album45506334_101886701 (a single album - custom)
+    @Test
     public void testVkAlbumHttpRip() throws IOException {
         VkRipper ripper = new VkRipper(new URL("http://vk.com/album45506334_0"));
         testRipper(ripper);
     }
+    @Test
     public void testVkAlbumHttpsRip() throws IOException {
         VkRipper ripper = new VkRipper(new URL("https://vk.com/album45506334_0"));
         testRipper(ripper);
     }
+    @Test
     public void testVkPhotosRip() throws IOException {
         VkRipper ripper = new VkRipper(new URL("https://vk.com/photos45506334"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WebtoonsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WebtoonsRipperTest.java
@@ -4,18 +4,20 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.WebtoonsRipper;
+import org.junit.jupiter.api.Test;
 
 public class WebtoonsRipperTest extends RippersTest {
+    @Test
     public void testWebtoonsAlbum() throws IOException {
         WebtoonsRipper ripper = new WebtoonsRipper(new URL("http://www.webtoons.com/en/drama/my-boo/ep-33/viewer?title_no=1185&episode_no=33"));
         testRipper(ripper);
     }
-
+    @Test
     public void testWebtoonsType() throws IOException {
     	WebtoonsRipper ripper = new WebtoonsRipper(new URL("http://www.webtoons.com/en/drama/lookism/ep-145/viewer?title_no=1049&episode_no=145"));
     	testRipper(ripper);
     }
-
+    @Test
     public void testGetGID() throws IOException {
         URL url = new URL("http://www.webtoons.com/en/drama/my-boo/ep-33/viewer?title_no=1185&episode_no=33");
         WebtoonsRipper ripper = new WebtoonsRipper(url);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/WordpressComicRipperTest.java
@@ -43,26 +43,26 @@ public class WordpressComicRipperTest extends RippersTest {
                 new URL("http://themonsterunderthebed.net/?comic=test-post"));
         testRipper(ripper);
     }
-
+    @Test
     public void test_prismblush() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://prismblush.com/comic/hella-trap-pg-01/"));
         testRipper(ripper);
     }
-
+    @Test
     public void test_konradokonski_1() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://www.konradokonski.com/sawdust/comic/get-up/"));
         testRipper(ripper);
 
     }
-
+    @Test
     public void test_konradokonski_2() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://www.konradokonski.com/wiory/comic/08182008/"));
         testRipper(ripper);
     }
-
+    @Test
     public void test_konradokonski_getAlbumTitle() throws IOException {
         URL url = new URL("http://www.konradokonski.com/sawdust/comic/get-up/");
         WordpressComicRipper ripper = new WordpressComicRipper(url);
@@ -77,31 +77,31 @@ public class WordpressComicRipperTest extends RippersTest {
                 new URL("http://freeadultcomix.com/finders-feepaid-in-full-sparrow/"));
         testRipper(ripper);
     }
-
+    @Test
     public void test_delvecomic() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://thisis.delvecomic.com/NewWP/comic/in-too-deep/"));
         testRipper(ripper);
     }
-
+    @Test
     public void test_Eightmuses_download() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("https://8muses.download/lustomic-playkittens-josh-samuel-porn-comics-8-muses/"));
         testRipper(ripper);
     }
-
+    @Test
     public void test_Eightmuses_getAlbumTitle() throws IOException {
         URL url = new URL("https://8muses.download/lustomic-playkittens-josh-samuel-porn-comics-8-muses/");
         WordpressComicRipper ripper = new WordpressComicRipper(url);
         assertEquals("8muses.download_lustomic-playkittens-josh-samuel-porn-comics-8-muses", ripper.getAlbumTitle(url));
     }
-
+    @Test
     public void test_spyingwithlana_download() throws IOException {
         WordpressComicRipper ripper = new WordpressComicRipper(
                 new URL("http://spyingwithlana.com/comic/the-big-hookup/"));
         testRipper(ripper);
     }
-
+    @Test
     public void test_spyingwithlana_getAlbumTitle() throws IOException {
         URL url = new URL("http://spyingwithlana.com/comic/the-big-hookup/");
         WordpressComicRipper ripper = new WordpressComicRipper(url);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XvideosRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XvideosRipperTest.java
@@ -5,9 +5,10 @@ import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.XvideosRipper;
 import com.rarchives.ripme.tst.ripper.rippers.RippersTest;
+import org.junit.jupiter.api.Test;
 
 public class XvideosRipperTest extends RippersTest {
-
+    @Test
     public void testXhamsterAlbum1() throws IOException {
         XvideosRipper ripper = new XvideosRipper(new URL("https://www.xvideos.com/video23515878/dee_s_pool_toys"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/YoupornRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/YoupornRipperTest.java
@@ -1,6 +1,7 @@
 package com.rarchives.ripme.tst.ripper.rippers;
 
 import com.rarchives.ripme.ripper.rippers.YoupornRipper;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URL;
@@ -8,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class YoupornRipperTest  extends RippersTest {
+    @Test
     public void testYoupornRipper() throws IOException {
         List<URL> contentURLs = new ArrayList<>();
         contentURLs.add(new URL("http://www.youporn.com/watch/7669155/mrs-li-amateur-69-orgasm/?from=categ"));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/YuvutuRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/YuvutuRipperTest.java
@@ -4,14 +4,15 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.YuvutuRipper;
+import org.junit.jupiter.api.Test;
 
 public class YuvutuRipperTest extends RippersTest {
-
+    @Test
     public void testYuvutuAlbum1() throws IOException {
         YuvutuRipper ripper = new YuvutuRipper(new URL("http://www.yuvutu.com/modules.php?name=YuGallery&action=view&set_id=127013"));
         testRipper(ripper);
     }
-
+    @Test
     public void testYuvutuAlbum2() throws IOException {
         YuvutuRipper ripper = new YuvutuRipper(new URL("http://www.yuvutu.com/modules.php?name=YuGallery&action=view&set_id=420333"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ZizkiRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ZizkiRipperTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.ZizkiRipper;
+import org.junit.jupiter.api.Test;
 
 public class ZizkiRipperTest extends RippersTest {
     public void testRip() throws IOException {
@@ -16,7 +17,7 @@ public class ZizkiRipperTest extends RippersTest {
         ZizkiRipper ripper = new ZizkiRipper(url);
         assertEquals("dee-chorde", ripper.getGID(url));
     }
-
+    @Test
     public void testAlbumTitle() throws IOException {
         URL url = new URL("http://zizki.com/dee-chorde/we-got-spirit");
         ZizkiRipper ripper = new ZizkiRipper(url);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Re-enabled some tests that had been disabled when we upgrade some deps 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
