### PR TITLE
Fixes: #1395 ... gfycat-ripper does not rip URL starting with thumbs.gfycat.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
@@ -29,7 +29,7 @@ public class GfycatRipper extends AbstractHTMLRipper {
 
 
     public GfycatRipper(URL url) throws IOException {
-        super(url);
+        super(new URL(url.toExternalForm().split("-")[0].replace("thumbs.", "")));
     }
 
     @Override
@@ -76,15 +76,16 @@ public class GfycatRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://[wm.]*gfycat\\.com/@?([a-zA-Z0-9]+).*$");
+        Pattern p = Pattern.compile("^https?://(thumbs\\.|[wm\\.]*)gfycat\\.com/@?([a-zA-Z0-9]+).*$");
         Matcher m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return m.group(1);
-        }
-
+        
+        if (m.matches())
+            return m.group(2);
+        
         throw new MalformedURLException(
-                "Expected gfycat.com format:"
-                        + "gfycat.com/id"
+                "Expected gfycat.com format: "
+                        + "gfycat.com/id or "
+                        + "thumbs.gfycat.com/id.gif"
                         + " Got: " + url);
     }
 
@@ -92,7 +93,7 @@ public class GfycatRipper extends AbstractHTMLRipper {
         t = t.replaceAll("<html>\n" +
                 " <head></head>\n" +
                 " <body>", "");
-        t.replaceAll("</body>\n" +
+        t = t.replaceAll("</body>\n" +
                 "</html>", "");
         t = t.replaceAll("\n", "");
         t = t.replaceAll("=\"\"", "");


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1395)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fixes the issue where the app was unable to rip a gfycat URL starting with thumbs.


# Testing

URL tested:
* https://gfycat.com/@ehaydon
* https://gfycat.com/powerfulgoodaustraliansilkyterrier-drinking-thirsty-cats
* https://www.gfycat.com/angryblaringguineapig-cat-jfaoiwejfoewjfpoawej
* https://thumbs.gfycat.com/ShadowyDiligentHuemul-mobile.jpg
* https://thumbs.gfycat.com/ParallelSpectacularAmmonite-size_restricted.gif

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
   * [x] Downloads all relevant content.
   * [x] Downloads content from multiple pages (as necessary or appropriate).
   * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
