### PR TITLE
Update CfakeRipper to new site format (Fixes #2116)

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CfakeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CfakeRipper.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import com.rarchives.ripme.utils.Http;
@@ -31,7 +32,7 @@ public class CfakeRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("https?://cfake\\.com/(?:picture|images/celebrity)/([a-zA-Z1-9_-]*)/\\d+/?$");
+        Pattern p = Pattern.compile("https?://cfake\\.com/images/celebrity/([a-zA-Z1-9_-]*)/\\d+/?$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);
@@ -49,13 +50,26 @@ public class CfakeRipper extends AbstractHTMLRipper {
     @Override
     public Document getNextPage(Document doc) throws IOException {
         // We use comic-nav-next to the find the next page
-        Element elem = doc.select("td > div.next > a").first();
+        Element elem = doc.select("div#wrapper_path div#content_path div#num_page").last();
         if (elem == null) {
-            throw new IOException("No more pages");
+            throw new IOException("No more pages (cannot find nav)");
         }
-        String nextPage = elem.attr("href");
-        // Some times this returns a empty string
-        // This for stops that
+
+        Element nextAnchor = elem.select("a").first();
+        if (nextAnchor == null) {
+            throw new IOException("No more pages (cannot find anchor)");
+        }
+
+        Elements nextSpans = nextAnchor.select("span");
+        if (nextSpans.isEmpty()) {
+            // This is the expected case that we're done iterating.
+            throw new IOException("No more pages (last page)");
+        }
+
+        // Use the nextAnchor (parent of the span) for the URL
+        String nextPage = nextAnchor.attr("href");
+
+        // Sometimes this returns an empty string; this stops that
         if (nextPage.equals("")) {
             return null;
         } else {
@@ -66,17 +80,15 @@ public class CfakeRipper extends AbstractHTMLRipper {
     @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> result = new ArrayList<>();
-        for (Element el : doc.select("table.display > tbody > tr > td > table > tbody > tr > td > a")) {
-            if (el.attr("href").contains("upload")) {
-                return result;
-            } else {
-                String imageSource = el.select("img").attr("src");
-                // We remove the .md from images so we download the full size image
-                // not the thumbnail ones
-                imageSource = imageSource.replace("thumbs", "photos");
-                result.add("http://cfake.com" + imageSource);
-            }
+        for (Element el : doc.select("div#media_content .responsive .gallery > a img")) {
+            // Convert found src value e.g. /medias/thumbs/2025/17358722979850276d_cfake.jpg
+            // to photo src value e.g.
+            // https://cfake.com/medias/photos/2025/17358722979850276d_cfake.jpg
+            String imageSource = el.attr("src");
+            imageSource = imageSource.replace("thumbs", "photos");
+            result.add("http://cfake.com" + imageSource);
         }
+
         return result;
     }
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CfakeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CfakeRipper.java
@@ -49,7 +49,6 @@ public class CfakeRipper extends AbstractHTMLRipper {
 
     @Override
     public Document getNextPage(Document doc) throws IOException {
-        // We use comic-nav-next to the find the next page
         Element elem = doc.select("div#wrapper_path div#content_path div#num_page").last();
         if (elem == null) {
             throw new IOException("No more pages (cannot find nav)");

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/CfakeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/CfakeRipper.java
@@ -73,7 +73,7 @@ public class CfakeRipper extends AbstractHTMLRipper {
         if (nextPage.equals("")) {
             return null;
         } else {
-            return Http.url("http://cfake.com" + nextPage).get();
+            return Http.url("https://cfake.com" + nextPage).get();
         }
     }
 
@@ -86,7 +86,7 @@ public class CfakeRipper extends AbstractHTMLRipper {
             // https://cfake.com/medias/photos/2025/17358722979850276d_cfake.jpg
             String imageSource = el.attr("src");
             imageSource = imageSource.replace("thumbs", "photos");
-            result.add("http://cfake.com" + imageSource);
+            result.add("https://cfake.com" + imageSource);
         }
 
         return result;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CfakeRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CfakeRipperTest.java
@@ -4,11 +4,15 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.junit.jupiter.api.Test;
+
 import com.rarchives.ripme.ripper.rippers.CfakeRipper;
 
 public class CfakeRipperTest extends RippersTest {
+    @Test
     public void testRip() throws IOException, URISyntaxException {
-        CfakeRipper ripper = new CfakeRipper(new URI("https://cfake.com/images/celebrity/Zooey_Deschanel/1264").toURL());
+        CfakeRipper ripper = new CfakeRipper(
+                new URI("https://cfake.com/images/celebrity/Zooey_Deschanel/1264").toURL());
         testRipper(ripper);
     }
 }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CfakeRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/CfakeRipperTest.java
@@ -8,7 +8,7 @@ import com.rarchives.ripme.ripper.rippers.CfakeRipper;
 
 public class CfakeRipperTest extends RippersTest {
     public void testRip() throws IOException, URISyntaxException {
-        CfakeRipper ripper = new CfakeRipper(new URI("http://cfake.com/picture/Zooey_Deschanel/1264").toURL());
+        CfakeRipper ripper = new CfakeRipper(new URI("https://cfake.com/images/celebrity/Zooey_Deschanel/1264").toURL());
         testRipper(ripper);
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #2116)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Cfake site changed URL and layout. This PR fixes the ripper to align with the new site layout.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `gradlew test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
