### PR TITLE
Fixes to Hypnohub Ripper

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HypnohubRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/HypnohubRipperTest.java
@@ -6,32 +6,32 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.rarchives.ripme.ripper.rippers.HypnohubRipper;
 
 public class HypnohubRipperTest extends RippersTest {
+    private static final String POOL_URL = "https://hypnohub.net/index.php?page=pool&s=show&id=6717";
+    private static final String POST_URL = "https://hypnohub.net/index.php?page=post&s=view&id=234499&pool_id=6717";
+
     @Test
-    @Disabled("wants a human")
-    public void testRip() throws IOException, URISyntaxException {
-        URL poolURL = new URI("http://hypnohub.net/pool/show/2303").toURL();
-        URL postURL = new URI("http://hypnohub.net/post/show/63464/black_hair-bracelet-collar-corruption-female_only-")
-                .toURL();
-        HypnohubRipper ripper = new HypnohubRipper(poolURL);
-        testRipper(ripper);
-        ripper = new HypnohubRipper(postURL);
-        testRipper(ripper);
+    public void testRipPoolAndPost() throws IOException, URISyntaxException {
+        URL poolURL = new URI(POOL_URL).toURL();
+        HypnohubRipper poolRipper = new HypnohubRipper(poolURL);
+        testRipper(poolRipper);
+        URL postURL = new URI(POST_URL).toURL();
+        HypnohubRipper postRipper = new HypnohubRipper(postURL);
+        testRipper(postRipper);
     }
 
     @Test
     public void testGetGID() throws IOException, URISyntaxException {
-        URL poolURL = new URI("http://hypnohub.net/pool/show/2303").toURL();
-        HypnohubRipper ripper = new HypnohubRipper(poolURL);
-        Assertions.assertEquals("2303", ripper.getGID(poolURL));
+        URL poolURL = new URI(POOL_URL).toURL();
+        HypnohubRipper poolRipper = new HypnohubRipper(poolURL);
+        Assertions.assertEquals("6717", poolRipper.getGID(poolURL));
 
-        URL postURL = new URI("http://hypnohub.net/post/show/63464/black_hair-bracelet-collar-corruption-female_only-")
-                .toURL();
-        Assertions.assertEquals("63464_black_hair-bracelet-collar-corruption-female_only-", ripper.getGID(postURL));
+        URL postURL = new URI(POST_URL).toURL();
+        HypnohubRipper postRipper = new HypnohubRipper(postURL);
+        Assertions.assertEquals("post&s=view&id=234499&pool_id=6717", postRipper.getGID(postURL));
     }
 }


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #2125 )
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description
Fixed HypnoHub ripper to work with the new url format. Modified the requisite unit test case for the ripper.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `gradlew test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.
