### PR TITLE
Fix #1416 - Fails to download gfycat.com/amp/*

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
@@ -49,10 +49,12 @@ public class GfycatRipper extends AbstractHTMLRipper {
 
     @Override
     public URL sanitizeURL(URL url) throws MalformedURLException {
-        url = new URL(url.toExternalForm().replace("/gifs/detail", ""));
-        
-        return url;
+        String sUrl = url.toExternalForm();
+        sUrl = sUrl.replace("/gifs/detail", "");
+        sUrl = sUrl.replace("/amp", "");
+        return new URL(sUrl);
     }
+
     public boolean isProfile() {
         Pattern p = Pattern.compile("^https?://[wm.]*gfycat\\.com/@([a-zA-Z0-9]+).*$");
         Matcher m = p.matcher(url.toExternalForm());

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/GfycatRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/GfycatRipperTest.java
@@ -27,8 +27,21 @@ public class GfycatRipperTest extends RippersTest {
         testRipper(ripper);
     }
 
+    /**
+     * Rips a Gfycat profile
+     * @throws IOException 
+     */
     public void testGfycatProfile() throws IOException {
         GfycatRipper ripper  = new GfycatRipper(new URL("https://gfycat.com/@golbanstorage"));
+        testRipper(ripper);
+    }
+    
+    /**
+     * Rips a Gfycat amp link 
+     * @throws IOException 
+     */
+    public void testGfycatAmp() throws IOException {
+        GfycatRipper ripper = new GfycatRipper(new URL("https://gfycat.com/amp/TemptingExcellentIchthyosaurs"));
         testRipper(ripper);
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1416)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Adding a string replace to remove the "/amp"

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
