### PR TITLE
Fixed path name issues on windows

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -870,8 +870,6 @@ public class Utils {
         // How long the path without the file name is
         int pathLength = ripsDirPath.length();
         int fileNameLength = fileName.length();
-        LOGGER.info(pathLength);
-        LOGGER.info(fileNameLength);
         if (pathLength == 260) {
             // We've reached the max length, there's nothing more we can do
             throw new FileNotFoundException("File path is too long for this OS");
@@ -881,8 +879,8 @@ public class Utils {
         // file extension
         String fileExt = saveAsSplit[saveAsSplit.length - 1];
         // The max limit for paths on Windows is 260 chars
-        LOGGER.info(fullPath.substring(0, 260 - pathLength - fileExt.length() + 1) + "." + fileExt);
-        fullPath = fullPath.substring(0, 260 - pathLength - fileExt.length() + 1) + "." + fileExt;
+        LOGGER.info(fullPath.substring(0, 259 - pathLength - fileExt.length() + 1) + "." + fileExt);
+        fullPath = fullPath.substring(0, 259 - pathLength - fileExt.length() + 1) + "." + fileExt;
         LOGGER.info(fullPath);
         LOGGER.info(fullPath.length());
         return new File(fullPath);

--- a/src/test/java/com/rarchives/ripme/tst/UtilsTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/UtilsTest.java
@@ -7,10 +7,12 @@ import java.util.Arrays;
 import com.rarchives.ripme.utils.Utils;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class UtilsTest {
 
-    public void testGetEXTFromMagic() {
+    public void testGetEXTFromMagic()
+    {
         Assertions.assertEquals("jpeg", Utils.getEXTFromMagic(new byte[] { -1, -40, -1, -37, 0, 0, 0, 0 }));
         Assertions.assertEquals("png", Utils.getEXTFromMagic(new byte[] { -119, 80, 78, 71, 13, 0, 0, 0 }));
     }
@@ -44,13 +46,13 @@ public class UtilsTest {
     public void testBetween() {
         Assertions.assertEquals(Arrays.asList(" is a "), Utils.between("This is a test", "This", "test"));
     }
-
+    @Test
     public void testShortenFileNameWindows() throws FileNotFoundException {
         String filename = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.png";
         // Test filename shortening for windows
         File f = Utils.shortenSaveAsWindows("D:/rips/test/reddit/deep", filename);
         Assertions.assertEquals(new File(
-                "D:/rips/test/reddit/deep/fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.png"),
+                "D:/rips/test/reddit/deep/ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff.png"),
                 f);
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #1477)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Shortens max path name on windows to 259 chars


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
