### PR TITLE
NullPointerException handled for invalid save path. #1785

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
+++ b/src/main/java/com/rarchives/ripme/ripper/DownloadFileThread.java
@@ -282,7 +282,14 @@ class DownloadFileThread extends Thread {
                 logger.debug("IOException", e);
                 logger.error("[!] " + Utils.getLocalizedString("exception.while.downloading.file") + ": " + url + " - "
                         + e.getMessage());
-            } finally {
+            } catch (NullPointerException npe){
+
+                logger.error("[!] " + Utils.getLocalizedString("failed.to.download") + " for URL " + url);
+                observer.downloadErrored(url,
+                        Utils.getLocalizedString("failed.to.download") + " " + url.toExternalForm());
+                return;
+
+            }finally {
                 // Close any open streams
                 try {
                     if (bis != null) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1785 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

A code block was added where the NullPointerException is controlled, since having an album and multiple multimedia files, the videos (more specifically the mp4 formats) cannot be downloaded. Therefore, it alerts the user when the file cannot be downloaded and in this case it does not try to download it again.

# Testing

Required verification:
* [x ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [ x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
