### PR TITLE
Fix #1666 - Motherless search term ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MotherlessRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MotherlessRipper.java
@@ -55,6 +55,8 @@ public class MotherlessRipper extends AbstractHTMLRipper {
         Pattern p = Pattern.compile("[MIV]");
         Matcher m = p.matcher(String.valueOf(path.charAt(2)));
         boolean notHome = m.matches();
+        // Check if it's a search term
+        boolean term = path.contains("term");
         // If it's the homepage go to the "All Uploads" gallery (/Gxxxxx -> /GMxxxxx)
         if (!notHome) {
             StringBuilder newPath = new StringBuilder(path);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MotherlessRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MotherlessRipperTest.java
@@ -13,4 +13,8 @@ public class MotherlessRipperTest extends RippersTest {
         MotherlessRipper ripper = new MotherlessRipper(new URL("https://motherless.com/G1168D90"));
         testRipper(ripper);
     }
+    public void testMotherlessTagSearch() throws IOException {
+        MotherlessRipper ripper = new MotherlessRipper(new URL("https://motherless.com/term/images/cherubesque"));
+        testRipper(ripper);
+    }
 }


### PR DESCRIPTION
Line 61 is adding an "M" as the second character in the path, if it does not detect an "M", "I" or "V" there.

I have made it not do so if the path contains "term", as the path for search terms is "....com/term/`$search-term`"

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Please add details about your change here.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
