### PR TITLE
added audio post downloading support for tumblr + test

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TumblrRipper.java
@@ -144,7 +144,7 @@ public class TumblrRipper extends AlbumRipper {
         if (albumType == ALBUM_TYPE.POST) {
             mediaTypes = new String[] { "post" };
         } else {
-            mediaTypes = new String[] { "photo", "video" };
+            mediaTypes = new String[] { "photo", "video", "audio" };
         }
 
         int offset;
@@ -293,6 +293,23 @@ public class TumblrRipper extends AlbumRipper {
                 } catch (Exception e) {
                     logger.error("[!] Error while parsing video in " + post, e);
                     return true;
+                }
+            } else if (post.has("audio_url")) {
+                try {
+                    fileURL = new URI(post.getString("audio_url").replaceAll("http:", "https:")).toURL();
+                    downloadURL(fileURL, date);
+                } catch (Exception e) {
+                    logger.error("[!] Error while parsing audio in " + post, e);
+                    return true;
+                }
+                if (post.has("album_art")) {
+                    try {
+                        fileURL = new URI(post.getString("album_art").replaceAll("http:", "https:")).toURL();
+                        downloadURL(fileURL, date);
+                    } catch (Exception e) {
+                        logger.error("[!] Error while parsing album art in " + post, e);
+                        return true;
+                    }
                 }
             } else if (post.has("body")) {
                 Document d = Jsoup.parse(post.getString("body"));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TumblrRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TumblrRipperTest.java
@@ -39,4 +39,9 @@ public class TumblrRipperTest extends RippersTest {
                 new URI("https://these-are-my-b-sides.tumblr.com/post/178225921524/this-was-fun").toURL());
         testRipper(ripper);
     }
+    @Test
+    public void testTumblrAudioRip() throws IOException, URISyntaxException {
+        TumblrRipper ripper = new TumblrRipper(new URI("https://pilotredsun.tumblr.com/post/117939380846/march-2015").toURL());
+        testRipper(ripper);
+    }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following:
* [ ] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [x] a new feature
    * Tumblr audio download


# Description

I've added support for batch downloading audio in Tumblr posts.

# Testing

Required verification:
* [x] I've verified that there are no regressions in `gradlew test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
```
./gradlew testAll --tests TumblrRipperTest.testTumblrAudioRip
```
