### PR TITLE
Mastodon rippers

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ArtAlleyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ArtAlleyRipper.java
@@ -1,0 +1,20 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class ArtAlleyRipper extends MastodonRipper {
+    public ArtAlleyRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "artalley";
+    }
+
+    @Override
+    public String getDomain() {
+        return "artalley.social";
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/BaraagRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/BaraagRipper.java
@@ -1,0 +1,20 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class BaraagRipper extends MastodonRipper {
+    public BaraagRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "baraag";
+    }
+
+    @Override
+    public String getDomain() {
+        return "baraag.net";
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MastodonRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MastodonRipper.java
@@ -1,0 +1,96 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.json.JSONObject;
+import org.json.JSONArray;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+public class MastodonRipper extends AbstractHTMLRipper {
+    private Map<String, String> itemIDs = Collections.synchronizedMap(new HashMap<String, String>());
+
+    public MastodonRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "mastodon";
+    }
+
+    @Override
+    public String getDomain() {
+        return "mastodon.social";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https?://(" + getDomain() + ")/@([a-zA-Z0-9_-]+)(/media/?)?$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            // Return the text contained between () in the regex
+            return m.group(1) + "@" + m.group(2);
+        }
+        throw new MalformedURLException(
+                "Expected " + getDomain() + " URL format: " +
+                getDomain() + "/@username - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        Pattern p = Pattern.compile("^/@[a-zA-Z0-9_-]+/media/?$");
+        Matcher m = p.matcher(url.getPath());
+        if (m.matches()) {
+            return Http.url(url).get();
+        }
+        return Http.url(url.toExternalForm().replaceAll("/$", "") + "/media").get();
+    }
+
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        Elements hrefs = doc.select(".h-entry + .entry > a.load-more.load-gap");
+        if (hrefs.isEmpty()) {
+            throw new IOException("No more pages");
+        }
+        String nextUrl = hrefs.last().attr("href");
+        sleep(500);
+        return Http.url(nextUrl).get();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<String>();
+        for (Element el : doc.select("[data-component=\"MediaGallery\"]")) {
+            String props = el.attr("data-props");
+            JSONObject obj = new JSONObject(props);
+            JSONArray arr = obj.getJSONArray("media");
+            for (int i = 0; i < arr.length(); i++) {
+                String url = arr.getJSONObject(i).getString("url");
+                result.add(url);
+                String id = arr.getJSONObject(i).getString("id");
+                itemIDs.put(url, id);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, itemIDs.get(url.toString()) + "_");
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MastodonXyzRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MastodonXyzRipper.java
@@ -1,0 +1,20 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class MastodonXyzRipper extends MastodonRipper {
+    public MastodonXyzRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "mastodonxyz";
+    }
+
+    @Override
+    public String getDomain() {
+        return "mastodon.xyz";
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PawooRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PawooRipper.java
@@ -1,0 +1,20 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class PawooRipper extends MastodonRipper {
+    public PawooRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "pawoo";
+    }
+
+    @Override
+    public String getDomain() {
+        return "pawoo.net";
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ArtAlleyRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/ArtAlleyRipperTest.java
@@ -1,0 +1,15 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.ArtAlleyRipper;
+import org.junit.jupiter.api.Test;
+
+public class ArtAlleyRipperTest extends RippersTest {
+    @Test
+    public void testRip() throws IOException {
+        ArtAlleyRipper ripper = new ArtAlleyRipper(new URL("https://artalley.social/@curator/media"));
+        testRipper(ripper);
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BaraagRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/BaraagRipperTest.java
@@ -1,0 +1,15 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.BaraagRipper;
+import org.junit.jupiter.api.Test;
+
+public class BaraagRipperTest extends RippersTest {
+    @Test
+    public void testRip() throws IOException {
+        BaraagRipper ripper = new BaraagRipper(new URL("https://baraag.net/@darkshadow777/media"));
+        testRipper(ripper);
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MastodonRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MastodonRipperTest.java
@@ -1,0 +1,15 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.MastodonRipper;
+import org.junit.jupiter.api.Test;
+
+public class MastodonRipperTest extends RippersTest {
+    @Test
+    public void testRip() throws IOException {
+        MastodonRipper ripper = new MastodonRipper(new URL("https://mastodon.social/@pythonhub/media"));
+        testRipper(ripper);
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MastodonXyzRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MastodonXyzRipperTest.java
@@ -1,0 +1,15 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.MastodonXyzRipper;
+import org.junit.jupiter.api.Test;
+
+public class MastodonXyzRipperTest extends RippersTest {
+    @Test
+    public void testRip() throws IOException {
+        MastodonXyzRipper ripper = new MastodonXyzRipper(new URL("https://mastodon.xyz/@artwo/media"));
+        testRipper(ripper);
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PawooRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/PawooRipperTest.java
@@ -1,0 +1,15 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.rarchives.ripme.ripper.rippers.PawooRipper;
+import org.junit.jupiter.api.Test;
+
+public class PawooRipperTest extends RippersTest {
+    @Test
+    public void testRip() throws IOException {
+        PawooRipper ripper = new PawooRipper(new URL("https://pawoo.net/@halki/media"));
+        testRipper(ripper);
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following:
* [x] a new Ripper

# Description

I've added a basic Mastodon ripper and several rippers that extend it for various Mastodon instances. This includes mastodon.social, mastodon.xyz, artalley.social, pawoo.net, and baraag.net. It downloads a single user's full media gallery, by scraping the web interface instead of via the API, so no authentication is required.

It accepts URLs in the form `https://[host]/@[user]`, with an optional `/media` suffix appended if not specified.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.

The following URLs were tested and work as expected:

```
https://mastodon.social/@pythonhub/media
https://mastodon.xyz/@artwo/media
https://artalley.social/@curator/media
https://pawoo.net/@halki/media
https://baraag.net/@darkshadow777/media
```