### PR TITLE
Fixed LusciousRipper.

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LusciousRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LusciousRipperTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class LusciousRipperTest extends RippersTest {
-    @Test @Disabled("Flaky in the CI")
+    @Test
     public void testPahealRipper() throws IOException {
         // a photo set
         LusciousRipper ripper = new LusciousRipper(
@@ -16,12 +16,14 @@ public class LusciousRipperTest extends RippersTest {
         testRipper(ripper);
     }
 
+    @Test
     public void testGetGID() throws IOException {
         URL url = new URL("https://luscious.net/albums/h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609/");
         LusciousRipper ripper = new LusciousRipper(url);
         assertEquals("h-na-alice-wa-suki-desu-ka-do-you-like-alice-when_321609", ripper.getGID(url));
     }
-    @Test @Disabled("Flaky in the CI")
+    
+    @Test
     public void testGetNextPage() throws IOException {
         URL multiPageAlbumUrl = new URL("https://luscious.net/albums/women-of-color_58/");
         LusciousRipper multiPageRipper = new LusciousRipper(multiPageAlbumUrl);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1531, fix #1525, fix #1488, fix #1447)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
* Changed regex pattern to match `https://www.luscious.net/...`,  `https://old.luscious.net/...`, `https://members.luscious.net/...`.
* Added overrides for `sanitizeUrl` and `normalizeUrl`.
* Re-enabled test cases.

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
