### PR TITLE
Added FreecomiconlineRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FreeComicOnlineRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FreeComicOnlineRipper.java
@@ -1,0 +1,89 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+public class FreeComicOnlineRipper extends AbstractHTMLRipper {
+
+    public FreeComicOnlineRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "freecomiconline";
+    }
+
+    @Override
+    public String getDomain() {
+        return "freecomiconline.me";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("https://freecomiconline.me/comic/([a-zA-Z0-9_\\-]+)/([a-zA-Z0-9_\\-]+)/?$");
+	Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1) + "_" + m.group(2);
+        }
+        p = Pattern.compile("^https://freecomiconline.me/comic/([a-zA-Z0-9_\\-]+)/?$");
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected freecomiconline URL format: " +
+                "freecomiconline.me/TITLE/CHAPTER - got " + url + " instead");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException {
+        // "url" is an instance field of the superclass
+        return Http.url(url).get();
+    }
+    
+    @Override
+    public Document getNextPage(Document doc) throws IOException {
+        String nextPage = doc.select("div.select-pagination a").get(1).attr("href");
+	String nextUrl = "";
+	// "https://freecomiconline.me/comic/([a-zA-Z0-9_\\-]+)/([a-zA-Z0-9_\\-]+)/?$"
+        System.out.println("\n\nPagination.(0).href: "+ nextPage); 
+
+	Pattern p = Pattern.compile("https://freecomiconline.me/comic/([a-zA-Z0-9_\\-]+)/([a-zA-Z0-9_\\-]+)/?$");
+        Matcher m = p.matcher(nextPage);
+        
+	if(m.matches()){ 
+		nextUrl = m.group(0);
+		//System.out.println("\n\nMatched and recreatedUrl: "+ nextUrl+"\n\n");
+	
+	}
+	if(nextUrl.equals("")) throw new IOException("No more pages");
+
+	sleep(500);
+        return Http.url(nextUrl).get();
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) {
+        List<String> result = new ArrayList<>();
+        for (Element el : doc.select(".wp-manga-chapter-img")) {
+            result.add(el.attr("src"));
+        }
+        return result;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+}

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FreeComicOnlineRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FreeComicOnlineRipper.java
@@ -57,7 +57,7 @@ public class FreeComicOnlineRipper extends AbstractHTMLRipper {
 	Pattern p = Pattern.compile("https://freecomiconline.me/comic/([a-zA-Z0-9_\\-]+)/([a-zA-Z0-9_\\-]+)/?$");
         Matcher m = p.matcher(nextPage);
 	if(m.matches()){ 
-		nextUrl = m.group(0);
+	    nextUrl = m.group(0);
 	}
 	if(nextUrl.equals("")) throw new IOException("No more pages");
 	sleep(500);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FreeComicOnlineRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FreeComicOnlineRipper.java
@@ -7,10 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import com.rarchives.ripme.utils.Http;
 
@@ -56,19 +54,12 @@ public class FreeComicOnlineRipper extends AbstractHTMLRipper {
     public Document getNextPage(Document doc) throws IOException {
         String nextPage = doc.select("div.select-pagination a").get(1).attr("href");
 	String nextUrl = "";
-	// "https://freecomiconline.me/comic/([a-zA-Z0-9_\\-]+)/([a-zA-Z0-9_\\-]+)/?$"
-        System.out.println("\n\nPagination.(0).href: "+ nextPage); 
-
 	Pattern p = Pattern.compile("https://freecomiconline.me/comic/([a-zA-Z0-9_\\-]+)/([a-zA-Z0-9_\\-]+)/?$");
         Matcher m = p.matcher(nextPage);
-        
 	if(m.matches()){ 
 		nextUrl = m.group(0);
-		//System.out.println("\n\nMatched and recreatedUrl: "+ nextUrl+"\n\n");
-	
 	}
 	if(nextUrl.equals("")) throw new IOException("No more pages");
-
 	sleep(500);
         return Http.url(nextUrl).get();
     }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
Added a ripper for freecomiconline.me supports chapter download and continues to next chapter until caught up


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
