### PR TITLE
Add Ripper for folio.ink

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FolioRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FolioRipper.java
@@ -1,0 +1,75 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+import org.json.JSONObject;
+import org.json.JSONArray;
+
+import com.rarchives.ripme.ripper.AbstractJSONRipper;
+import com.rarchives.ripme.utils.Http;
+
+/**
+ * @author owaiswiz
+ *
+ */
+public class FolioRipper extends AbstractJSONRipper {
+    public FolioRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "folio";
+    }
+
+    @Override
+    public String getDomain() {
+        return "folio.ink";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https?://(?:www.)?folio.ink/([a-zA-Z0-9]+).*$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected folio.ink URL format: " +
+            "folio.ink/albumid (e.g: folio.ink/DmBe6i) - got " + url + " instead");
+    }
+
+    @Override
+    public JSONObject getFirstPage() throws IOException {
+        String jsonArrayString = Http.url("https://folio.ink/getimages/" + getGID(url)).ignoreContentType().response().body();
+        JSONArray imagesArray = new JSONArray(jsonArrayString);
+        JSONObject imagesObject = new JSONObject();
+        imagesObject.put("images", imagesArray);
+
+        return imagesObject;
+    }
+
+    @Override
+    public List<String> getURLsFromJSON(JSONObject json) {
+        List<String> result = new ArrayList<String>();
+        JSONArray imagesArray = json.getJSONArray("images");
+
+        for (int i = 0; i < imagesArray.length(); i++) {
+            JSONObject image = imagesArray.getJSONObject(i);
+            result.add(image.getString("image_url"));
+        }
+
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FolioRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FolioRipperTest.java
@@ -1,0 +1,26 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import java.io.IOException;
+import java.net.URL;
+import com.rarchives.ripme.ripper.rippers.FolioRipper;
+
+import org.junit.jupiter.api.Test;
+
+public class FolioRipperTest extends RippersTest {
+    /**
+     * Test for folio.ink ripper
+     * @throws IOException
+     */
+    @Test
+    public void testFolioRip() throws IOException {
+        FolioRipper ripper = new FolioRipper(new URL("https://folio.ink/DmBe6i"));
+        testRipper(ripper);
+    }
+
+    @Test
+    public void testGetGID() throws IOException {
+        URL url = new URL("https://folio.ink/DmBe6i");
+        FolioRipper ripper = new FolioRipper(url);
+        assertEquals("DmBe6i", ripper.getGID(url));
+    }
+}


### PR DESCRIPTION
# Category
* [ ] a bug fix (Fix #...)
* [x] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

- A new ripper for folio.ink
- Example supported URL: ```https://folio.ink/DmBe6i```

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors **Before** - 200 tests, failures: 16, skipped: 56; **After** - 202 tests, failures: 16, skipped: 56).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
