### PR TITLE
Added LanvshenRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/LanvshenRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/LanvshenRipper.java
@@ -1,0 +1,86 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class LanvshenRipper extends AbstractHTMLRipper {
+    public LanvshenRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "lanvshen";
+    }
+
+    @Override
+    public String getDomain() {
+        return "lanvshen.com";
+    }
+
+    // To use in getting URLs
+    String albumID = "";
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        // without escape
+        // ^https?://[w.]*lanvshen\.com/a/([0-9]+)/([0-9]+\.html)*$
+        // https://www.lanvshen.com/a/14449/
+        // also matches https://www.lanvshen.com/a/14449/3.html etc.
+        // group 1 is 14449
+        Pattern p = Pattern.compile("^https?://[w.]*lanvshen\\.com/a/([0-9]+)/([0-9]+\\.html)*$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            albumID = m.group(1);
+            return m.group(1);
+        }
+        throw new MalformedURLException(
+                "Expected lanvshen.com URL format: " + "lanvshen.com/a/albumid/ - got " + url + "instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        return Http.url(url).get();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> imageURLs = new ArrayList<>();
+        // Get number of images from the page
+        // Then generate links according to that
+        int numOfImages = 1;
+        Pattern p = Pattern.compile("^<p>图片数量： ([0-9]+)P</p>$");
+        for (Element para : doc.select("div.tuji > p")) {
+            // <p>图片数量： 55P</p>
+            Matcher m = p.matcher(para.toString());
+            if (m.matches()) {
+                // 55
+                numOfImages = Integer.parseInt(m.group(1));
+            }
+        }
+
+        // Base URL: http://ii.hywly.com/a/1/albumid/imgnum.jpg
+        String baseURL = "http://ii.hywly.com/a/1/" + albumID + "/";
+
+        // Loop through and add images to the URL list
+        for (int i = 1; i <= numOfImages; i++) {
+            imageURLs.add(baseURL + i + ".jpg");
+        }
+        return imageURLs;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LanvshenRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/LanvshenRipperTest.java
@@ -1,0 +1,24 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import com.rarchives.ripme.ripper.rippers.LanvshenRipper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URL;
+
+public class LanvshenRipperTest extends RippersTest {
+    @Test
+    @Disabled("Broken ripper")
+    public void testMeituriRip() throws IOException {
+        LanvshenRipper ripper = new LanvshenRipper(new URL("https://www.lanvshen.com/a/14449/"));
+        testRipper(ripper);
+    }
+
+    @Test
+    public void testGetGID() throws IOException {
+        URL url = new URL("https://www.lanvshen.com/a/14449/");
+        LanvshenRipper ripper = new LanvshenRipper(url);
+        assertEquals("14449", ripper.getGID(url));
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1608)
* [x] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Since Meituri.com is now lanvshen.com a new ripper class was added. Since meituri.com-links still work I left the initial ripper untouched.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
