### PR TITLE
Fix early termination bug in cookiesForURL

### DIFF
--- a/src/main/java/com/rarchives/ripme/utils/Http.java
+++ b/src/main/java/com/rarchives/ripme/utils/Http.java
@@ -81,8 +81,9 @@ public class Http {
             while (parts.length > 1) {
                 String domain = String.join(".", parts);
                 // Try to get cookies for this host from config
+                logger.info("Trying to load cookies from config for " + domain);
                 cookieStr = Utils.getConfigString("cookies." + domain, "");
-                if (cookieStr.equals("")) {
+                if (!cookieStr.equals("")) {
                     cookieDomain = domain; 
                     // we found something, start parsing
                     break;


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

The condition for the while loop was causing the config cookie search to break after only checking the full domain, instead of trying higher-level domains. For example www.imagefap.com would be tried but not imagefap.com.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
