### PR TITLE
Fix XvideosRipper: update URL pattern to match current URL scheme.

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XvideosRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XvideosRipper.java
@@ -24,7 +24,7 @@ public class XvideosRipper extends AbstractSingleFileRipper {
     private static final String HOST = "xvideos";
 
     private static final Pattern videoPattern = Pattern.compile("^https?://[wm.]*xvideos\\.com/video([0-9]+|\\.[^/]*)(.*)$");
-    private static final Pattern albumPattern = Pattern.compile("^https?://[wm.]*xvideos\\.com/profiles/([a-zA-Z0-9_-]+)/photos/(\\d+)/([a-zA-Z0-9_-]+)$");
+    private static final Pattern albumPattern = Pattern.compile("^https?://[wm.]*xvideos\\.com/(profiles|amateurs)/([a-zA-Z0-9_-]+)/photos/(\\d+)/([a-zA-Z0-9_-]+)$");
 
     public XvideosRipper(URL url) throws IOException {
         super(url);
@@ -67,7 +67,7 @@ public class XvideosRipper extends AbstractSingleFileRipper {
         p = albumPattern;
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
-            return m.group(2);
+            return m.group(3);
         }
 
         throw new MalformedURLException(
@@ -116,7 +116,7 @@ public class XvideosRipper extends AbstractSingleFileRipper {
         Pattern p = albumPattern;
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
-            return getHost() + "_" + m.group(1) + "_" + m.group(3) + "_" + m.group(2);
+            return getHost() + "_" + m.group(1) + "_" + m.group(2) + "_" + m.group(4) + "_" + m.group(3);
         }
 
         p = videoPattern;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XvideosRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XvideosRipper.java
@@ -11,15 +11,11 @@ import java.util.regex.Pattern;
 
 import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
 public class XvideosRipper extends AbstractSingleFileRipper {
-
-    private static final Logger logger = LogManager.getLogger(XvideosRipper.class);
 
     private static final String HOST = "xvideos";
 
@@ -28,7 +24,6 @@ public class XvideosRipper extends AbstractSingleFileRipper {
 
     public XvideosRipper(URL url) throws IOException {
         super(url);
-        logger.debug("Attempting to initialize XvideosRipper video from " + url);
     }
 
     @Override
@@ -43,7 +38,6 @@ public class XvideosRipper extends AbstractSingleFileRipper {
 
     @Override
     public boolean canRip(URL url) {
-        logger.debug("Checking if XvideosRipper can rip " + url);
         Pattern p = videoPattern;
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/XvideosRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/XvideosRipper.java
@@ -19,7 +19,7 @@ public class XvideosRipper extends AbstractSingleFileRipper {
 
     private static final String HOST = "xvideos";
 
-    private static final Pattern videoPattern = Pattern.compile("^https?://[wm.]*xvideos\\.com/video([0-9]+|\\.[^/]*)(.*)$");
+    private static final Pattern videoPattern = Pattern.compile("^https?://[wm.]*xvideos\\.com/video\\.([^/]*)(.*)$");
     private static final Pattern albumPattern = Pattern.compile("^https?://[wm.]*xvideos\\.com/(profiles|amateurs)/([a-zA-Z0-9_-]+)/photos/(\\d+)/([a-zA-Z0-9_-]+)$");
 
     public XvideosRipper(URL url) throws IOException {
@@ -107,16 +107,19 @@ public class XvideosRipper extends AbstractSingleFileRipper {
 
     @Override
     public String getAlbumTitle(URL url) throws MalformedURLException, URISyntaxException {
-        Pattern p = albumPattern;
-        Matcher m = p.matcher(url.toExternalForm());
-        if (m.matches()) {
-            return getHost() + "_" + m.group(1) + "_" + m.group(2) + "_" + m.group(4) + "_" + m.group(3);
-        }
+        Pattern p;
+        Matcher m;
 
         p = videoPattern;
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return getHost() + "_" + m.group(1) + "_" + m.group(2);
+        }
+
+        p = albumPattern;
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return getHost() + "_" + m.group(1) + "_" + m.group(2) + "_" + m.group(4) + "_" + m.group(3);
         }
 
         return super.getAlbumTitle(url);

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XvideosRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XvideosRipperTest.java
@@ -22,4 +22,16 @@ public class XvideosRipperTest extends RippersTest {
         XvideosRipper ripper = new XvideosRipper(new URI("https://www.xvideos.com/video.ufkmptkc4ae/big_tit_step_sis_made_me_cum_inside_her").toURL());
         testRipper(ripper);
     }
+
+    @Test
+    public void testXvideosAmateursAlbum() throws IOException, URISyntaxException {
+        XvideosRipper ripper = new XvideosRipper(new URI("https://www.xvideos.com/amateurs/nikibeee/photos/2476083/lanikki").toURL());
+        testRipper(ripper);
+    }
+
+    @Test
+    public void testXvideosProfilesAlbum() throws IOException, URISyntaxException {
+        XvideosRipper ripper = new XvideosRipper(new URI("https://www.xvideos.com/profiles/dmthate/photos/8259625/sexy").toURL());
+        testRipper(ripper);
+    }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XvideosRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/XvideosRipperTest.java
@@ -9,9 +9,17 @@ import org.junit.jupiter.api.Test;
 
 public class XvideosRipperTest extends RippersTest {
     @Test
-    public void testXhamsterAlbum1() throws IOException, URISyntaxException {
-        XvideosRipper ripper = new XvideosRipper(new URI("https://www.xvideos.com/video23515878/dee_s_pool_toys").toURL());
+    public void testXvideosVideo1() throws IOException, URISyntaxException {
+        // This format is obsolete
+        // XvideosRipper ripper = new XvideosRipper(new URI("https://www.xvideos.com/video23515878/dee_s_pool_toys").toURL());
+        // The website now redirects that video to this page
+        XvideosRipper ripper = new XvideosRipper(new URI("https://www.xvideos.com/video.hppdiepcbfe/dee_s_pool_toys").toURL());
         testRipper(ripper);
     }
 
+    @Test
+    public void testXvideosVideo2() throws IOException, URISyntaxException {
+        XvideosRipper ripper = new XvideosRipper(new URI("https://www.xvideos.com/video.ufkmptkc4ae/big_tit_step_sis_made_me_cum_inside_her").toURL());
+        testRipper(ripper);
+    }
 }


### PR DESCRIPTION
Also, extract patterns to be compiled once in static members to avoid repeating the match patterns and make the code read a little more clearly.

Improve album name for the video case.

# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* a new Ripper
* a refactoring
* a style change/fix
* a new feature


# Description

Please add details about your change here.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
  * Note: an issue of concern - I'm not clear on why the existing unit test didn't catch this issue in the first place. Maybe because it effectively did nothing and didn't fail.
