### PR TITLE
Added option to download entire manga from mangadex

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MangadexRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MangadexRipper.java
@@ -1,24 +1,28 @@
 package com.rarchives.ripme.ripper.rippers;
 
 import com.rarchives.ripme.ripper.AbstractJSONRipper;
+import com.rarchives.ripme.ui.History;
+import com.rarchives.ripme.ui.RipStatusMessage;
 import com.rarchives.ripme.utils.Http;
 import com.rarchives.ripme.utils.Utils;
+import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.jsoup.Connection;
 import org.jsoup.nodes.Document;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class MangadexRipper extends AbstractJSONRipper {
     private String chapterApiEndPoint = "https://mangadex.org/api/chapter/";
-
+    private String mangaApiEndPoint = "https://mangadex.org/api/manga/";
+    private boolean isSingleChapter;
     private String getImageUrl(String chapterHash, String imageName, String server) {
         return server + chapterHash + "/" + imageName;
     }
@@ -44,41 +48,102 @@ public class MangadexRipper extends AbstractJSONRipper {
     @Override
     public String getGID(URL url) throws MalformedURLException {
         String capID = getChapterID(url.toExternalForm());
+        String mangaID = getMangaID(url.toExternalForm());
         if (capID != null) {
+            isSingleChapter=true;
             return capID;
         }
+        else
+            if(mangaID!=null){
+                isSingleChapter=false;
+                return mangaID;
+            }
         throw new MalformedURLException("Unable to get chapter ID from" + url);
     }
 
     private String getChapterID(String url) {
-        Pattern p = Pattern.compile("https://mangadex.org/chapter/([\\d]+)/?");
+        Pattern p = Pattern.compile("https://mangadex.org/chapter/([\\d]+)/([\\d+]?)");
         Matcher m = p.matcher(url);
         if (m.matches()) {
             return m.group(1);
         }
         return null;
     }
+    private String getMangaID(String url){
+        Pattern p = Pattern.compile("https://mangadex.org/title/([\\d]+)/(.+)");
+        Matcher m = p.matcher(url);
+        if(m.matches()){
+            return m.group(1);
+        }
+        return null;
+    }
+
 
     @Override
     public JSONObject getFirstPage() throws IOException {
         // Get the chapter ID
         String chapterID = getChapterID(url.toExternalForm());
-        return Http.url(new URL(chapterApiEndPoint + chapterID)).getJSON();
+        String mangaID = getMangaID(url.toExternalForm());
+        if(mangaID!=null){
+            return Http.url(new URL(mangaApiEndPoint+mangaID)).getJSON();
+        }
+        else
+            return Http.url(new URL(chapterApiEndPoint + chapterID)).getJSON();
     }
 
     @Override
     protected List<String> getURLsFromJSON(JSONObject json) {
+        if(isSingleChapter){
+            List<String> assetURLs = new ArrayList<>();
+            JSONArray currentObject;
+            String chapterHash;
+            // Server is the cdn hosting the images.
+            String server;
+            chapterHash = json.getString("hash");
+            server = json.getString("server");
+            for (int i = 0; i < json.getJSONArray("page_array").length(); i++) {
+                currentObject = json.getJSONArray("page_array");
+
+                assetURLs.add(getImageUrl(chapterHash, currentObject.getString(i), server));
+            }
+            return assetURLs;
+        }
+        JSONObject chaptersJSON = (JSONObject) json.get("chapter");
+        JSONObject temp;
+        Iterator<String> keys = chaptersJSON.keys();
+        HashMap<Double,String> chapterIDs = new HashMap<>();
+        while (keys.hasNext()) {
+            String keyValue = (String) keys.next();
+            temp=(JSONObject)chaptersJSON.get(keyValue);
+            if(temp.getString("lang_name").equals("English")) {
+                chapterIDs.put(temp.getDouble("chapter"),keyValue);
+            }
+
+        }
+
         List<String> assetURLs = new ArrayList<>();
         JSONArray currentObject;
-
-        String chapterHash = json.getString("hash");
+        String chapterHash;
         // Server is the cdn hosting the images.
-        String server = json.getString("server");
+        String server;
+        JSONObject chapterJSON=null;
+        TreeMap<Double,String> treeMap = new TreeMap<>(chapterIDs);
+        Iterator it = treeMap.keySet().iterator();
+        while(it.hasNext()) {
+            double key =(double) it.next();
+            try {
+                chapterJSON = Http.url(new URL(chapterApiEndPoint + treeMap.get(key))).getJSON();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            sendUpdate(RipStatusMessage.STATUS.LOADING_RESOURCE,"chapter "+key);
+            chapterHash = chapterJSON.getString("hash");
+            server = chapterJSON.getString("server");
+            for (int i = 0; i < chapterJSON.getJSONArray("page_array").length(); i++) {
+                currentObject = chapterJSON.getJSONArray("page_array");
 
-        for (int i = 0; i < json.getJSONArray("page_array").length(); i++) {
-            currentObject = json.getJSONArray("page_array");
-
-            assetURLs.add(getImageUrl(chapterHash, currentObject.getString(i), server));
+                assetURLs.add(getImageUrl(chapterHash, currentObject.getString(i), server));
+            }
         }
 
         return assetURLs;
@@ -90,5 +155,6 @@ public class MangadexRipper extends AbstractJSONRipper {
         sleep(1000);
         addURLToDownload(url, getPrefix(index));
     }
+
 
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MangadexRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/MangadexRipperTest.java
@@ -11,5 +11,12 @@ public class MangadexRipperTest extends RippersTest{
         MangadexRipper ripper = new MangadexRipper(new URL("https://mangadex.org/chapter/467904/"));
         testRipper(ripper);
     }
+    public class testMangaRip extends RippersTest{
+
+        public void testRip() throws IOException {
+            MangadexRipper ripper = new MangadexRipper(new URL("https://mangadex.org/title/44625/this-croc-will-die-in-100-days"));
+            testRipper(ripper);
+        }
+    }
 
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


# Description

Added functionality to rip entire manga instead of just single chapter.Only supports english language.
All chapters are saved in one folder.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
