### PR TITLE
Added extra condition to include reddit gallery gifs urls 

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -318,7 +318,12 @@ public class RedditRipper extends AlbumRipper {
                 prefix += String.format("%02d-", i + 1);
             }
             try {
-                URL mediaURL = new URL(media.getJSONObject("s").getString("u").replaceAll("&amp;", "&"));
+                URL mediaURL;
+            	if (!media.getJSONObject("s").isNull("gif")) {
+            		mediaURL = new URL(media.getJSONObject("s").getString("gif").replaceAll("&amp;", "&"));
+            	} else {
+            		mediaURL = new URL(media.getJSONObject("s").getString("u").replaceAll("&amp;", "&"));
+            	}
                 addURLToDownload(mediaURL, prefix, subdirectory);
             } catch (MalformedURLException | JSONException e) {
                 LOGGER.error("[!] Unable to parse gallery JSON:\ngallery_data:\n" + data +"\nmedia_metadata:\n" + metadata);


### PR DESCRIPTION
 Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


#  Description

Edited RedditRipper#handleGallery() method to include gif urls.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
