### PR TITLE
Changed imagefap links from http to https

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImagefapRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImagefapRipper.java
@@ -38,7 +38,7 @@ public class ImagefapRipper extends AbstractHTMLRipper {
     @Override
     public URL sanitizeURL(URL url) throws MalformedURLException {
         String gid = getGID(url);
-        String newURL = "http://www.imagefap.com/gallery.php?";
+        String newURL = "https://www.imagefap.com/gallery.php?";
         if (isNewAlbumType) {
             newURL += "p";
         }
@@ -107,7 +107,7 @@ public class ImagefapRipper extends AbstractHTMLRipper {
         String nextURL = null;
         for (Element a : doc.select("a.link3")) {
             if (a.text().contains("next")) {
-                nextURL = "http://imagefap.com/gallery.php" + a.attr("href");
+                nextURL = "https://imagefap.com/gallery.php" + a.attr("href");
                 break;
             }
         }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1629 ; #1387 ; #1074 ; #1065)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Only changed `http` to `https` 
Since some users are experiencing problem with `http` version of imgaefap, `https` should be used.

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
