### PR TITLE
ViscoRipper add video support

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
@@ -116,7 +116,7 @@ public class VscoRipper extends AbstractHTMLRipper {
     }
 
     private String getUserName() {
-        Pattern p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/gallery(/)?");
+        Pattern p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)(/gallery)?(/)?");
         Matcher m = p.matcher(url.toExternalForm());
 
         if (m.matches()) {
@@ -200,7 +200,7 @@ public class VscoRipper extends AbstractHTMLRipper {
         }
         
         //Member profile (Usernames should all be different, so this should work.
-        p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/gallery(/)?");
+        p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)(/gallery)?(/)?");
         m = p.matcher(url.toExternalForm());
         
         if (m.matches()){

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
@@ -24,7 +24,7 @@ public class VscoRipper extends AbstractHTMLRipper {
 
 
     private static final String DOMAIN = "vsco.co",
-                        HOST   = "vsco";
+                                HOST   = "vsco";
     
     public VscoRipper(URL url) throws IOException{
         super(url);
@@ -101,7 +101,7 @@ public class VscoRipper extends AbstractHTMLRipper {
 
     private String getUserTkn(String username) {
         String userinfoPage = "https://vsco.co/content/Static/userinfo";
-        String referer = "https://vsco.co/" + username + "/images/1";
+        String referer = "https://vsco.co/" + username + "/gallery";
         Map<String,String> cookies = new HashMap<>();
         cookies.put("vs_anonymous_id", UUID.randomUUID().toString());
         try {
@@ -116,7 +116,7 @@ public class VscoRipper extends AbstractHTMLRipper {
     }
 
     private String getUserName() {
-        Pattern p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/images/[0-9]+");
+        Pattern p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/gallery(/)?");
         Matcher m = p.matcher(url.toExternalForm());
 
         if (m.matches()) {
@@ -200,7 +200,7 @@ public class VscoRipper extends AbstractHTMLRipper {
         }
         
         //Member profile (Usernames should all be different, so this should work.
-        p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/images/[0-9]+");
+        p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/gallery(/)?");
         m = p.matcher(url.toExternalForm());
         
         if (m.matches()){

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
@@ -85,7 +85,12 @@ public class VscoRipper extends AbstractHTMLRipper {
             while (true) {
                 profileJSON = getProfileJSON(userTkn, username, Integer.toString(pageNumber), siteID);
                 for (int i = 0; i < profileJSON.getJSONArray("media").length(); i++) {
-                    toRip.add("https://" + profileJSON.getJSONArray("media").getJSONObject(i).getString("responsive_url"));
+                    // Check if video or image and add corresponding to queue
+                    if(profileJSON.getJSONArray("media").getJSONObject(i).has("video_url")) {
+                        toRip.add("https://" + profileJSON.getJSONArray("media").getJSONObject(i).getString("video_url"));
+                    } else {
+                        toRip.add("https://" + profileJSON.getJSONArray("media").getJSONObject(i).getString("responsive_url"));
+                    }
                 }
                 if (pageNumber * 1000 > profileJSON.getInt("total")) {
                     return toRip;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


# Description

Every media file is now checked if it is a video and if the the mp4-file is downloaded. Before, only the preview image for videos was downloaded.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
