### PR TITLE
fix(sec): upgrade commons-io:commons-io to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>1.3.2</version>
+      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in commons-io:commons-io 1.3.2
- [CVE-2021-29425](https://www.oscs1024.com/hd/CVE-2021-29425)


### What did I do？
Upgrade commons-io:commons-io from 1.3.2 to 2.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS