### PR TITLE
Add Nude-Gals video support

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NudeGalsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NudeGalsRipper.java
@@ -8,14 +8,20 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
-import com.rarchives.ripme.utils.Http;
 
 public class NudeGalsRipper extends AbstractHTMLRipper {
+
+    private static final Logger logger = LogManager.getLogger(NudeGalsRipper.class);
+
+    private static final Pattern ALBUM_PATTERN = Pattern.compile("^.*nude-gals\\.com/photoshoot\\.php\\?photoshoot_id=(\\d+)$");
+    private static final Pattern VIDEO_PATTERN = Pattern.compile("^.*nude-gals\\.com/video\\.php\\?video_id=(\\d+)$");
 
     public NudeGalsRipper(URL url) throws IOException {
         super(url);
@@ -36,7 +42,13 @@ public class NudeGalsRipper extends AbstractHTMLRipper {
         Pattern p;
         Matcher m;
 
-        p = Pattern.compile("^.*nude-gals\\.com/photoshoot\\.php\\?photoshoot_id=(\\d+)$");
+        p = ALBUM_PATTERN;
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            return m.group(1);
+        }
+
+        p = VIDEO_PATTERN;
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);
@@ -50,17 +62,38 @@ public class NudeGalsRipper extends AbstractHTMLRipper {
 
     @Override
     public List<String> getURLsFromPage(Document doc) {
-        List<String> imageURLs = new ArrayList<>();
+        List<String> urlsToDownload = new ArrayList<>();
 
-        Elements thumbs = doc.select("img.thumbnail");
-        for (Element thumb : thumbs) {
-            String link = thumb.attr("src").replaceAll("thumbs/th_", "");
-            String imgSrc = "http://nude-gals.com/" + link;
-            imgSrc = imgSrc.replaceAll(" ", "%20");
-            imageURLs.add(imgSrc);
+        Pattern p;
+        Matcher m;
+
+        p = ALBUM_PATTERN;
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            logger.info("Found nude-gals photo album");
+            Elements thumbs = doc.select("img.thumbnail");
+            for (Element thumb : thumbs) {
+                String link = thumb.attr("src").strip().replaceAll("thumbs/th_", "");
+                String imgSrc = "http://nude-gals.com/" + link;
+                imgSrc = imgSrc.replaceAll(" ", "%20");
+                urlsToDownload.add(imgSrc);
+            }
         }
 
-        return imageURLs;
+        p = VIDEO_PATTERN;
+        m = p.matcher(url.toExternalForm());
+        if (m.matches()) {
+            logger.info("Found nude-gals video");
+            Elements thumbs = doc.select("video source");
+            for (Element thumb : thumbs) {
+                String link = thumb.attr("src").strip();
+                String videoSrc = "http://nude-gals.com/" + link;
+                videoSrc = videoSrc.replaceAll(" ", "%20");
+                urlsToDownload.add(videoSrc);
+            }
+        }
+
+        return urlsToDownload;
     }
 
     @Override

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NudeGalsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NudeGalsRipper.java
@@ -45,13 +45,13 @@ public class NudeGalsRipper extends AbstractHTMLRipper {
         p = ALBUM_PATTERN;
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
-            return m.group(1);
+            return "album_" + m.group(1);
         }
 
         p = VIDEO_PATTERN;
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
-            return m.group(1);
+            return "video_" + m.group(1);
         }
 
         throw new MalformedURLException(

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/NudeGalsRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/NudeGalsRipper.java
@@ -45,12 +45,14 @@ public class NudeGalsRipper extends AbstractHTMLRipper {
         p = ALBUM_PATTERN;
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
+            logger.info("Found nude-gals photo album page");
             return "album_" + m.group(1);
         }
 
         p = VIDEO_PATTERN;
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
+            logger.info("Found nude-gals video page");
             return "video_" + m.group(1);
         }
 
@@ -70,7 +72,7 @@ public class NudeGalsRipper extends AbstractHTMLRipper {
         p = ALBUM_PATTERN;
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
-            logger.info("Found nude-gals photo album");
+            logger.info("Ripping nude-gals photo album");
             Elements thumbs = doc.select("img.thumbnail");
             for (Element thumb : thumbs) {
                 String link = thumb.attr("src").strip().replaceAll("thumbs/th_", "");
@@ -83,7 +85,7 @@ public class NudeGalsRipper extends AbstractHTMLRipper {
         p = VIDEO_PATTERN;
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
-            logger.info("Found nude-gals video");
+            logger.info("Ripping nude-gals video");
             Elements thumbs = doc.select("video source");
             for (Element thumb : thumbs) {
                 String link = thumb.attr("src").strip();

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NudeGalsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NudeGalsRipperTest.java
@@ -27,12 +27,12 @@ public class NudeGalsRipperTest extends RippersTest {
     @Test
     public void testGetAlbumGID() throws IOException, URISyntaxException {
         NudeGalsRipper ripper = new NudeGalsRipper(new URI(ALBUM_TEST_URL).toURL());
-        Assertions.assertEquals("5541", ripper.getGID( new URI(ALBUM_TEST_URL).toURL()));
+        Assertions.assertEquals("album_5541", ripper.getGID( new URI(ALBUM_TEST_URL).toURL()));
     }
 
     @Test
     public void testGetVideoGID() throws IOException, URISyntaxException {
         NudeGalsRipper ripper = new NudeGalsRipper(new URI(VIDEO_TEST_URL).toURL());
-        Assertions.assertEquals("5541", ripper.getGID(new URI(VIDEO_TEST_URL).toURL()));
+        Assertions.assertEquals("video_1277", ripper.getGID(new URI(VIDEO_TEST_URL).toURL()));
     }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NudeGalsRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/NudeGalsRipperTest.java
@@ -9,15 +9,30 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class NudeGalsRipperTest extends RippersTest {
+    private static String ALBUM_TEST_URL = "https://nude-gals.com/photoshoot.php?photoshoot_id=5541";
+    private static String VIDEO_TEST_URL = "https://nude-gals.com/video.php?video_id=1277";
+
     @Test
-    public void testRip() throws IOException, URISyntaxException {
-        NudeGalsRipper ripper = new NudeGalsRipper(new URI("https://nude-gals.com/photoshoot.php?photoshoot_id=5541").toURL());
+    public void testAlbumRip() throws IOException, URISyntaxException {
+        NudeGalsRipper ripper = new NudeGalsRipper(new URI(ALBUM_TEST_URL).toURL());
         testRipper(ripper);
     }
 
     @Test
-    public void testGetGID() throws IOException, URISyntaxException {
-        NudeGalsRipper ripper = new NudeGalsRipper(new URI("https://nude-gals.com/photoshoot.php?photoshoot_id=5541").toURL());
-        Assertions.assertEquals("5541", ripper.getGID( new URI("https://nude-gals.com/photoshoot.php?photoshoot_id=5541").toURL()));
+    public void testVideoRip() throws IOException, URISyntaxException {
+        NudeGalsRipper ripper = new NudeGalsRipper(new URI(VIDEO_TEST_URL).toURL());
+        testRipper(ripper);
+    }
+
+    @Test
+    public void testGetAlbumGID() throws IOException, URISyntaxException {
+        NudeGalsRipper ripper = new NudeGalsRipper(new URI(ALBUM_TEST_URL).toURL());
+        Assertions.assertEquals("5541", ripper.getGID( new URI(ALBUM_TEST_URL).toURL()));
+    }
+
+    @Test
+    public void testGetVideoGID() throws IOException, URISyntaxException {
+        NudeGalsRipper ripper = new NudeGalsRipper(new URI(VIDEO_TEST_URL).toURL());
+        Assertions.assertEquals("5541", ripper.getGID(new URI(VIDEO_TEST_URL).toURL()));
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Added support for nude-gals.com video pages like https://nude-gals.com/video.php?video_id=1277 (NSFW)


# Testing

Required verification:
* [x] I've verified that there are no regressions in `mvn test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
