### PR TITLE
Reset Java minimum version to Java 17 (OpenJDK 17), to support Debian (Closes #2055)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,7 +18,7 @@ jobs:
         java: [23]
         include: # test old java on one os only, upload from ubuntu java-17
           - os: ubuntu-latest
-            java: 21
+            java: 17
             upload: true
 
     steps:


### PR DESCRIPTION
From the Java SE Support Roadmap (see https://www.oracle.com/java/technologies/java-se-support-roadmap.html)

Java 17 LTS is supported (from "Premiere Support" column) until "September 2026, or later", so it is reasonable to keep ensuring compatibility with Java 17.

As for Java 21 LTS, even though it has been in General Availability (GA) since September 2023, Debian only has the OpenJDK 21 package in `testing` and `unstable` -- see https://tracker.debian.org/pkg/openjdk-21