### PR TITLE
Fixed xhamster ripper not downloading after 30 images

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -140,8 +140,11 @@ public class XhamsterRipper extends AbstractHTMLRipper {
     @Override
     public Document getNextPage(Document doc) throws IOException {
         if (doc.select("a[data-page=next]").first() != null) {
-            if (doc.select("a[data-page=next]").first().attr("href").startsWith("http")) {
-                return Http.url(doc.select("a[data-page=next]").first().attr("href")).get();
+            String nextPageUrl = doc.select("a[data-page=next]").first().attr("href");
+            if (nextPageUrl.startsWith("http")) {
+                nextPageUrl = nextPageUrl.replaceAll("https?://\\w?\\w?\\.?xhamster\\.", "https://m.xhamster.");
+                nextPageUrl = nextPageUrl.replaceAll("https?://xhamster2\\.", "https://m.xhamster2.");
+                return Http.url(nextPageUrl).get();
             }
         }
         throw new IOException("No more pages");
@@ -153,7 +156,7 @@ public class XhamsterRipper extends AbstractHTMLRipper {
         LOGGER.debug("Checking for urls");
         List<String> result = new ArrayList<>();
         if (!isVideoUrl(url)) {
-          for (Element page : doc.select("div.items > div.item-container > a.item")) {
+          for (Element page : doc.select("div.picture_view > div.pictures_block > div.items > div.item-container > a.item")) {
               // Make sure we don't waste time running the loop if the ripper has been stopped
               if (isStopped()) {
                   break;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1410 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fixed xhamster ripper not downloading after 30 images.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
