### PR TITLE
Fix InstagramRipper for single posts by updating path

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/InstagramRipper.java
@@ -153,7 +153,7 @@ public class InstagramRipper extends AbstractJSONRipper {
         qHash = getQhash(document);
         JSONObject jsonObject = getJsonObjectFromDoc(document);
         String hashtagNamePath = "entry_data.TagPage[0].graphql.hashtag.name";
-        String singlePostIdPath = "graphql.shortcode_media.shortcode";
+        String singlePostIdPath = "entry_data.PostPage[0].graphql.shortcode_media.shortcode";
         String profileIdPath = "entry_data.ProfilePage[0].graphql.user.id";
         String storiesPath = "entry_data.StoriesPage[0].user.id";
         String idPath = hashtagRip ? hashtagNamePath : storiesRip ? storiesPath : postRip ? singlePostIdPath : profileIdPath;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/InstagramRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/InstagramRipperTest.java
@@ -36,7 +36,6 @@ public class InstagramRipperTest extends RippersTest {
     }
 
     @Test
-    @Disabled("Ripper broken for single items")
     public void testInstagramAlbums() throws IOException {
         List<URL> contentURLs = new ArrayList<>();
         // This unit test is a bit flaky 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1545 & #1533)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Update `singlePostIdPath`

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
