### PR TITLE
Fixed #1795 and added new test

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/GfycatRipper.java
@@ -57,7 +57,7 @@ public class GfycatRipper extends AbstractHTMLRipper {
     }
 
     public boolean isProfile() {
-        Pattern p = Pattern.compile("^https?://[wm.]*gfycat\\.com/@([a-zA-Z0-9]+).*$");
+        Pattern p = Pattern.compile("^https?://[wm.]*gfycat\\.com/@([a-zA-Z0-9\\.\\-\\_]+).*$");
         Matcher m = p.matcher(url.toExternalForm());
         return m.matches();
     }
@@ -79,11 +79,11 @@ public class GfycatRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("^https?://(thumbs\\.|[wm\\.]*)gfycat\\.com/@?([a-zA-Z0-9]+).*$");
+        Pattern p = Pattern.compile("^https?://(?:thumbs\\.|[wm\\.]*)gfycat\\.com/@?([a-zA-Z0-9\\.\\-\\_]+).*$");
         Matcher m = p.matcher(url.toExternalForm());
         
         if (m.matches())
-            return m.group(2);
+            return m.group(1);
         
         throw new MalformedURLException(
                 "Expected gfycat.com format: "

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/GfycatRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/GfycatRipperTest.java
@@ -44,4 +44,13 @@ public class GfycatRipperTest extends RippersTest {
         GfycatRipper ripper = new GfycatRipper(new URL("https://gfycat.com/amp/TemptingExcellentIchthyosaurs"));
         testRipper(ripper);
     }
+
+    /**
+     * Rips a Gfycat profile with special characters in username
+     * @throws IOException
+     */
+    public void testGfycatSpecialChar() throws IOException {
+        GfycatRipper ripper = new GfycatRipper(new URL("https://gfycat.com/@rsss.kr"));
+        testRipper(ripper);
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1795 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Gfycat allows special chars in the username (dot, hyphen and underscore) but only letters and numbers were included in the username regex used to call the API and get the download links.
Fixed the issue, "cleaned" the regex and added a new test.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
