### PR TITLE
Fix Webtoons (disable Age Gate)

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WebtoonsRipper.java
@@ -84,7 +84,10 @@ public class WebtoonsRipper extends AbstractHTMLRipper {
     public Document getFirstPage() throws IOException {
         Response resp = Http.url(url).response();
         cookies = resp.cookies();
-        return Http.url(url).get();
+        cookies.put("needCOPPA", "false");
+        cookies.put("needCCPA", "false");
+        cookies.put("needGDPR", "false");
+        return Http.url(url).cookies(cookies).get();
     }
 
     @Override


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fix Webtoons (disable Age Gate)
Test was redirected to a "verify age" page, this is avoided by setting cookies

# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
