### PR TITLE
updated input url to match current update for vsco ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/VscoRipper.java
@@ -200,7 +200,7 @@ public class VscoRipper extends AbstractHTMLRipper {
         }
         
         //Member profile (Usernames should all be different, so this should work.
-        p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/images/[0-9]+");
+        p = Pattern.compile("^https?://vsco.co/([a-zA-Z0-9-]+)/gallery");
         m = p.matcher(url.toExternalForm());
         
         if (m.matches()){


### PR DESCRIPTION
Instead of "vsco.co/<username>/images/1" it is "vsco.co/<username>/gallery"

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Please add details about your change here.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
