### PR TITLE
Ethan

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/DribbbleRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/DribbbleRipper.java
@@ -55,11 +55,34 @@ public class DribbbleRipper extends AbstractHTMLRipper {
     @Override
     public List<String> getURLsFromPage(Document doc) {
         List<String> imageURLs = new ArrayList<>();
-        for (Element thumb : doc.select("a.dribbble-link > picture > source")) {
-            // nl skips thumbnails
-            if ( thumb.attr("srcset").contains("teaser")) continue;
-            String image = thumb.attr("srcset").replace("_1x", "");
-            imageURLs.add(image);
+        for (Element thumbLink : doc.select("a.dribbble-link")) {
+            // Resolve the absolute shot page URL
+            String shotPage = thumbLink.absUrl("href");
+            if (shotPage.isEmpty()) {
+                continue;
+            }
+
+            // Fetch the shot page
+            Document shotDoc;
+            try {
+                shotDoc = Http.url(shotPage).get();
+            } catch (IOException e) {
+                continue;
+            }
+
+            // Grab the first <img> (the full-size image) on that page
+            Element imageEl = shotDoc.selectFirst("div.shot-page-container img");
+            if (imageEl == null) {
+                continue;
+            }
+
+            // Always use absUrl so you get a complete URI or an empty string
+            String imageURL = imageEl.absUrl("src");
+            if (imageURL.isEmpty()) {
+                continue;
+            }
+
+            imageURLs.add(imageURL);
         }
         return imageURLs;
     }

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DribbbleRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DribbbleRipperTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 public class DribbbleRipperTest extends RippersTest {
     @Test
-    @Disabled("test or ripper broken")
     public void testDribbbleRip() throws IOException, URISyntaxException {
         DribbbleRipper ripper = new DribbbleRipper(new URI("https://dribbble.com/typogriff").toURL());
         testRipper(ripper);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #2120 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

I went to https://dribbble.com/typogriff to figure out what changed on the website. I used inspect to investigate the images on the website. I found out that each thumbnail image was actually a link to a dedicated webpage with the full image. On that dedicated webpage, there was a link to the image address. Going back to the code, I had to scrap the old system. The old system involved grabbing the image addresses directly from the main page. Once finishing my implementation, the new system involved grabbing the link to the dedicated webpage for each thumbnail, opening the link, then grabbing the image address within each webpage.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `gradlew test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
