### PR TITLE
Fix MeituriRipper and VKRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MeituriRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MeituriRipper.java
@@ -70,7 +70,7 @@ public class MeituriRipper extends AbstractHTMLRipper {
             }
         }
 
-        // Base URL: http://ii.hywly.com/a/1/albumid/imgnum.jpg
+        // Base URL: https://ii.hywly.com/a/1/albumid/imgnum.jpg
         String baseURL = "https://ii.hywly.com/a/1/" + albumID + "/";
 
         // Loop through and add images to the URL list

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MeituriRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MeituriRipper.java
@@ -71,7 +71,7 @@ public class MeituriRipper extends AbstractHTMLRipper {
         }
 
         // Base URL: http://ii.hywly.com/a/1/albumid/imgnum.jpg
-        String baseURL = "http://ii.hywly.com/a/1/" + albumID + "/";
+        String baseURL = "https://ii.hywly.com/a/1/" + albumID + "/";
 
         // Loop through and add images to the URL list
         for (int i = 1; i <= numOfImages; i++) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1478, Fix #1413, Fix #1476)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Meituri: Protocoll changed to http**s** because http access doesn't work anymore (HTTP answer 403). Test was already set up on https.

VK: Download of albums works now


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
