### PR TITLE
Fix Pawoo ripper pagination

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PawooRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PawooRipper.java
@@ -3,6 +3,11 @@ package com.rarchives.ripme.ripper.rippers;
 import java.io.IOException;
 import java.net.URL;
 
+import com.rarchives.ripme.utils.Http;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+
 public class PawooRipper extends MastodonRipper {
     public PawooRipper(URL url) throws IOException {
         super(url);
@@ -16,5 +21,18 @@ public class PawooRipper extends MastodonRipper {
     @Override
     public String getDomain() {
         return "pawoo.net";
+    }
+
+
+    @Override
+    // Pawoo uses a custom theme that has different navigation links
+    public Document getNextPage(Document doc) throws IOException {
+        Elements hrefs = doc.select(".pagination a[rel=\"next\"]");
+        if (hrefs.isEmpty()) {
+            throw new IOException("No more pages");
+        }
+        String nextUrl = hrefs.last().attr("href");
+        sleep(500);
+        return Http.url(nextUrl).get();
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Not submitted as an issue)


# Description

The generic Mastodon ripper mostly worked as a base for this ripper, but Pawoo uses an alternate web UI that changes how navigation links work, so I've updated it to use the correct selector. Before this change, only the first page of the media for a user was ripped.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.

As an aside, I really like how we're forcing Travis to repeatedly rip loads of porn.