### PR TITLE
Pawoo no longer has a custom theme

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PawooRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PawooRipper.java
@@ -23,16 +23,4 @@ public class PawooRipper extends MastodonRipper {
         return "pawoo.net";
     }
 
-
-    @Override
-    // Pawoo uses a custom theme that has different navigation links
-    public Document getNextPage(Document doc) throws IOException {
-        Elements hrefs = doc.select(".pagination a[rel=\"next\"]");
-        if (hrefs.isEmpty()) {
-            throw new IOException("No more pages");
-        }
-        String nextUrl = hrefs.last().attr("href");
-        sleep(500);
-        return Http.url(nextUrl).get();
-    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1583)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Ripper was previously only downloading one page. Now it downloads all pages.


# Testing

Downloaded images from from an an individuals profile on pawoo.

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
