### PR TITLE
Folder names remain closer to their original name. Fixes #1258

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -486,8 +486,15 @@ public class Utils {
         return text;
     }
 
+    /**
+     * Removes any potentially unsafe characters from a string and truncates it on a maximum length of 100 characters.
+     * Characters considered safe are alpha numerical characters as well as minus, dot, comma, underscore and whitespace.
+     *
+     * @param text The potentially unsafe text
+     * @return a filesystem safe string
+     */
     public static String filesystemSafe(String text) {
-        text = text.replaceAll("[^a-zA-Z0-9.-]", "_").replaceAll("__", "_").replaceAll("_+$", "");
+        text = text.replaceAll("[^a-zA-Z0-9-.,_ ]", "");
         if (text.length() > 100) {
             text = text.substring(0, 99);
         }


### PR DESCRIPTION
# Category

This change is 
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Illegal characters are removed instead of being replaced with underscores and double underscores are preserved.
Thereby the folder names remain closer to the original and are still safe for the file system.
Reference for illegal characters: https://superuser.com/a/748264

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
