### PR TITLE
Now sends a referrer when fetching first page

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
@@ -25,6 +25,7 @@ public class GfycatRipper extends AbstractHTMLRipper {
     String username = "";
     String cursor = "";
     String count = "30";
+    String REFERRER = "www.reddit.com";
 
 
 
@@ -64,10 +65,10 @@ public class GfycatRipper extends AbstractHTMLRipper {
     @Override
     public Document getFirstPage() throws IOException {
         if (!isProfile()) {
-            return Http.url(url).get();
+            return Http.url(url).referrer(REFERRER).get();
         } else {
             username = getGID(url);
-            return Http.url(new URL("https://api.gfycat.com/v1/users/" +  username + "/gfycats")).ignoreContentType().get();
+            return Http.url(new URL("https://api.gfycat.com/v1/users/" +  username + "/gfycats")).referrer((REFERRER)).ignoreContentType().get();
         }
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Please add details about your change here.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
