### PR TITLE
Allporncomic ripper fix

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/AllporncomicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/AllporncomicRipper.java
@@ -37,6 +37,11 @@ public class AllporncomicRipper extends AbstractHTMLRipper {
         if (m.matches()) {
             return m.group(1) + "_" + m.group(2);
         }
+        p = Pattern.compile("^https?://allporncomic.com/porncomic/([a-zA-Z0-9_\\-]+)/?$");
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
         throw new MalformedURLException("Expected allporncomic URL format: " +
                 "allporncomic.com/TITLE/CHAPTER - got " + url + " instead");
     }
@@ -54,6 +59,27 @@ public class AllporncomicRipper extends AbstractHTMLRipper {
             result.add(el.attr("src"));
         }
         return result;
+    }
+
+    @Override
+    public boolean hasQueueSupport() {
+        return true;
+    }
+
+    @Override
+    public boolean pageContainsAlbums(URL url) {
+        Pattern pa = Pattern.compile("^https?://allporncomic.com/porncomic/([a-zA-Z0-9_\\-]+)/?$");
+        Matcher ma = pa.matcher(url.toExternalForm());
+        return ma.matches();
+    }
+
+    @Override
+    public List<String> getAlbumsToQueue(Document doc) {
+        List<String> urlsToAddToQueue = new ArrayList<>();
+        for (Element elem : doc.select(".wp-manga-chapter > a")) {
+            urlsToAddToQueue.add(elem.attr("href"));
+        }
+        return urlsToAddToQueue;
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/AllporncomicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/AllporncomicRipper.java
@@ -32,7 +32,7 @@ public class AllporncomicRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("https?://allporncomic.com/porncomic/([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)");
+        Pattern p = Pattern.compile("https?://allporncomic.com/porncomic/([a-zA-Z0-9_\\-]+)/([a-zA-Z0-9_\\-]+)/?$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1) + "_" + m.group(2);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Ripper now accepts link ending with a / and links to series pages 


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
