### PR TITLE
Negate expression

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/Http.java
+++ b/src/main/java/com/rarchives/ripme/utils/Http.java
@@ -82,7 +82,7 @@ public class Http {
                 String domain = String.join(".", parts);
                 // Try to get cookies for this host from config
                 cookieStr = Utils.getConfigString("cookies." + domain, "");
-                if (cookieStr.equals("")) {
+                if (!cookieStr.equals("")) {
                     cookieDomain = domain; 
                     // we found something, start parsing
                     break;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (no bug report)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

It is clear from this [commit diff](https://github.com/RipMeApp/ripme/pull/1483/commits/74bfac0e3efc331588b6eebf8ce78ac0733ab066#diff-593478eb17f5932cf73ff6689499875fL85-R85) that the changed `if` statement
```
if (cookieStr != "")
```
was incorrectly changed to
```
if (cookieStr.equals(""))
```
which should be
```
if (!cookieStr.equals(""))
```
instead.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
