### PR TITLE
VscoRipper Fix

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
@@ -116,7 +116,7 @@ public class VscoRipper extends AbstractHTMLRipper {
     }
 
     private String getUserName() {
-        Pattern p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/gallery(/)?");
+        Pattern p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)(/gallery)?(/)?");
         Matcher m = p.matcher(url.toExternalForm());
 
         if (m.matches()) {
@@ -200,7 +200,7 @@ public class VscoRipper extends AbstractHTMLRipper {
         }
         
         //Member profile (Usernames should all be different, so this should work.
-        p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/gallery(/)?");
+        p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)(/gallery)?(/)?");
         m = p.matcher(url.toExternalForm());
         
         if (m.matches()){

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
@@ -24,7 +24,7 @@ public class VscoRipper extends AbstractHTMLRipper {
 
 
     private static final String DOMAIN = "vsco.co",
-                        HOST   = "vsco";
+                                HOST   = "vsco";
     
     public VscoRipper(URL url) throws IOException{
         super(url);
@@ -101,7 +101,7 @@ public class VscoRipper extends AbstractHTMLRipper {
 
     private String getUserTkn(String username) {
         String userinfoPage = "https://vsco.co/content/Static/userinfo";
-        String referer = "https://vsco.co/" + username + "/images/1";
+        String referer = "https://vsco.co/" + username + "/gallery";
         Map<String,String> cookies = new HashMap<>();
         cookies.put("vs_anonymous_id", UUID.randomUUID().toString());
         try {
@@ -116,7 +116,7 @@ public class VscoRipper extends AbstractHTMLRipper {
     }
 
     private String getUserName() {
-        Pattern p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/images/[0-9]+");
+        Pattern p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/gallery(/)?");
         Matcher m = p.matcher(url.toExternalForm());
 
         if (m.matches()) {
@@ -200,7 +200,7 @@ public class VscoRipper extends AbstractHTMLRipper {
         }
         
         //Member profile (Usernames should all be different, so this should work.
-        p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/images/[0-9]+");
+        p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/gallery(/)?");
         m = p.matcher(url.toExternalForm());
         
         if (m.matches()){


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1579)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

URL format was changed from `https://vsco.co/<username>/images/1` to `https://vsco.co/<username>/gallery` and an error occured when entering an URL of the new scheme. The corrosponding regular expressions were adopted. Now URLs of following formats are allowed and work:

- `https://vsco.co/<username>`
- `https://vsco.co/<username>/`
- `https://vsco.co/<username>/gallery`
- `https://vsco.co/<username>/gallery/`


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
