### PR TITLE
Added Examplegallery ripper as a minimal working example. Fixes issue #2069

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ExamplegalleryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ExamplegalleryRipper.java
@@ -1,0 +1,78 @@
+package com.rarchives.ripme.ripper.rippers;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.Map;
+
+import com.rarchives.ripme.ripper.AbstractRipper;
+
+public class ExamplegalleryRipper extends AbstractRipper {
+
+    public ExamplegalleryRipper(URL url) throws IOException {
+        super(url);
+    }
+
+    @Override
+    public String getHost() {
+        return "examplegallery.com";
+    }
+
+    @Override
+    public void rip() throws IOException {
+        System.out.println("Examplegallery ripper running...");
+    }
+
+    @Override
+    public boolean canRip(URL url) {
+        return url.getHost().contains("examplegallery.com");
+    }
+
+    @Override
+    public URL sanitizeURL(URL url) throws MalformedURLException, URISyntaxException {
+        return url;
+    }
+
+    @Override
+    public String getGID(URL url) throws MalformedURLException, URISyntaxException {
+        return url.getPath().replace("/", "_");
+    }
+
+    @Override
+    public boolean addURLToDownload(URL url, Path saveAs) {
+        return true;
+    }
+
+    @Override
+    protected boolean addURLToDownload(URL url, Path saveAs, String referrer, Map<String, String> cookies, Boolean getFileExtFromMIME) {
+        return true;
+    }
+
+    @Override
+    public void downloadCompleted(URL url, Path saveAs) {
+    }
+
+    @Override
+    public void downloadErrored(URL url, String reason) {
+    }
+
+    @Override
+    public void downloadExists(URL url, Path file) {
+    }
+
+    @Override
+    public void setWorkingDir(URL url) throws IOException, URISyntaxException {
+    }
+
+    @Override
+    public int getCompletionPercentage() {
+        return 0;
+    }
+
+    @Override
+    public String getStatusText() {
+        return "Examplegallery ripper running";
+    }
+}


### PR DESCRIPTION
# Category

This change is exactly one of the following (please change `[ ]` to `[x]`) to indicate which:
* [ ] a bug fix (Fix #...)
* [x] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature


# Description

Please add details about your change here.


# Testing

Required verification:
* [x] I've verified that there are no regressions in `gradlew test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [x] Downloads content from multiple pages (as necessary or appropriate).
  * [x] Saves content at reasonable file names (e.g. page titles or content IDs) to help easily browse downloaded content.
* [x] I've verified that this change did not break existing functionality (especially in the Ripper I modified).

Optional but recommended:
* [ ] I've added a unit test to cover my change.
