### PR TITLE
Issues/820 history folder

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -279,8 +279,8 @@ public abstract class AbstractRipper
         if (url.toExternalForm().equals("http:") || url.toExternalForm().equals("https:")) {
             LOGGER.info(url.toExternalForm() + " is a invalid url amd will be changed");
             return false;
-
         }
+        
         // Make sure the url doesn't contain any spaces as that can cause a 400 error when requesting the file
         if (url.toExternalForm().contains(" ")) {
             // If for some reason the url with all spaces encoded as %20 is malformed print an error

--- a/src/main/java/com/rarchives/ripme/ui/HistoryEntry.java
+++ b/src/main/java/com/rarchives/ripme/ui/HistoryEntry.java
@@ -6,29 +6,23 @@ import org.json.JSONObject;
 
 public class HistoryEntry {
 
-    public String  url          = "",
-                   title        = "",
-                   dir          = "";
-    public int     count        = 0;
-    public Date    startDate    = new Date(),
-                   modifiedDate = new Date();
-    public boolean selected     = false;
-
-    public HistoryEntry() {
-    }
+    public String url = "", title = "", dir = "";
+    public int count = 0;
+    public Date startDate = new Date(), modifiedDate = new Date();
+    public boolean selected = false;
 
     public HistoryEntry fromJSON(JSONObject json) {
-        this.url          = json.getString("url");
-        this.startDate    = new Date(json.getLong("startDate"));
+        this.url = json.getString("url");
+        this.startDate = new Date(json.getLong("startDate"));
         this.modifiedDate = new Date(json.getLong("modifiedDate"));
         if (json.has("title")) {
-            this.title    = json.getString("title");
+            this.title = json.getString("title");
         }
         if (json.has("count")) {
-            this.count    = json.getInt("count");
+            this.count = json.getInt("count");
         }
         if (json.has("dir")) {
-            this.dir      = json.getString("dir");
+            this.dir = json.getString("dir");
         }
         if (json.has("selected")) {
             this.selected = json.getBoolean("selected");
@@ -38,12 +32,14 @@ public class HistoryEntry {
 
     public JSONObject toJSON() {
         JSONObject json = new JSONObject();
-        json.put("url",          this.url);
-        json.put("startDate",    this.startDate.getTime());
+        json.put("url", this.url);
+        json.put("startDate", this.startDate.getTime());
         json.put("modifiedDate", this.modifiedDate.getTime());
-        json.put("title",        this.title);
-        json.put("count",        this.count);
-        json.put("selected",     this.selected);
+        json.put("title", this.title);
+        json.put("count", this.count);
+        json.put("selected", this.selected);
+        if (!dir.isEmpty())
+            json.put("dir", this.dir);
         return json;
     }
 

--- a/src/main/java/com/rarchives/ripme/ui/HistoryMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/HistoryMenuMouseListener.java
@@ -1,9 +1,12 @@
 package com.rarchives.ripme.ui;
 
+import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.io.File;
+import java.io.IOException;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -15,9 +18,10 @@ import com.rarchives.ripme.utils.Utils;
 class HistoryMenuMouseListener extends MouseAdapter {
     private JPopupMenu popup = new JPopupMenu();
     private JTable tableComponent;
+    private Point lastPoint;
 
     @SuppressWarnings("serial")
-    public HistoryMenuMouseListener() {
+    public HistoryMenuMouseListener(History history) {
         Action checkAllAction = new AbstractAction(Utils.getLocalizedString("history.check.all")) {
             @Override
             public void actionPerformed(ActionEvent ae) {
@@ -59,6 +63,21 @@ class HistoryMenuMouseListener extends MouseAdapter {
             }
         };
         popup.add(uncheckSelected);
+        popup.addSeparator();
+        popup.add(new AbstractAction(Utils.getLocalizedString("history.open.folder")) {
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    String url = tableComponent.getValueAt(tableComponent.rowAtPoint(lastPoint), 0).toString();
+                    File dir = new File(history.getEntryByURL(url).dir);
+                    if (dir.exists())
+                        java.awt.Desktop.getDesktop().open(dir);
+                } catch (IOException e1) {
+                    e1.printStackTrace();
+                }
+            }
+        });
     }
 
     @Override
@@ -70,6 +89,8 @@ class HistoryMenuMouseListener extends MouseAdapter {
 
             tableComponent = (JTable) e.getSource();
             tableComponent.requestFocus();
+
+            lastPoint = e.getPoint();
 
             int nx = e.getX();
 

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1,6 +1,23 @@
 package com.rarchives.ripme.ui;
 
-import java.awt.*;
+import java.awt.AWTException;
+import java.awt.CheckboxMenuItem;
+import java.awt.Color;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Desktop;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Image;
+import java.awt.MenuItem;
+import java.awt.Point;
+import java.awt.PopupMenu;
+import java.awt.SystemTray;
+import java.awt.TrayIcon;
 import java.awt.TrayIcon.MessageType;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -8,14 +25,20 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Enumeration;
 import java.util.List;
 
 import javax.imageio.ImageIO;
@@ -38,6 +61,7 @@ import javax.swing.JTextPane;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -49,16 +73,14 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import javax.swing.text.StyledDocument;
 
-import org.apache.log4j.ConsoleAppender;
-import org.apache.log4j.FileAppender;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-
 import com.rarchives.ripme.ripper.AbstractRipper;
 import com.rarchives.ripme.utils.RipUtils;
 import com.rarchives.ripme.utils.Utils;
 
-import javax.swing.UnsupportedLookAndFeelException;
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.FileAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 
 /**
  * Everything UI-related starts and ends here.
@@ -430,7 +452,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             }
         };
         historyTable = new JTable(historyTableModel);
-        historyTable.addMouseListener(new HistoryMenuMouseListener());
+        historyTable.addMouseListener(new HistoryMenuMouseListener(HISTORY));
         historyTable.setAutoCreateRowSorter(true);
         for (int i = 0; i < historyTable.getColumnModel().getColumnCount(); i++) {
             int width = 130; // Default
@@ -1418,10 +1440,10 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             RipStatusComplete rsc = (RipStatusComplete) msg.getObject();
             String url = ripper.getURL().toExternalForm();
             if (HISTORY.containsURL(url)) {
-                // TODO update "modifiedDate" of entry in HISTORY
                 HistoryEntry entry = HISTORY.getEntryByURL(url);
                 entry.count = rsc.count;
                 entry.modifiedDate = new Date();
+                entry.dir = rsc.getDir();
             } else {
                 HistoryEntry entry = new HistoryEntry();
                 entry.url = url;

--- a/src/main/resources/LabelsBundle.properties
+++ b/src/main/resources/LabelsBundle.properties
@@ -43,6 +43,7 @@ history.uncheck.selected = Uncheck Selected
 history.load.failed.warning = RipMe failed to load the history file at historyFile.getAbsolutePath() \n\nError: %s\n\nClosing RipMe will automatically overwrite the contents of this file,\nso you may want to back the file up before closing RipMe!
 history.load.none = There are no history entries to re-rip. Rip some albums first
 history.load.none.checked = No history entries have been 'Checked' Check an entry by clicking the checkbox to the right of the URL or Right-click a URL to check/uncheck all items
+history.open.folder = Open Folder
 
 # TrayIcon
 tray.show = Show


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [X] a new feature (resolve #820 )


# Description
Add option to open folder from history tab


# Testing

Required verification:
* [X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [X] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
