### PR TITLE
Encoding string URL

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -902,6 +902,11 @@ public final class MainWindow implements Runnable, RipStatusHandler {
             String chosenPath = null;
             try {
                 chosenPath = chosenFile.getCanonicalPath();
+
+                File theDir = new File(chosenPath);
+                if (!theDir.exists()){
+                    theDir.mkdirs();
+                }
             } catch (Exception e) {
                 LOGGER.error("Error while getting selected path: ", e);
                 return;

--- a/src/main/java/com/rarchives/ripme/utils/Http.java
+++ b/src/main/java/com/rarchives/ripme/utils/Http.java
@@ -20,6 +20,9 @@ import org.jsoup.nodes.Document;
 
 import com.rarchives.ripme.ripper.AbstractRipper;
 
+import java.nio.charset.StandardCharsets;
+import java.net.URLEncoder;
+
 /**
  * Wrapper around the Jsoup connection methods.
  *
@@ -45,9 +48,11 @@ public class Http {
     }
 
     public static Http url(String url) {
-        return new Http(url);
+        String encodedURL =  URLEncoder.encode(url, StandardCharsets.UTF_8);
+        return new Http(encodedURL);
     }
     public static Http url(URL url) {
+        // TODO: Endcode URL
         return new Http(url);
     }
 


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [X ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Please add details about your change here.
Adding string encoding of URLS in http util

# Testing

Required verification:
* [ X] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ X] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ X] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
