### PR TITLE
Fixed issue which caused ripme to fail to rip more than 1 url when ru…

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1279,11 +1279,15 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 ripper.setObserver(this);
                 Thread t = new Thread(ripper);
                 if (configShowPopup.isSelected() && (!mainFrame.isVisible() || !mainFrame.isActive())) {
-                    mainFrame.toFront();
-                    mainFrame.setAlwaysOnTop(true);
-                    trayIcon.displayMessage(mainFrame.getTitle(), "Started ripping " + ripper.getURL().toExternalForm(),
-                            MessageType.INFO);
-                    mainFrame.setAlwaysOnTop(false);
+                    try {
+                        mainFrame.toFront();
+                        mainFrame.setAlwaysOnTop(true);
+                        trayIcon.displayMessage(mainFrame.getTitle(), "Started ripping " + ripper.getURL().toExternalForm(),
+                                MessageType.INFO);
+                        mainFrame.setAlwaysOnTop(false);
+                    } catch (NullPointerException e) {
+                        LOGGER.error("Could not send popup, are tray icons supported?");
+                    }
                 }
                 return t;
             } catch (Exception e) {


### PR DESCRIPTION
…nning in the background

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1804)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Ripme no longer end current rip if it is unable to send a message via the tray icon 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
