### PR TITLE
Fix BooruRipper 'URI is not absolute' error for gelbooru #2115

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/BooruRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/BooruRipper.java
@@ -99,9 +99,11 @@ public class BooruRipper extends AbstractHTMLRipper {
     @Override
     public String getGID(URL url) throws MalformedURLException {
         try {
-            return Utils.filesystemSafe(new URI(getTerm(url).replaceAll("&tags=", "")).getPath());
-        } catch (URISyntaxException ex) {
-            logger.error(ex);
+            // Get the search term and make it filesystem safe
+            String term = getTerm(url).replaceAll("&tags=", "");
+            return Utils.filesystemSafe(term);
+        } catch (Exception ex) {
+            logger.error("Error getting GID from URL: " + url, ex);
         }
 
         throw new MalformedURLException("Expected xbooru.com URL format: " + getHost() + ".com/index.php?tags=searchterm - got " + url + " instead");


### PR DESCRIPTION
## Summary
- Fix the "URI is not absolute" error in BooruRipper when processing gelbooru URLs
- Replace problematic URI creation with direct string processing in getGID() method
- Maintains compatibility with xbooru which was already working
- Improves error logging with more context

## Issue
Fixes #2115 - BooruRipper was partially not working (xbooru works, gelbooru doesn't) due to a URISyntaxException when trying to create a URI from search terms.

## Root Cause
The `getGID()` method was trying to create a URI from search terms (like "animal_ears") using `new URI(term).getPath()`, which threw `URISyntaxException: URI is not absolute` because search terms are not valid absolute URIs.

## Solution
- Simplified the `getGID()` method to directly process the search term string
- Removed the problematic URI creation logic
- Used `Utils.filesystemSafe()` directly on the search term
- Enhanced error logging with more context

## Testing
- ✅ Unit tests pass for both gelbooru and xbooru
- ✅ Manual verification confirms both sites now work correctly
- ✅ No regression in existing functionality

## Test plan
- Ran `testGetGID` - passes for both gelbooru and xbooru
- Ran `testGetDomain` - passes for both sites  
- Ran `testGetHost` - passes for both sites
- Created manual test program to verify fix works correctly
- Confirmed xbooru still works as before

🤖 Generated with [Claude Code](https://claude.ai/code)