### PR TITLE
Removed unused vars and imports in ripper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/BatoRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/BatoRipper.java
@@ -117,7 +117,6 @@ public class BatoRipper extends AbstractHTMLRipper {
                 logger.info("Script data: " + s);
 
                 Pattern p = Pattern.compile(".*imgHttps = (\\[\"[^\\];]*\"\\]);.*");
-                Matcher m = p.matcher(s);
                 String json = scanForImageList(p, s);
 
                 logger.info("JSON: " + json);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/BooruRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/BooruRipper.java
@@ -5,8 +5,6 @@ import com.rarchives.ripme.utils.Http;
 import com.rarchives.ripme.utils.Utils;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/ErofusRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/ErofusRipper.java
@@ -73,7 +73,6 @@ public class ErofusRipper extends AbstractHTMLRipper {
                         logger.info("Retrieving " + subUrl);
                         sendUpdate(RipStatusMessage.STATUS.LOADING_RESOURCE, subUrl);
                         Document subPage = Http.url(subUrl).get();
-                        List<String> subalbumImages = getURLsFromPage(subPage);
                     } catch (IOException e) {
                         logger.warn("Error while loading subalbum " + subUrl, e);
                     }

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaigalleryRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyhentaigalleryRipper.java
@@ -1,7 +1,6 @@
 package com.rarchives.ripme.ripper.rippers;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
-import com.rarchives.ripme.utils.Http;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/MyreadingmangaRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/MyreadingmangaRipper.java
@@ -2,7 +2,6 @@
 package com.rarchives.ripme.ripper.rippers;
 
 import com.rarchives.ripme.ripper.AbstractHTMLRipper;
-import com.rarchives.ripme.utils.Http;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RedditRipper.java
@@ -53,7 +53,7 @@ public class RedditRipper extends AlbumRipper {
         super(url);
     }
 
-    private static final String HOST   = "reddit";
+    private static final String HOST   = "reddit";  
     private static final String DOMAIN = "reddit.com";
 
     private static final String REDDIT_USER_AGENT = "RipMe:github.com/RipMeApp/ripme:" + UpdateUtils.getThisJarVersion() + " (by /u/metaprime and /u/ineedmorealts)";

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/RulePornRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/RulePornRipper.java
@@ -11,7 +11,6 @@ import java.util.regex.Pattern;
 import com.rarchives.ripme.ripper.AbstractSingleFileRipper;
 import org.jsoup.nodes.Document;
 
-import com.rarchives.ripme.utils.Http;
 
 public class RulePornRipper extends AbstractSingleFileRipper {
 

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SmuttyRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SmuttyRipper.java
@@ -17,8 +17,7 @@ import com.rarchives.ripme.utils.Http;
 
 public class SmuttyRipper extends AbstractHTMLRipper {
 
-    private static final String DOMAIN = "smutty.com",
-                                HOST   = "smutty";
+    private static final String DOMAIN = "smutty.com";
 
     public SmuttyRipper(URL url) throws IOException {
         super(url);

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/SoundgasmRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/SoundgasmRipper.java
@@ -17,7 +17,6 @@ import java.util.regex.Pattern;
 
 public class SoundgasmRipper extends AbstractHTMLRipper {
 
-    private static final String HOST = "soundgasm.net";
 
     public SoundgasmRipper(URL url) throws IOException, URISyntaxException {
         super(new URI(url.toExternalForm()).toURL());

--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TeenplanetRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TeenplanetRipper.java
@@ -12,7 +12,6 @@ import com.rarchives.ripme.ripper.AbstractHTMLRipper;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
-import com.rarchives.ripme.utils.Http;
 import com.rarchives.ripme.utils.Utils;
 
 public class TeenplanetRipper extends AbstractHTMLRipper {

--- a/src/main/java/com/rarchives/ripme/ui/ContextMenuMouseListener.java
+++ b/src/main/java/com/rarchives/ripme/ui/ContextMenuMouseListener.java
@@ -3,12 +3,8 @@ package com.rarchives.ripme.ui;
 import com.rarchives.ripme.uiUtils.ContextActionProtections;
 
 import java.awt.Toolkit;
-import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
-import java.awt.datatransfer.Transferable;
-import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.*;
-import java.io.IOException;
 
 import javax.swing.*;
 import javax.swing.text.JTextComponent;

--- a/src/main/java/com/rarchives/ripme/uiUtils/ContextActionProtections.java
+++ b/src/main/java/com/rarchives/ripme/uiUtils/ContextActionProtections.java
@@ -1,6 +1,5 @@
 package com.rarchives.ripme.uiUtils;
 
-import javax.swing.*;
 import javax.swing.text.JTextComponent;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DeviantartRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/DeviantartRipperTest.java
@@ -8,8 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.rarchives.ripme.ripper.rippers.DeviantartRipper;
-import com.rarchives.ripme.utils.Http;
-import org.jsoup.nodes.Document;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -49,9 +48,6 @@ public class DeviantartRipperTest extends RippersTest {
     @Test
     @Disabled("Broken ripper")
     public void testGetGalleryIDAndUsername() throws IOException, URISyntaxException {
-        URL url = new URI("https://www.deviantart.com/airgee/gallery/").toURL();
-        DeviantartRipper ripper = new DeviantartRipper(url);
-        Document doc = Http.url(url).get();
         // Had to comment because of refactoring/style change
         // assertEquals("airgee", ripper.getUsername(doc));
         // assertEquals("714589", ripper.getGalleryID(doc));

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FlickrRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/FlickrRipperTest.java
@@ -6,7 +6,6 @@ import java.net.URISyntaxException;
 
 import com.rarchives.ripme.ripper.rippers.FlickrRipper;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/JabArchivesRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/JabArchivesRipperTest.java
@@ -1,9 +1,5 @@
 package com.rarchives.ripme.tst.ripper.rippers;
 
-import java.io.IOException;
-import java.net.URL;
-
-import com.rarchives.ripme.ripper.rippers.JabArchivesRipper;
 
 public class JabArchivesRipperTest extends RippersTest {
     // TODO add a test

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/RedditRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/RedditRipperTest.java
@@ -84,8 +84,7 @@ public class RedditRipperTest extends RippersTest {
      */
     @Test
     public void testRedditGfycatRedirectURL() throws IOException, URISyntaxException {
-        RedditRipper ripper = new RedditRipper(
-                new URI("https://www.reddit.com/r/NSFW_GIF/comments/ennwsa/gorgeous_tits/").toURL());
+       
     }
 
     @Test

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SoundgasmRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/SoundgasmRipperTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 
 public class SoundgasmRipperTest extends RippersTest {
 

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VideoRippersTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/VideoRippersTest.java
@@ -45,10 +45,6 @@ public class VideoRippersTest extends RippersTest {
     public void testTwitchVideoRipper() throws IOException, URISyntaxException {
         List<URL> contentURLs = new ArrayList<>();
         contentURLs.add(new URI("https://clips.twitch.tv/FaithfulIncredulousPotTBCheesePull").toURL());
-        for (URL url : contentURLs) {
-            // TwitchVideoRipper ripper = new TwitchVideoRipper(url);
-            // videoTestHelper(ripper);
-        }
     }
 
     @Test


### PR DESCRIPTION
Removed unused local variables and imports identified by the IDE.

These changes do not affect functionality and are intended to improve code cleanliness and readability.