### PR TITLE
Fix DribbbleRipper to get image URLs

### DIFF
--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DribbbleRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DribbbleRipperTest.java
@@ -5,12 +5,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import com.rarchives.ripme.ripper.rippers.DribbbleRipper;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class DribbbleRipperTest extends RippersTest {
     @Test
-    @Disabled("test or ripper broken")
     public void testDribbbleRip() throws IOException, URISyntaxException {
         DribbbleRipper ripper = new DribbbleRipper(new URI("https://dribbble.com/typogriff").toURL());
         testRipper(ripper);


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [x] a bug fix (Fix #2120)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

The site changed its layout, so the original logic for parsing image URLs no longer works. This PR updates the logic to get the largest image URL from the `<img>` element inside each `div.shot-thumbnail-base`.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `gradlew test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [ ] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (as necessary or appropriate).
  * [ ] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
