### PR TITLE
Fix usage of deprecated URL constructors, which found a couple of issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ the following combinations of tags:
 - testSlow runs tests with tag "slow".
 - tests can be run by test class, or single test. Use "testAll" so it does
   not matter if a test is tagged or not.
+- tests can give the full stack of an assertion, exception, or error if you pass `--info` to the command
 
 ```bash
 ./gradlew test
@@ -129,6 +130,7 @@ the following combinations of tags:
 ./gradlew testSlow
 ./gradlew testAll --tests XhamsterRipperTest
 ./gradlew testAll --tests XhamsterRipperTest.testXhamster2Album
+./gradlew testAll --tests ChanRipperTest --info
 ```
 
 Please note that some tests may fail as sites change and our rippers

--- a/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/AbstractJSONRipper.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -94,7 +95,7 @@ public abstract class AbstractJSONRipper extends AbstractRipper {
                 
                 index += 1;
                 LOGGER.debug("Found image url #" + index+ ": " + imageURL);
-                downloadURL(new URL(imageURL), index);
+                downloadURL(new URI(imageURL).toURL(), index);
             }
 
             if (isStopped() || isThisATest()) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -256,7 +256,7 @@ public class ChanRipper extends AbstractHTMLRipper {
                 URL originalURL;
                 try {
                     originalURL = new URI(href).toURL();
-                } catch (MalformedURLException e) {
+                } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
                     continue;
                 }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -6,6 +6,7 @@ import com.rarchives.ripme.utils.Utils;
 import com.rarchives.ripme.utils.RipUtils;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -208,7 +209,7 @@ public class ChanRipper extends AbstractHTMLRipper {
         return false;
     }
     @Override
-    public List<String> getURLsFromPage(Document page) {
+    public List<String> getURLsFromPage(Document page) throws URISyntaxException {
         List<String> imageURLs = new ArrayList<>();
         Pattern p; Matcher m;
         for (Element link : page.select("a")) {
@@ -254,7 +255,7 @@ public class ChanRipper extends AbstractHTMLRipper {
                 //Copied code from RedditRipper, getFilesFromURL should also implement stuff like flickr albums
                 URL originalURL;
                 try {
-                    originalURL = new URL(href);
+                    originalURL = new URI(href).toURL();
                 } catch (MalformedURLException e) {
                     continue;
                 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/LusciousRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/LusciousRipper.java
@@ -10,6 +10,8 @@ import org.jsoup.nodes.Document;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -27,10 +29,10 @@ public class LusciousRipper extends AbstractHTMLRipper {
     }
 
     @Override
-    public URL sanitizeURL(URL url) throws MalformedURLException {
+    public URL sanitizeURL(URL url) throws MalformedURLException, URISyntaxException{
         String URLToReturn = url.toExternalForm();
         URLToReturn = URLToReturn.replaceAll("https?://(?:www\\.)?luscious\\.", "https://old.luscious.");
-        URL san_url = new URL(URLToReturn);
+        URL san_url = new URI(URLToReturn).toURL();
         LOGGER.info("sanitized URL is " + san_url.toExternalForm());
         return san_url;
     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NudeGalsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NudeGalsRipper.java
@@ -56,6 +56,7 @@ public class NudeGalsRipper extends AbstractHTMLRipper {
         for (Element thumb : thumbs) {
             String link = thumb.attr("src").replaceAll("thumbs/th_", "");
             String imgSrc = "http://nude-gals.com/" + link;
+            imgSrc = imgSrc.replaceAll(" ", "%20");
             imageURLs.add(imgSrc);
         }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XvideosRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XvideosRipper.java
@@ -82,7 +82,7 @@ public class XvideosRipper extends AbstractSingleFileRipper {
                     String[] lines = e.html().split("\n");
                     for (String line : lines) {
                         if (line.contains("html5player.setVideoUrlHigh")) {
-                            String videoURL = line.replaceAll("\t", "").replaceAll("html5player.setVideoUrlHigh\\(", "").replaceAll("\'", "").replaceAll("\\);", "");
+                            String videoURL = line.strip().replaceAll("\t", "").replaceAll("html5player.setVideoUrlHigh\\(", "").replaceAll("\'", "").replaceAll("\\);", "");
                             results.add(videoURL);
                         }
                     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/video/MotherlessVideoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/video/MotherlessVideoRipper.java
@@ -2,6 +2,8 @@ package com.rarchives.ripme.ripper.rippers.video;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -51,7 +53,7 @@ public class MotherlessVideoRipper extends VideoRipper {
     }
 
     @Override
-    public void rip() throws IOException {
+    public void rip() throws IOException, URISyntaxException {
         LOGGER.info("    Retrieving " + this.url);
         String html = Http.url(this.url).get().toString();
         if (html.contains("__fileurl = '")) {
@@ -62,7 +64,7 @@ public class MotherlessVideoRipper extends VideoRipper {
             throw new IOException("Could not find video URL at " + url);
         }
         String vidUrl = vidUrls.get(0);
-        addURLToDownload(new URL(vidUrl), HOST + "_" + getGID(this.url));
+        addURLToDownload(new URI(vidUrl).toURL(), HOST + "_" + getGID(this.url));
         waitForThreads();
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* a bug fix (Fix #...)
* a new Ripper
* a refactoring
* [x] a style change/fix
* a new feature


# Description

Please add details about your change here.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* I've added a unit test to cover my change.
