### PR TITLE
Fix Hentai nexus and Hentai cafe (disable test), both offline

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaicafeRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaicafeRipperTest.java
@@ -4,12 +4,14 @@ import java.io.IOException;
 import java.net.URL;
 
 import com.rarchives.ripme.ripper.rippers.HentaiCafeRipper;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class HentaicafeRipperTest extends RippersTest {
     @Test
     @Tag("flaky")
+    @Disabled("20/05/2021 This test was disabled as the site has experienced notable downtime")
     public void testHentaiCafeAlbum() throws IOException {
         HentaiCafeRipper ripper = new HentaiCafeRipper(new URL("https://hentai.cafe/kikuta-the-oni-in-the-room/"));
         testRipper(ripper);
@@ -17,6 +19,7 @@ public class HentaicafeRipperTest extends RippersTest {
     // This album has a line break (<br />) in the url. Test it to make sure ripme can handle these invalid urls
     @Test
     @Tag("flaky")
+    @Disabled("20/05/2021 This test was disabled as the site has experienced notable downtime")
     public void testAlbumWithInvalidChars() throws IOException {
         HentaiCafeRipper ripper = new HentaiCafeRipper(new URL("https://hentai.cafe/chobipero-club/"));
         testRipper(ripper);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentainexusRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentainexusRipperTest.java
@@ -8,12 +8,14 @@ import java.util.List;
 import com.rarchives.ripme.ripper.rippers.HentaiNexusRipper;
 import org.json.JSONObject;
 import org.junit.Assert;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class HentainexusRipperTest extends RippersTest {
     @Test
     @Tag("flaky")
+    @Disabled("20/05/2021 This test was disabled as the site has experienced notable downtime")
     public void testHentaiNexusJson() throws IOException {
         List<URL> testURLs = new ArrayList<>();
         testURLs.add(new URL("https://hentainexus.com/view/9202"));


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fix Hentai nexus and Hentai cafe (disable test), both offline


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
