### PR TITLE
Update HentaiimageRipper for new URL (Fixes #2122)

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiimageRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/HentaiimageRipper.java
@@ -1,10 +1,5 @@
 package com.rarchives.ripme.ripper.rippers;
 
-import com.rarchives.ripme.ripper.AbstractHTMLRipper;
-import com.rarchives.ripme.utils.Http;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -13,10 +8,13 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import com.rarchives.ripme.ripper.AbstractHTMLRipper;
+import com.rarchives.ripme.utils.Http;
 
 public class HentaiimageRipper extends AbstractHTMLRipper {
-
-
     public HentaiimageRipper(URL url) throws IOException {
         super(url);
     }
@@ -43,13 +41,13 @@ public class HentaiimageRipper extends AbstractHTMLRipper {
 
     @Override
     public String getGID(URL url) throws MalformedURLException {
-        Pattern p = Pattern.compile("https://(?:\\w\\w\\.)?hentai-(image|comic).com/image/([a-zA-Z0-9_-]+)/?");
+        Pattern p = Pattern.compile("https://(?:\\w\\w\\.)?hentai-(image|comic|img-xxx).com/image/([a-zA-Z0-9_-]+)/?");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             return m.group(1);
         }
         throw new MalformedURLException("Expected hitomi URL format: " +
-                "https://hentai-image.com/image/ID - got " + url + " instead");
+                "https://hentai-img-xxx.com/image/ID - got " + url + " instead");
     }
 
     @Override

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaiimageRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HentaiimageRipperTest.java
@@ -4,17 +4,15 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import com.rarchives.ripme.ripper.rippers.HentaiimageRipper;
-import com.rarchives.ripme.utils.Utils;
 import org.junit.jupiter.api.Test;
+
+import com.rarchives.ripme.ripper.rippers.HentaiimageRipper;
 
 public class HentaiimageRipperTest extends RippersTest {
     @Test
     public void testHentaifoundryRip() throws IOException, URISyntaxException {
-        if (Utils.getConfigBoolean("test.run_flaky_tests", false)) {
-            HentaiimageRipper ripper = new HentaiimageRipper(new URI("https://hentai-image.com/image/afrobull-gerudo-ongoing-12/").toURL());
-            testRipper(ripper);
-        }
+        HentaiimageRipper ripper = new HentaiimageRipper(
+                new URI("https://hentai-img-xxx.com/image/afrobull-gerudo-ongoing-12/").toURL());
+        testRipper(ripper);
     }
 }
-


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #...)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

The URL changed. Updated the ripper and test.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `gradlew test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
