### PR TITLE
Fixes: #1351 ... auto update stopped working

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -23,7 +23,7 @@ import com.rarchives.ripme.utils.Utils;
 public class UpdateUtils {
 
     private static final Logger logger = Logger.getLogger(UpdateUtils.class);
-    private static final String DEFAULT_VERSION = "1.7.87";
+    private static final String DEFAULT_VERSION = "1.7.86";
     private static final String REPO_NAME = "ripmeapp/ripme";
     private static final String updateJsonURL = "https://raw.githubusercontent.com/" + REPO_NAME + "/master/ripme.json";
     private static String mainFileName;

--- a/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
+++ b/src/main/java/com/rarchives/ripme/ui/UpdateUtils.java
@@ -23,7 +23,7 @@ import com.rarchives.ripme.utils.Utils;
 public class UpdateUtils {
 
     private static final Logger logger = Logger.getLogger(UpdateUtils.class);
-    private static final String DEFAULT_VERSION = "1.7.86";
+    private static final String DEFAULT_VERSION = "1.7.87";
     private static final String REPO_NAME = "ripmeapp/ripme";
     private static final String updateJsonURL = "https://raw.githubusercontent.com/" + REPO_NAME + "/master/ripme.json";
     private static String mainFileName;
@@ -264,12 +264,14 @@ public class UpdateUtils {
             // Windows
             final String batchFile = "update_ripme.bat";
             final String batchPath = new File(batchFile).getAbsolutePath();
-            String script = "@echo off\r\n" + "timeout 1\r\n" + "copy " + updateFileName + " " + mainFileName + "\r\n"
-                    + "del " + updateFileName + "\r\n";
-            if (shouldLaunch) {
-                script += mainFileName + "\r\n";
-            }
-            script += "del " + batchPath + "\r\n";
+            String script = "@echo off\r\n" + "timeout 1\r\n" 
+                    + "copy \"" + updateFileName + "\" \"" + mainFileName + "\"\r\n"
+                    + "del \"" + updateFileName + "\"\r\n";
+            
+            if (shouldLaunch) 
+                script += "\"" + mainFileName + "\"\r\n";
+            script += "del \"" + batchPath + "\"\r\n";
+            
             final String[] batchExec = new String[] { batchPath };
             // Create updater script
             try (BufferedWriter bw = new BufferedWriter(new FileWriter(batchFile))) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1351)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fixes the update batch file to work in directories with spaces.


# Testing

Result:
```@echo off
timeout 1
copy "ripme.jar.update" "D:\Cloud\GitHub\ripme\target\ripme-1.7.84-jar-with-dependencies.jar"
del "ripme.jar.update"
"D:\Cloud\GitHub\ripme\target\ripme-1.7.84-jar-with-dependencies.jar"
del "D:\Cloud\GitHub\ripme\target\update_ripme.bat"
```

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
