### PR TITLE
Add Ripper for nsfwalbum.com

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NsfwAlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NsfwAlbumRipper.java
@@ -61,19 +61,6 @@ public class NsfwAlbumRipper extends AbstractHTMLRipper
         return Http.url(url).get();
     }
 
-    //TODO most likely broken.
-    @Override
-    public String normalizeUrl(String url)
-    {
-        Pattern p = Pattern.compile("https:[\\/]{2,}nsfwalbum.com[\\/]{1,}album[\\/]{1,}\\d+");
-        Matcher m = p.matcher(url);
-
-        if (m.matches())
-            return m.group(1).replaceAll("\\", "/").trim();
-        else
-            return url;
-    }
-
     @Override
     public List<String> getURLsFromPage(Document doc) 
     {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NsfwAlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NsfwAlbumRipper.java
@@ -61,6 +61,7 @@ public class NsfwAlbumRipper extends AbstractHTMLRipper
         return Http.url(url).get();
     }
 
+    //TODO most likely broken.
     @Override
     public String normalizeUrl(String url)
     {
@@ -71,8 +72,6 @@ public class NsfwAlbumRipper extends AbstractHTMLRipper
             return m.group(1).replaceAll("\\", "/").trim();
         else
             return url;
-
-        //throw new MalformedURLException("Expected nsfwalbum.com URL format nsfwalbum.com/album/albumid - got " + url + "instead.");
     }
 
     @Override
@@ -82,12 +81,33 @@ public class NsfwAlbumRipper extends AbstractHTMLRipper
 
         Elements imgs = doc.select(".album img");
 
-        System.out.println(imgs.size() + " elements (images) found.");
+        System.out.println(imgs.size() + " elements (thumbnails) found.");
 
         for (Element img : imgs)
         {
-            //TODO: Account for other hosting platforms. See C:\Users\Joel Goransson\Documents\python\nsfwalbum.py
-            results.add(img.attr("data-src").replace("/th/", "/i/"));
+            String thumbURL = img.attr("data-src");
+            String fullResURL = null;
+
+            if (thumbURL.contains("imgspice.com"))
+            {
+                fullResURL = thumbURL.replace("_t.jpg", ".jpg");
+            }
+            else if (thumbURL.contains("imagetwist.com"))
+            {
+                fullResURL = thumbURL.replace("/th/", "/i/");
+            }
+            else if (thumbURL.contains("pixhost.com"))
+            {
+                fullResURL = thumbURL.replace("https://t", "https://img");
+                fullResURL = fullResURL.replace("/thumbs/", "/images/");
+            }
+            else if (thumbURL.contains("imx.to"))
+            {
+                fullResURL = thumbURL.replace("/t/", "/i/");
+            }
+
+            if (fullResURL != null)
+                results.add(fullResURL);
         }
 
         return results;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NsfwAlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NsfwAlbumRipper.java
@@ -1,0 +1,101 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.regex.Pattern;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+
+import org.jsoup.*;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+
+//https://github.com/ripmeapp/ripme/wiki/How-To-Create-A-Ripper-for-HTML-websites
+public class NsfwAlbumRipper extends AbstractHTMLRipper 
+{
+    private static final String HOST = "nsfwalbum";
+    private static final String DOMAIN = "nsfwalbum.com";
+
+    public NsfwAlbumRipper(URL url) throws IOException 
+    {
+        super(url);
+    }
+
+    @Override
+    public String getHost() 
+    {
+        return HOST;
+    }
+
+    @Override
+    public String getDomain()
+    {
+        return DOMAIN;
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException
+    {
+        Pattern pattern = Pattern.compile("(?!https:\\/\\/nsfwalbum.com\\/album\\/)\\d+");
+        Matcher matcher = pattern.matcher(url.toExternalForm());
+
+        if (matcher.find())
+        {
+            return matcher.group();
+        }
+
+        throw new MalformedURLException("Expected https://nsfwalbum.com/album/albumid URL format nsfwalbum.com/album/albumid - got " + url + " instead.");
+    }
+
+    @Override
+    public Document getFirstPage() throws IOException
+    {
+        return Http.url(url).get();
+    }
+
+    @Override
+    public String normalizeUrl(String url)
+    {
+        Pattern p = Pattern.compile("https:[\\/]{2,}nsfwalbum.com[\\/]{1,}album[\\/]{1,}\\d+");
+        Matcher m = p.matcher(url);
+
+        if (m.matches())
+            return m.group(1).replaceAll("\\", "/").trim();
+        else
+            return url;
+
+        //throw new MalformedURLException("Expected nsfwalbum.com URL format nsfwalbum.com/album/albumid - got " + url + "instead.");
+    }
+
+    @Override
+    public List<String> getURLsFromPage(Document doc) 
+    {
+        List<String> results = new ArrayList<String>();
+
+        Elements imgs = doc.select(".album img");
+
+        System.out.println(imgs.size() + " elements (images) found.");
+
+        for (Element img : imgs)
+        {
+            //TODO: Account for other hosting platforms. See C:\Users\Joel Goransson\Documents\python\nsfwalbum.py
+            results.add(img.attr("data-src").replace("/th/", "/i/"));
+        }
+
+        return results;
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) 
+    {
+        addURLToDownload(url);
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

I've gone ahead and added a ripper for nsfwalbum.com. 
They host their images on many different image hosting sites so you must replace part of the image urls to get the full image instead of the thumbnails.
There may be more hosts that I did not find, they can be added in later very easily.

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.

NOTES: 
mvn test failed, i think it may because of how my maven is setup, it doesnt reference any files of ripme in the stacktrace, i can post the error if that is helpful.
I don't have any experience on how to do unit testing, I am eager to learn if someone wants to help and give me a quick run down.
