### PR TITLE
Fix queue count update when queue is 0

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -146,10 +146,10 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         if (model.size() > 0) {
             Utils.setConfigList("queue", (Enumeration<Object>) model.elements());
             Utils.saveConfig();
-
-            MainWindow.optionQueue.setText(String.format("%s%s", Utils.getLocalizedString("queue"),
-                    model.size() == 0 ? "" : "(" + model.size() + ")"));
         }
+
+        MainWindow.optionQueue.setText(String.format("%s%s", Utils.getLocalizedString("queue"),
+                model.size() == 0 ? "" : "(" + model.size() + ")"));
     }
 
     private void updateQueue() {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fix queue count update when queue is empty


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
