### PR TITLE
Fix Flaky Tests

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractHTMLRipper.java
@@ -128,7 +128,7 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
                     index += 1;
                     LOGGER.debug("Found image url #" + index + ": " + imageURL);
                     downloadURL(new URL(imageURL), index);
-                    if (isStopped()) {
+                    if (isStopped() || isThisATest()) {
                         break;
                     }
                 }
@@ -139,7 +139,7 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
                 if (!textURLs.isEmpty()) {
                     LOGGER.debug("Found description link(s) from " + doc.location());
                     for (String textURL : textURLs) {
-                        if (isStopped()) {
+                        if (isStopped() || isThisATest()) {
                             break;
                         }
                         textindex += 1;
@@ -293,10 +293,10 @@ public abstract class AbstractHTMLRipper extends AbstractRipper {
      * Queues multiple URLs of single images to download from a single Album URL
      */
     public boolean addURLToDownload(URL url, File saveAs, String referrer, Map<String,String> cookies, Boolean getFileExtFromMIME) {
-            // Only download one file if this is a test.
-        if (super.isThisATest() &&
-                (itemsPending.size() > 0 || itemsCompleted.size() > 0 || itemsErrored.size() > 0)) {
+        // Only download one file if this is a test.
+        if (super.isThisATest() && (itemsCompleted.size() > 0 || itemsErrored.size() > 0)) {
             stop();
+            itemsPending.clear();
             return false;
         }
         if (!allowDuplicates()

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
@@ -141,10 +141,10 @@ public abstract class AbstractJSONRipper extends AbstractRipper {
      * Queues multiple URLs of single images to download from a single Album URL
      */
     public boolean addURLToDownload(URL url, File saveAs, String referrer, Map<String,String> cookies, Boolean getFileExtFromMIME) {
-            // Only download one file if this is a test.
-        if (super.isThisATest() &&
-                (itemsPending.size() > 0 || itemsCompleted.size() > 0 || itemsErrored.size() > 0)) {
+        // Only download one file if this is a test.
+        if (super.isThisATest() && (itemsCompleted.size() > 0 || itemsErrored.size() > 0)) {
             stop();
+            itemsPending.clear();
             return false;
         }
         if (!allowDuplicates()

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Observable;
 import java.util.Scanner;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.apache.log4j.FileAppender;
 import org.apache.log4j.Logger;
 import org.jsoup.HttpStatusException;
@@ -47,17 +49,18 @@ public abstract class AbstractRipper
     public boolean hasASAPRipping() { return false; }
     // Everytime addUrlToDownload skips a already downloaded url this increases by 1
     public int alreadyDownloadedUrls = 0;
-    private boolean shouldStop = false;
+    private final AtomicBoolean shouldStop = new AtomicBoolean(false);
     private static boolean thisIsATest = false;
 
     public void stop() {
-        shouldStop = true;
+        LOGGER.trace("stop()");
+        shouldStop.set(true);
     }
     public boolean isStopped() {
-        return shouldStop;
+        return shouldStop.get();
     }
     protected void stopCheck() throws IOException {
-        if (shouldStop) {
+        if (shouldStop.get()) {
             throw new IOException("Ripping interrupted");
         }
     }

--- a/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AlbumRipper.java
@@ -51,10 +51,10 @@ public abstract class AlbumRipper extends AbstractRipper {
      * Queues multiple URLs of single images to download from a single Album URL
      */
     public boolean addURLToDownload(URL url, File saveAs, String referrer, Map<String,String> cookies, Boolean getFileExtFromMIME) {
-            // Only download one file if this is a test.
-        if (super.isThisATest() &&
-                (itemsPending.size() > 0 || itemsCompleted.size() > 0 || itemsErrored.size() > 0)) {
+        // Only download one file if this is a test.
+        if (super.isThisATest() && (itemsCompleted.size() > 0 || itemsErrored.size() > 0)) {
             stop();
+            itemsPending.clear();
             return false;
         }
         if (!allowDuplicates()

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/RippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/RippersTest.java
@@ -32,6 +32,13 @@ public class RippersTest {
             ripper.setup();
             ripper.markAsTest();
             ripper.rip();
+            if (logger.isTraceEnabled()) {
+                logger.trace("working dir: " + ripper.getWorkingDir());
+                logger.trace("list files: " + ripper.getWorkingDir().listFiles().length);
+                for (int i = 0; i < ripper.getWorkingDir().listFiles().length; i++) {
+                    logger.trace("   " + ripper.getWorkingDir().listFiles()[i]);
+                }
+            }
             Assertions.assertTrue(ripper.getWorkingDir().listFiles().length >= 1,
                     "Failed to download a single file from " + ripper.getURL());
         } catch (IOException e) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

In addURLToDownload(), the stop() is called too soon in some cases, download might not have been started
and calling stop will leave the items in pending
so only call stop if items have been completed or on error
+ improve shouldStop as AtomicBoolean
+ trace logging in case issue happens again

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
