### PR TITLE
Added support for Cyberdrop.me

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CyberdropRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CyberdropRipper.java
@@ -1,0 +1,60 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+public class CyberdropRipper extends AbstractHTMLRipper {
+
+    public CyberdropRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "cyberdrop";
+    }
+
+    @Override
+    protected Document getFirstPage() throws IOException {
+        return Http.url(url).get();
+    }
+
+    @Override
+    public String getDomain() {
+        return "cyberdrop.me";
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException {
+        Pattern p = Pattern.compile("^https?://cyberdrop\\.me/a/([a-zA-Z0-9]+).*?$");
+        Matcher m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+        throw new MalformedURLException("Expected cyberdrop.me URL format: " +
+                "https://cyberdrop.me/a/xxxxxxxx - got " + url + "instead");
+    }
+
+    @Override
+    public void downloadURL(URL url, int index) {
+        addURLToDownload(url, getPrefix(index));
+    }
+
+    @Override
+    protected List<String> getURLsFromPage(Document page) {
+        ArrayList<String> urls = new ArrayList<>();
+        for (Element element: page.getElementsByClass("image")) {
+                urls.add(element.attr("href"));
+        }
+        return urls;
+    }
+}

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CyberdropRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CyberdropRipperTest.java
@@ -1,0 +1,51 @@
+package com.rarchives.ripme.tst.ripper.rippers;
+
+import com.rarchives.ripme.ripper.rippers.CyberdropRipper;
+import com.rarchives.ripme.utils.Http;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CyberdropRipperTest extends RippersTest {
+    @Test
+    public void testScrolllerGID() throws IOException {
+        Map<URL, String> testURLs = new HashMap<>();
+
+        testURLs.put(new URL("https://cyberdrop.me/a/n4umdBjw"), "n4umdBjw");
+        testURLs.put(new URL("https://cyberdrop.me/a/iLtp4BjW"), "iLtp4BjW");
+        for (URL url : testURLs.keySet()) {
+            CyberdropRipper ripper = new CyberdropRipper(url);
+            ripper.setup();
+            Assertions.assertEquals(testURLs.get(url), ripper.getGID(ripper.getURL()));
+            deleteDir(ripper.getWorkingDir());
+        }
+    }
+
+    @Test
+    public void testCyberdropNumberOfFiles() throws IOException {
+        List<URL> testURLs = new ArrayList<URL>();
+
+        testURLs.add(new URL("https://cyberdrop.me/a/n4umdBjw"));
+        testURLs.add(new URL("https://cyberdrop.me/a/iLtp4BjW"));
+        for (URL url : testURLs) {
+            Assertions.assertTrue(willDownloadAllFiles(url));
+        }
+    }
+
+    public boolean willDownloadAllFiles(URL url) throws IOException {
+        Document doc = Http.url(url).get();
+        long numberOfLinks = doc.getElementsByClass("image").stream().count();
+        int numberOfFiles = Integer.parseInt(doc.getElementById("totalFilesAmount").text());
+        return numberOfLinks == numberOfFiles;
+    }
+
+
+
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Adds support (and tests) for Cyberdrop.me as requested in #1746 


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
