### PR TITLE
Add a ScrollView to hold the list of supported sites in the About dialog (Fixes #2104)

### DIFF
--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1125,10 +1125,9 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         trayMenuMain.addActionListener(arg0 -> toggleTrayClick());
         MenuItem trayMenuAbout = new MenuItem("About " + mainFrame.getTitle());
         trayMenuAbout.addActionListener(arg0 -> {
-            StringBuilder about = new StringBuilder();
-
             try {
-                List<String> rippers = Utils.getListOfAlbumRippers();
+                List<String> albumRippers = Utils.getListOfAlbumRippers();
+                List<String> videoRippers = Utils.getListOfVideoRippers();
 
                 JTextArea aboutTextArea = new JTextArea();
                 aboutTextArea.setEditable(false);
@@ -1140,7 +1139,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
 
                 StringBuilder aboutContent = new StringBuilder();
                 aboutContent.append("Download albums from various websites:\n");
-                for (String ripper : rippers) {
+                for (String ripper : albumRippers) {
                     ripper = ripper.substring(ripper.lastIndexOf('.') + 1);
                     if (ripper.contains("Ripper")) {
                         ripper = ripper.substring(0, ripper.indexOf("Ripper"));
@@ -1148,40 +1147,29 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                     aboutContent.append("- ").append(ripper).append("\n");
                 }
 
-                aboutTextArea.setText(aboutContent.toString());
-                JOptionPane.showMessageDialog(null, scrollPane, "Supported Rippers", JOptionPane.INFORMATION_MESSAGE);
-            } catch (Exception e) {
-                LOGGER.warn(e.getMessage());
-            }
-
-            about.append("<br>And download videos from video sites:");
-            try {
-                List<String> rippers = Utils.getListOfVideoRippers();
-                about.append("<ul>");
-                for (String ripper : rippers) {
-                    about.append("<li>");
+                aboutContent.append("\nDownload videos from video sites:\n");
+                for (String ripper : videoRippers) {
                     ripper = ripper.substring(ripper.lastIndexOf('.') + 1);
                     if (ripper.contains("Ripper")) {
                         ripper = ripper.substring(0, ripper.indexOf("Ripper"));
                     }
-                    about.append(ripper);
-                    about.append("</li>");
+                    aboutContent.append("- ").append(ripper).append("\n");
                 }
-                about.append("</ul>");
+
+                aboutContent.append("\nDo you want to visit the project homepage on Github?");
+                aboutTextArea.setText(aboutContent.toString());
+
+                int response = JOptionPane.showConfirmDialog(null, scrollPane, mainFrame.getTitle(),
+                        JOptionPane.YES_NO_OPTION, JOptionPane.PLAIN_MESSAGE, new ImageIcon(mainIcon));
+                if (response == JOptionPane.YES_OPTION) {
+                    try {
+                        Desktop.getDesktop().browse(URI.create("http://github.com/ripmeapp/ripme"));
+                    } catch (IOException e) {
+                        LOGGER.error("Exception while opening project home page", e);
+                    }
+                }
             } catch (Exception e) {
                 LOGGER.warn(e.getMessage());
-            }
-
-            about.append("Do you want to visit the project homepage on Github?");
-            about.append("</html>");
-            int response = JOptionPane.showConfirmDialog(null, about.toString(), mainFrame.getTitle(),
-                    JOptionPane.YES_NO_OPTION, JOptionPane.PLAIN_MESSAGE, new ImageIcon(mainIcon));
-            if (response == JOptionPane.YES_OPTION) {
-                try {
-                    Desktop.getDesktop().browse(URI.create("http://github.com/ripmeapp/ripme"));
-                } catch (IOException e) {
-                    LOGGER.error("Exception while opening project home page", e);
-                }
             }
         });
 

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1156,7 +1156,6 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                     aboutContent.append("- ").append(ripper).append("\n");
                 }
 
-                aboutContent.append("\nDo you want to visit the project homepage on Github?");
                 aboutTextArea.setText(aboutContent.toString());
 
                 // Ensure the scroll pane starts at the top
@@ -1167,6 +1166,9 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD, 16));
                 aboutPanel.add(titleLabel, BorderLayout.NORTH);
                 aboutPanel.add(scrollPane, BorderLayout.CENTER);
+
+                JLabel footerLabel = new JLabel("Do you want to visit the project homepage on Github?", JLabel.CENTER);
+                aboutPanel.add(footerLabel, BorderLayout.SOUTH);
 
                 int response = JOptionPane.showConfirmDialog(null, aboutPanel, mainFrame.getTitle(),
                         JOptionPane.YES_NO_OPTION, JOptionPane.PLAIN_MESSAGE, new ImageIcon(mainIcon));

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1159,7 +1159,16 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 aboutContent.append("\nDo you want to visit the project homepage on Github?");
                 aboutTextArea.setText(aboutContent.toString());
 
-                int response = JOptionPane.showConfirmDialog(null, scrollPane, mainFrame.getTitle(),
+                // Ensure the scroll pane starts at the top
+                SwingUtilities.invokeLater(() -> scrollPane.getVerticalScrollBar().setValue(0));
+
+                JPanel aboutPanel = new JPanel(new BorderLayout());
+                JLabel titleLabel = new JLabel("Download albums and videos from various websites", JLabel.CENTER);
+                titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD, 16));
+                aboutPanel.add(titleLabel, BorderLayout.NORTH);
+                aboutPanel.add(scrollPane, BorderLayout.CENTER);
+
+                int response = JOptionPane.showConfirmDialog(null, aboutPanel, mainFrame.getTitle(),
                         JOptionPane.YES_NO_OPTION, JOptionPane.PLAIN_MESSAGE, new ImageIcon(mainIcon));
                 if (response == JOptionPane.YES_OPTION) {
                     try {

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1167,7 +1167,7 @@ public final class MainWindow implements Runnable, RipStatusHandler {
                 aboutPanel.add(titleLabel, BorderLayout.NORTH);
                 aboutPanel.add(scrollPane, BorderLayout.CENTER);
 
-                JLabel footerLabel = new JLabel("Do you want to visit the project homepage on Github?", JLabel.CENTER);
+                JLabel footerLabel = new JLabel("Do you want to visit the project homepage on GitHub?", JLabel.CENTER);
                 aboutPanel.add(footerLabel, BorderLayout.SOUTH);
 
                 int response = JOptionPane.showConfirmDialog(null, aboutPanel, mainFrame.getTitle(),

--- a/src/main/java/com/rarchives/ripme/ui/MainWindow.java
+++ b/src/main/java/com/rarchives/ripme/ui/MainWindow.java
@@ -1127,21 +1127,29 @@ public final class MainWindow implements Runnable, RipStatusHandler {
         trayMenuAbout.addActionListener(arg0 -> {
             StringBuilder about = new StringBuilder();
 
-            about.append("<html><h1>").append(mainFrame.getTitle()).append("</h1>");
-            about.append("Download albums from various websites:");
             try {
                 List<String> rippers = Utils.getListOfAlbumRippers();
-                about.append("<ul>");
+
+                JTextArea aboutTextArea = new JTextArea();
+                aboutTextArea.setEditable(false);
+                aboutTextArea.setLineWrap(true);
+                aboutTextArea.setWrapStyleWord(true);
+
+                JScrollPane scrollPane = new JScrollPane(aboutTextArea);
+                scrollPane.setPreferredSize(new Dimension(400, 300));
+
+                StringBuilder aboutContent = new StringBuilder();
+                aboutContent.append("Download albums from various websites:\n");
                 for (String ripper : rippers) {
-                    about.append("<li>");
                     ripper = ripper.substring(ripper.lastIndexOf('.') + 1);
                     if (ripper.contains("Ripper")) {
                         ripper = ripper.substring(0, ripper.indexOf("Ripper"));
                     }
-                    about.append(ripper);
-                    about.append("</li>");
+                    aboutContent.append("- ").append(ripper).append("\n");
                 }
-                about.append("</ul>");
+
+                aboutTextArea.setText(aboutContent.toString());
+                JOptionPane.showMessageDialog(null, scrollPane, "Supported Rippers", JOptionPane.INFORMATION_MESSAGE);
             } catch (Exception e) {
                 LOGGER.warn(e.getMessage());
             }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #2104)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

The "about" dialog accessible from the system tray icon had too much content without a scrollview that made the dialog too tall. This changes it so that the long list of sites supported is inside of a scrollview.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `gradlew test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
