### PR TITLE
feat(instagram): replace JS parsing with hardcoded query hashes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,6 @@
       <version>1.8.1</version>
     </dependency>
     <dependency>
-      <groupId>org.graalvm.js</groupId>
-      <artifactId>js</artifactId>
-      <version>20.1.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20190722</version>


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ x] a bug fix (Fix #...)
* [ ] a new Ripper
* [x ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Replaced parsing the JS with hardcoded query hashes. Had a look around and more tools seem to be working like this.

I did notice getting errors when being redirected multiple times, hence the changes to the regexes, but please review this thoroughly. There seem the be a lot of people that want this working properly but I don't really have time to check everything myself.


# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ ] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
