### PR TITLE
Move -l option up to allow setting path for -r/-R

### DIFF
--- a/src/main/java/com/rarchives/ripme/App.java
+++ b/src/main/java/com/rarchives/ripme/App.java
@@ -169,6 +169,12 @@ public class App {
             Utils.setConfigBoolean("errors.skip404", true);
         }
 
+        //Destination directory
+        if (cl.hasOption('l')) {
+            // change the default rips directory
+            Utils.setConfigString("rips.directory", cl.getOptionValue('l'));
+        }
+        
         //Re-rip <i>all</i> previous albums
         if (cl.hasOption('r')) {
             // Re-rip all via command-line
@@ -243,12 +249,6 @@ public class App {
         if ((cl.hasOption('d'))&&(cl.hasOption('D'))) {
             logger.error("\nCannot specify '-d' and '-D' simultaneously");
             System.exit(-1);
-        }
-
-        //Destination directory
-        if (cl.hasOption('l')) {
-            // change the default rips directory
-            Utils.setConfigString("rips.directory", cl.getOptionValue('l'));
         }
 
         //Read URLs from File


### PR DESCRIPTION
# Category

* [x] a bug fix (Fix #1861)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature

# Description

-r and -R options were running before setting the rips directory, moving this option to before allows users to set a directory for rerips when run from CLI.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.