### PR TITLE
Fix ImagevenueRipper not working after site update

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ImagevenueRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ImagevenueRipper.java
@@ -100,8 +100,8 @@ public class ImagevenueRipper extends AbstractHTMLRipper {
                 Document doc = Http.url(url)
                                    .retries(3)
                                    .get();
-                // Find image
-                Elements images = doc.select("a > img");
+                // Find image (select <img> whose src contains "imagevenue")
+                Elements images = doc.select("img[src*=\"imagevenue\"]");
                 if (images.isEmpty()) {
                     logger.warn("Image not found at " + this.url);
                     return;


### PR DESCRIPTION
Updated image selector from "a > img" to match current Imagevenue HTML structure.

# Category

* [x] a bug fix (Fix #2126)
* [ ] a new Ripper
* [ ] a refactoring
* [ ] a style change/fix
* [ ] a new feature

# Description

Imagevenue has updated its HTML structure. The previous selector `a > img` no longer matches the image element.

Updated the selector to target the current `<img>` element directly (`img.mw-100`), allowing correct extraction of image URLs again.

# Testing

Required verification:
* [ ] I've verified that there are no regressions in `gradlew test` (there are no new failures or errors).
* [x] I've verified that this change works as intended.
  * [x] Downloads all relevant content.
  * [ ] Downloads content from multiple pages (not tested)
  * [x] Saves content with correct filenames
* [ ] I've verified that this change did not break existing functionality

Optional but recommended:
* [ ] I've added a unit test to cover my change.