### PR TITLE
ChanRipper: Add a delay before downloading videos to avoid rate limiting related to specifically videos (fixes #2049)

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -279,8 +279,16 @@ public class ChanRipper extends AbstractHTMLRipper {
         return imageURLs;
     }
 
+    private boolean isVideo(URL url) {
+        String urlString = url.toExternalForm();
+        return urlString.endsWith(".webm") || urlString.endsWith(".mp4");
+    }
+
     @Override
     public void downloadURL(URL url, int index) {
+        if (isVideo(url)) {
+            sleep(1000);
+        }
         addURLToDownload(url, getPrefix(index));
     }
 }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ChanRipper.java
@@ -287,7 +287,7 @@ public class ChanRipper extends AbstractHTMLRipper {
     @Override
     public void downloadURL(URL url, int index) {
         if (isVideo(url)) {
-            sleep(1000);
+            sleep(5000);
         }
         addURLToDownload(url, getPrefix(index));
     }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #2049)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fix downloading 4chan threads that contain videos by adding a delay to avoid rate limiting.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `gradlew test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
