### PR TITLE
Fix EromeRipper doesn't correctly download albums that are a mix of images and video (Fixes #2121)

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/EromeRipper.java
@@ -48,7 +48,7 @@ public class EromeRipper extends AbstractHTMLRipper {
 
     @Override
     public void downloadURL(URL url, int index) {
-        addURLToDownload(url, getPrefix(index), "", "erome.com", this.cookies);
+        addURLToDownload(url, getPrefix(index), "", this.url.toString(), this.cookies);
     }
 
     @Override

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EromeRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/EromeRipperTest.java
@@ -51,7 +51,7 @@ public class EromeRipperTest extends RippersTest {
     @Test
     @Tag("slow")
     public void testVideoAlbumRip() throws IOException, URISyntaxException {
-        URL url = new URI("https://www.erome.com/a/P0x5Ambn").toURL();
+        URL url = new URI("https://www.erome.com/a/jEUFu6pi").toURL();
         EromeRipper ripper = new EromeRipper(url);
         testRipper(ripper);
     }


### PR DESCRIPTION


# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #2121)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Fixed EromeRipper to correctly download video URLs by using `this.url.toString()` instead of hardcoded "erome.com". Also changed test to use a working video album link.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `gradlew test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [x] I've added a unit test to cover my change.