### PR TITLE
Change behavior of closing dialog with hitting X

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -817,7 +817,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 checkChoise.add(noButton);
                 JFrame.setDefaultLookAndFeelDecorated(true);
                 JFrame frame = new JFrame("Are you sure?");
-                frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+                frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
                 frame.add(checkChoise);
                 frame.setSize(405, 70);
                 frame.setVisible(true);


### PR DESCRIPTION
https://github.com/RipMeApp/ripme/issues/1975

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #1975)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

I simply changed the behavior to close the dialog instead of terminating the application itself.

Technically, `mvn test` failed.
> Boot Manifest-JAR contains absolute paths in classpath 'X:\WORKING\DIRECTORY\target\test-classes'
> Hint: <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>

But it doesn't seem relevant to my changes and did fail with the HEAD version, too.

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
