### PR TITLE
Updated e621 ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/E621Ripper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/E621Ripper.java
@@ -97,9 +97,9 @@ public class E621Ripper extends AbstractHTMLRipper {
             gidPatternPool = Pattern.compile(
                     "^https?://(www\\.)?e621\\.net/pool/show/([a-zA-Z0-9$_.+!*'(),%:\\-]+)(\\?.*)?(/.*)?(#.*)?$");
         if (gidPatternNew == null)
-            gidPatternNew = Pattern.compile("^https?://(www\\.)?e621\\.net/posts\\?tags=([\\S]+)");
+            gidPatternNew = Pattern.compile("^https?://(www\\.)?e621\\.net/posts\\?tags=([a-zA-Z0-9$_.+!*'(),%:\\-]+)(\\&[\\S]+)?");
         if (gidPatternPoolNew == null)
-            gidPatternPoolNew = Pattern.compile("^https?://(www\\.)?e621\\.net/pools/([\\d]+)");
+            gidPatternPoolNew = Pattern.compile("^https?://(www\\.)?e621\\.net/pools/([\\d]+)(\\?[\\S]*)?");
 
         Matcher m = gidPattern.matcher(url.toExternalForm());
         if (m.matches()) {

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/E621RipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/E621RipperTest.java
@@ -8,16 +8,43 @@ import org.junit.jupiter.api.Test;
 
 public class E621RipperTest extends RippersTest {
     public void testRip() throws IOException {
-        E621Ripper ripper = new E621Ripper(new URL("https://e621.net/post/index/1/beach"));
+        E621Ripper ripper = new E621Ripper(new URL("https://e621.net/posts?tags=beach"));
         testRipper(ripper);
     }
     @Test
     public void testFlashOrWebm() throws IOException {
-        E621Ripper ripper = new E621Ripper(new URL("https://e621.net/post/index/1/gif"));
+        E621Ripper ripper = new E621Ripper(new URL("https://e621.net/posts?page=4&tags=gif+rating%3As+3d"));
         testRipper(ripper);
     }
     @Test
     public void testGetNextPage() throws IOException {
+        E621Ripper nextPageRipper = new E621Ripper(new URL("https://e621.net/posts?tags=cosmicminerals"));
+        try {
+            nextPageRipper.getNextPage(nextPageRipper.getFirstPage());
+            assert (true);
+        } catch (IOException e) {
+            throw e;
+        }
+
+        E621Ripper noNextPageRipper = new E621Ripper(new URL("https://e621.net/post/index/1/cosmicminerals"));
+        try {
+            noNextPageRipper.getNextPage(noNextPageRipper.getFirstPage());
+        } catch (IOException e) {
+            assertEquals(e.getMessage(), "No more pages.");
+        }
+    }
+    @Test
+    public void testOldRip() throws IOException {
+        E621Ripper ripper = new E621Ripper(new URL("https://e621.net/post/index/1/beach"));
+        testRipper(ripper);
+    }
+    @Test
+    public void testOldFlashOrWebm() throws IOException {
+        E621Ripper ripper = new E621Ripper(new URL("https://e621.net/post/index/1/gif"));
+        testRipper(ripper);
+    }
+    @Test
+    public void testOldGetNextPage() throws IOException {
         E621Ripper nextPageRipper = new E621Ripper(new URL("https://e621.net/post/index/1/cosmicminerals"));
         try {
             nextPageRipper.getNextPage(nextPageRipper.getFirstPage());


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1604, #1602, #1580)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
Changed e621 ripper to work with the updated e621 site. Added bypass for Cloudflare captcha and global anonymous user blacklist, which were added with this update. Created new config options e621.cookies and e621.useragent for this purpose.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
