### PR TITLE
Resolve xlecx error #1696

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XcartxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XcartxRipper.java
@@ -56,7 +56,7 @@ public class XcartxRipper extends AbstractHTMLRipper {
         for (Element image : imageElements) {
             String imageUrl = image.attr("data-src");
 
-            imageURLs.add(getDomain() + imageUrl);
+            imageURLs.add("https://" + getDomain() + imageUrl);
         }
         return imageURLs;
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XlecxRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XlecxRipper.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 
 public class XlecxRipper extends XcartxRipper {
 
-    private Pattern p = Pattern.compile("^https?://xlecx.com/([a-zA-Z0-9_\\-]+).html");
+    private Pattern p = Pattern.compile("^https?://xlecx.org/([a-zA-Z0-9_\\-]+).html");
 
     public XlecxRipper(URL url) throws IOException {
         super(url);
@@ -21,7 +21,7 @@ public class XlecxRipper extends XcartxRipper {
 
     @Override
     public String getDomain() {
-        return "xlecx.com";
+        return "xlecx.org";
     }
 
     @Override
@@ -30,7 +30,7 @@ public class XlecxRipper extends XcartxRipper {
         if (m.matches()) {
             return m.group(1);
         }
-        throw new MalformedURLException("Expected URL format: http://xlecx.com/comic, got: " + url);
+        throw new MalformedURLException("Expected URL format: http://xlecx.org/comic, got: " + url);
 
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1696)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature

# Description

xlecx has changed its URL from 'xlecx.com' to 'xlecx.org'.
This change modifies the ripper.java to reflect that change, and to add the required https prefix.
(If the https prefix is not added, the image download fails with 'no protocol'. That seems a little janky, but it was used in #120.)

This pull resolves Issue #1696

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Regarding _mvn test_, it has errors both before and after my changes... So I guess that counts as 'no _new_ failures'?
Please advise on how to do that better if I ought to.

Optional but recommended:
* [ ] I've added a unit test to cover my change.

Regarding a unit test, the unit test supplied when the xlecx ripper was first added in Merge #1206 should suffice, although I don't see it in the files anymore. (Let me know if I need to do something here, I haven't made one of those before.)