### PR TITLE
Fix slow tests

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/FuraffinityRipper.java
@@ -125,6 +125,9 @@ public class FuraffinityRipper extends AbstractHTMLRipper {
                     urls.add(urlToAdd);
                 }
             }
+            if (isStopped() || isThisATest()) {
+                break;
+            }
         }
         return urls;
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XhamsterRipper.java
@@ -84,6 +84,9 @@ public class XhamsterRipper extends AbstractHTMLRipper {
         LOGGER.info("getting albums");
         for (Element elem : doc.select("div.item-container > a.item")) {
             urlsToAddToQueue.add(elem.attr("href"));
+            if (isStopped() || isThisATest()) {
+                break;
+            }
         }
         LOGGER.info(doc.html());
         return urlsToAddToQueue;
@@ -168,6 +171,9 @@ public class XhamsterRipper extends AbstractHTMLRipper {
                   downloadFile(image);
               } catch (IOException e) {
                   LOGGER.error("Was unable to load page " + pageWithImageUrl);
+              }
+              if (isStopped() || isThisATest()) {
+                  break;
               }
           }
         } else {


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [x] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Added fast stop to Furaffinity and Xhamster (break in for-loops)


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
