### PR TITLE
Fix WordpressComic

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/WordpressComicRipper.java
@@ -376,7 +376,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
         // freeadultcomix gets it own if because it needs to add http://freeadultcomix.com to the start of each link
         // TODO review the above comment which no longer applies -- see if there's a refactoring we should do here.
         if (url.toExternalForm().contains("freeadultcomix.com")) {
-            for (Element elem : doc.select("div.single-post > p > img.aligncenter")) {
+            for (Element elem : doc.select("div.post-texto > p > noscript > img[class*=aligncenter]")) {
                 result.add(elem.attr("src"));
             }
         } else if (url.toExternalForm().contains("comics-xxx.com")) {
@@ -384,7 +384,7 @@ public class WordpressComicRipper extends AbstractHTMLRipper {
                 result.add(elem.attr("src"));
             }
         } else if (url.toExternalForm().contains("shipinbottle.pepsaga.com")) {
-            for (Element elem : doc.select("div#comic > div.comicpane > a > img")) {
+            for (Element elem : doc.select("div#comic > a > img")) {
                 result.add(elem.attr("src"));
             }
         } else if (url.toExternalForm().contains("8muses.download")) {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fix WordpressComic
Page layout changes to:
freeadultcomix.com
shipinbottle.pepsaga.com


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
