### PR TITLE
Power Users Can Use Redis to Filter Already Downloaded URLs, Use HashSet for URL Matching From File

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>it.ozimov</groupId>
+      <artifactId>embedded-redis</artifactId>
+      <version>0.7.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <!-- jsoup HTML parser library @ http://jsoup.org/ -->
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
       <artifactId>Java-WebSocket</artifactId>
       <version>1.5.1</version>
     </dependency>
+    <dependency>
+      <groupId>redis.clients</groupId>
+      <artifactId>jedis</artifactId>
+      <version>3.6.0</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -74,6 +74,7 @@ public abstract class AbstractRipper
             File file = new File(URLHistoryFile);
             if (file.exists()) {
                 try (Scanner scanner = new Scanner(file)) {
+                    LOGGER.debug("Building url hash set");
                     while (scanner.hasNextLine()) {
                         final String lineFromFile = scanner.nextLine();
                         urlHistoryHashSet.add(lineFromFile.trim());
@@ -200,7 +201,9 @@ public abstract class AbstractRipper
      */
     private boolean fileContainsURL(String url) {
         url = normalizeUrl(url.trim());
-        return urlHistoryHashSet.contains(url);
+        Boolean foundUrl = urlHistoryHashSet.contains(url);
+        LOGGER.debug("Found url in hash set: " + foundUrl.toString());
+        return foundUrl;
     }
 
     /**

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -83,8 +83,10 @@ public abstract class AbstractRipper
         }
 
         if (Utils.getConfigString("url_history.redis_cache.host", "") != "") {
-            LOGGER.info("Setting in Redis: " + downloadedURL.trim());
-            jedis.set(downloadedURL.trim(), "true");
+            String keyPrefix = Utils.getConfigString("url_history.redis_cache.key_prefix", "");
+            String key = keyPrefix + downloadedURL.trim();
+            LOGGER.info("Setting in Redis: " + key);
+            jedis.set(key, "true");
         }
 
         downloadedURL = normalizeUrl(downloadedURL);
@@ -162,12 +164,14 @@ public abstract class AbstractRipper
      *      Returns false if not yet downloaded.
      */
     private boolean reddisContainsURL(String url) {
-        String jedisResult = jedis.get(url.trim());
+        String keyPrefix = Utils.getConfigString("url_history.redis_cache.key_prefix", "");
+        String key = keyPrefix + url.trim();
+        String jedisResult = jedis.get(key);
         if (jedisResult == null) {
-            LOGGER.info(url.trim() + " not found in redis");
+            LOGGER.info(key + " not found in redis");
             return false;
         } else {
-            LOGGER.info(url.trim() + " was found in redis");
+            LOGGER.info(key + " was found in redis");
             return true;
         }
     }

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractRipper.java
@@ -43,7 +43,7 @@ public abstract class AbstractRipper
 
     private boolean completed = true;
     private Jedis jedis;
-    private HashSet<String> urlHistoryHashSet = new HashSet();
+    protected HashSet<String> urlHistoryHashSet = new HashSet();
     public abstract void rip() throws IOException;
     public abstract String getHost();
     public abstract String getGID(URL url) throws MalformedURLException;

--- a/src/test/java/com/rarchives/ripme/tst/AbstractRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/AbstractRipperTest.java
@@ -1,32 +1,115 @@
 package com.rarchives.ripme.tst;
 
 import com.rarchives.ripme.ripper.AbstractRipper;
+import com.rarchives.ripme.tst.TestRipper;
 import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.net.URL;
-
+import com.rarchives.ripme.utils.Utils;
+import redis.clients.jedis.Jedis; 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import redis.embedded.RedisServer;
 
 public class AbstractRipperTest {
 
    @Test
-    public void testGetFileName() throws IOException {
-       String fileName = AbstractRipper.getFileName(new URL("http://www.tsumino.com/Image/Object?name=U1EieteEGwm6N1dGszqCpA%3D%3D"), "test", "test");
-       assertEquals("test.test", fileName);
+   public void testGetFileName() throws IOException {
+      String fileName = AbstractRipper.getFileName(new URL("http://www.tsumino.com/Image/Object?name=U1EieteEGwm6N1dGszqCpA%3D%3D"), "test", "test");
+      assertEquals("test.test", fileName);
 
-       fileName = AbstractRipper.getFileName(new URL("http://www.tsumino.com/Image/Object?name=U1EieteEGwm6N1dGszqCpA%3D%3D"), "test", null);
-       assertEquals("test", fileName);
+      fileName = AbstractRipper.getFileName(new URL("http://www.tsumino.com/Image/Object?name=U1EieteEGwm6N1dGszqCpA%3D%3D"), "test", null);
+      assertEquals("test", fileName);
 
-       fileName = AbstractRipper.getFileName(new URL("http://www.tsumino.com/Image/Object?name=U1EieteEGwm6N1dGszqCpA%3D%3D"), null, null);
-       assertEquals("Object", fileName);
+      fileName = AbstractRipper.getFileName(new URL("http://www.tsumino.com/Image/Object?name=U1EieteEGwm6N1dGszqCpA%3D%3D"), null, null);
+      assertEquals("Object", fileName);
 
-       fileName = AbstractRipper.getFileName(new URL("http://www.test.com/file.png"), null, null);
-       assertEquals("file.png", fileName);
+      fileName = AbstractRipper.getFileName(new URL("http://www.test.com/file.png"), null, null);
+      assertEquals("file.png", fileName);
 
-       fileName = AbstractRipper.getFileName(new URL("http://www.test.com/file."), null, null);
-       assertEquals("file.", fileName);
-    }
+      fileName = AbstractRipper.getFileName(new URL("http://www.test.com/file."), null, null);
+      assertEquals("file.", fileName);
+   }
+
+   @Test
+   public void testHasDownloadedURL() throws IOException {
+      int testRedisPort = 6379;
+      RedisServer redisServer = new RedisServer(testRedisPort);
+      try {
+
+         URL ripURL = new URL("https://example.com");
+         URL fileURL = new URL("https://example.com/picture.jpg");
+         TestRipper ripper = new TestRipper(ripURL);
+         redisServer.start();
+         Jedis jedis = new Jedis("localhost", testRedisPort);
+         // Test with empty redis
+         Utils.setConfigString("url_history.redis_cache.host", "localhost");
+         Utils.setConfigString("url_history.redis_cache.port", Integer.toString(testRedisPort));
+         // Make the ripper connect to redis
+         ripper.callInitializeHistoryStore();
+         boolean hasAlreadyDownloaded = ripper.callHasDownloadedURL(fileURL.toString());
+         assertEquals(false, hasAlreadyDownloaded);
+         
+         // Test with URL loaded into redis
+         String keyPrefix = "somePrefix";
+         Utils.setConfigString("url_history.redis_cache.key_prefix", keyPrefix);
+         String key = keyPrefix + fileURL.toString().trim();
+         jedis.set(key, "true");
+         hasAlreadyDownloaded = ripper.callHasDownloadedURL(fileURL.toString());
+         assertEquals(true, hasAlreadyDownloaded);
+
+         redisServer.stop();
+
+         
+         // Re-initialize and test using hash set instead
+         Utils.setConfigString("url_history.redis_cache.host", "");
+         ripper.callInitializeHistoryStore();
+         hasAlreadyDownloaded = ripper.callHasDownloadedURL(fileURL.toString());
+         assertEquals(false, hasAlreadyDownloaded);
+
+         // Test using hashset with URL added
+         ripper.insertToURLHashSet(fileURL.toString());
+         hasAlreadyDownloaded = ripper.callHasDownloadedURL(fileURL.toString());
+         assertEquals(true, hasAlreadyDownloaded);
+      } catch (Exception exception) {
+         // Ensure that the redis server is destroyed, otherwise test re-runs will fail because it can't start a new server
+         // on the same port
+         redisServer.stop();
+         throw exception;
+      }
+   }
+
+   @Test
+   public void testWriteDownloadedURL() throws IOException {
+      int testRedisPort = 6379;
+      RedisServer redisServer = new RedisServer(testRedisPort);
+      try {
+         URL ripURL = new URL("https://example.com");
+         URL fileURL = new URL("https://example.com/picture.jpg");
+         TestRipper ripper = new TestRipper(ripURL);
+         redisServer.start();
+         Jedis jedis = new Jedis("localhost", testRedisPort);
+         String keyPrefix = "somePrefix";
+         String key = keyPrefix + fileURL.toString().trim();
+         Utils.setConfigString("url_history.redis_cache.key_prefix", keyPrefix);
+         Utils.setConfigString("url_history.redis_cache.host", "localhost");
+         Utils.setConfigString("url_history.redis_cache.port", Integer.toString(testRedisPort));
+         Boolean urlInHashSet = ripper.checkURLInHashSet(fileURL.toString());
+         String jedisResult = jedis.get(key);
+         assertEquals(null, jedisResult);
+         assertEquals(false, urlInHashSet);
+         ripper.callInitializeHistoryStore();
+         ripper.callWriteDownloadedURL(fileURL.toString());
+         urlInHashSet = ripper.checkURLInHashSet(fileURL.toString());
+         assertEquals(true, urlInHashSet);
+         jedisResult = jedis.get(key);
+         assertEquals("true", jedisResult);
+         redisServer.stop();
+      } catch (Exception exception) {
+         // Ensure that the redis server is destroyed, otherwise test re-runs will fail because it can't start a new server
+         // on the same port
+         redisServer.stop();
+         throw exception;
+      }
+   }
 
 }

--- a/src/test/java/com/rarchives/ripme/tst/TestRipper.java
+++ b/src/test/java/com/rarchives/ripme/tst/TestRipper.java
@@ -1,0 +1,100 @@
+package com.rarchives.ripme.tst;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Map;
+import java.io.IOException;
+
+import com.rarchives.ripme.ripper.AbstractRipper;
+
+public class TestRipper extends AbstractRipper {
+
+  public TestRipper(URL url) throws IOException {
+    super(url);
+  }
+
+  @Override
+  public String getStatusText() {
+    return "SomeStatusText";
+  }
+
+  @Override
+  public int getCompletionPercentage() {
+    return 50;
+  }
+
+  @Override
+  public void setWorkingDir(URL url) {
+    return;
+  }
+
+  @Override
+  public void downloadExists(URL url, File file){
+    return;
+  }
+  
+  @Override
+  public void downloadErrored(URL url, String string) {
+    return;
+  }
+
+  @Override
+  public void downloadCompleted(URL url, File file) {
+    return;
+  }
+
+  @Override
+  public boolean addURLToDownload(URL url, File saveAs) {
+    return false;
+  }
+
+  @Override
+  public boolean addURLToDownload(URL url, File saveAs, String referrer, Map<String, String> cookies, Boolean getFileExtFromMIME) {
+    return false;
+  }
+
+  @Override
+  public String getGID(URL url) {
+    return "SomeGID";
+  }
+
+  @Override
+  public String getHost() {
+    return "SomeHost";
+  }
+
+  @Override
+  public void rip() {
+    return;
+  }
+
+  @Override
+  public URL sanitizeURL(URL url) {
+    return url;
+  }
+
+  @Override
+  public boolean canRip(URL url) {
+    return true;
+  }
+
+  public boolean callHasDownloadedURL(String url) {
+    return this.hasDownloadedURL(url);
+  }
+
+  public void callInitializeHistoryStore() {
+    this.initializeHistoryStore();
+  }
+
+  public void insertToURLHashSet(String url) {
+    this.urlHistoryHashSet.add(url.trim());
+  }
+
+  public boolean checkURLInHashSet(String url) {
+    return this.urlHistoryHashSet.contains(url);
+  }
+
+  public void callWriteDownloadedURL(String url) throws IOException {
+    this.writeDownloadedURL(url);
+  }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature


# Description

This feature adds support to use Redis as the mechanism for skipping already downloaded URLs. If you use RipMe over a longer period of time, to download many, many galleries and albums, the url_history.txt file gets quite large. Doing an O(n) scan through the entire list for every URL in a job becomes VERY expensive. My own url_history.txt file is approaching 3 million lines and 130 MB. Using Redis speeds up the ripping process considerably AND allows power users the ability to coordinate jobs running across multiple machines on a network.

Users can optionally add the following lines to the rip.properties file:
```
url_history.redis_cache.host = 192.168.0.123  #IP address or domain name for the redis host 
url_history.redis_cache.port = 6379 #redis port (optional, rip me defaults to 6379)
url_history.redis_cache.key_prefix = RipMeURL:  #a prefix to give the keys added to redis (optional, will default to an empty string)
````

If users do not add this configuration, the URL matching algorithm now uses a HashSet. This is memory intensive, but performs faster than the sequential scan.


Note: RipMe will continue to append new lines to the url_history.txt file since this operation does not seem to slow down the job (...at least at the scales that I have encountered)

Note 2: The easiest way to run redis locally is to use docker (Something like `docker run --name my-redis -d -p 6379:6379 redis`). Alternatively you could download and install redis for your OS.

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [ ] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
