### PR TITLE
Mangadex - Allow www prefix and page suffix

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MangadexRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MangadexRipper.java
@@ -2,11 +2,8 @@ package com.rarchives.ripme.ripper.rippers;
 
 import com.rarchives.ripme.ripper.AbstractJSONRipper;
 import com.rarchives.ripme.utils.Http;
-import com.rarchives.ripme.utils.Utils;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.jsoup.Connection;
-import org.jsoup.nodes.Document;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -51,10 +48,10 @@ public class MangadexRipper extends AbstractJSONRipper {
     }
 
     private String getChapterID(String url) {
-        Pattern p = Pattern.compile("https://mangadex.org/chapter/([\\d]+)/?");
+        Pattern p = Pattern.compile("https://(www\\.)?mangadex\\.org/chapter/([\\d]+)/?[\\d]*");
         Matcher m = p.matcher(url);
         if (m.matches()) {
-            return m.group(1);
+            return m.group(2);
         }
         return null;
     }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MangadexRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MangadexRipperTest.java
@@ -1,15 +1,22 @@
 package com.rarchives.ripme.tst.ripper.rippers;
 
-
 import com.rarchives.ripme.ripper.rippers.MangadexRipper;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URL;
 
 public class MangadexRipperTest extends RippersTest{
+    @Test
     public void testRip() throws IOException {
         MangadexRipper ripper = new MangadexRipper(new URL("https://mangadex.org/chapter/467904/"));
         testRipper(ripper);
     }
 
+    @Test
+    public void testAltUrlRip() throws IOException {
+        MangadexRipper ripper = new MangadexRipper(new URL("https://www.mangadex.org/chapter/804465/1"));
+        testRipper(ripper);
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix


# Description

This updates the Mangadex ripper to make it a bit more relaxed on what URLs it considers valid and can rip. It now allows a "www" prefix on the URL, and correctly rips whole chapters when a page URL within a chapter is given.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
