### PR TITLE
Add x.com URL support to TwitterRipper

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/TwitterRipper.java
@@ -58,7 +58,7 @@ public class TwitterRipper extends AbstractJSONRipper {
     @Override
     public URL sanitizeURL(URL url) throws MalformedURLException {
         // https://twitter.com/search?q=from%3Apurrbunny%20filter%3Aimages&src=typd
-        Pattern p = Pattern.compile("^https?://(m\\.)?twitter\\.com/search\\?(.*)q=(?<search>[a-zA-Z0-9%\\-_]+).*$");
+        Pattern p = Pattern.compile("^https?://(m\\.)?(?:twitter|x)\\.com/search\\?(.*)q=(?<search>[a-zA-Z0-9%\\-_]+).*$");
         Matcher m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             albumType = ALBUM_TYPE.SEARCH;
@@ -74,7 +74,7 @@ public class TwitterRipper extends AbstractJSONRipper {
             }
             return url;
         }
-        p = Pattern.compile("^https?://(m\\.)?twitter\\.com/([a-zA-Z0-9\\-_]+).*$");
+        p = Pattern.compile("^https?://(m\\.)?(?:twitter|x)\\.com/([a-zA-Z0-9\\-_]+).*$");
         m = p.matcher(url.toExternalForm());
         if (m.matches()) {
             albumType = ALBUM_TYPE.ACCOUNT;
@@ -205,6 +205,12 @@ public class TwitterRipper extends AbstractJSONRipper {
     @Override
     protected String getDomain() {
         return DOMAIN;
+    }
+
+    @Override
+    public boolean canRip(URL url) {
+        String host = url.getHost();
+        return host.endsWith("twitter.com") || host.endsWith("x.com");
     }
 
     @Override

--- a/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TwitterRipperTest.java
+++ b/src/test/java/com/rarchives/ripme/tst/ripper/rippers/TwitterRipperTest.java
@@ -25,4 +25,19 @@ public class TwitterRipperTest extends RippersTest {
         testRipper(ripper);
     }
 
+    @Test
+    @Tag("flaky")
+    public void testXComUserRip() throws IOException, URISyntaxException {
+        TwitterRipper ripper = new TwitterRipper(new URI("https://x.com/danngamber01/media").toURL());
+        testRipper(ripper);
+    }
+
+    @Test
+    @Tag("flaky")
+    public void testXComSearchRip() throws IOException, URISyntaxException {
+        TwitterRipper ripper = new TwitterRipper(
+                new URI("https://x.com/search?f=tweets&q=from%3Aalinalixxx%20filter%3Aimages&src=typd").toURL());
+        testRipper(ripper);
+    }
+
 }


### PR DESCRIPTION
## Description

This PR adds support for x.com URLs in the TwitterRipper, in addition to the existing twitter.com support. Since Twitter rebranded to X, many users share x.com URLs that previously failed to rip.

## Changes

- Updated `sanitizeURL` regex patterns to accept both `twitter.com` and `x.com` URLs using non-capturing groups `(?:twitter|x)`
- Added `canRip()` override to match both `twitter.com` and `x.com` hostnames
- Added x.com URL test cases for both user timeline and search ripping
- The Twitter API endpoints (`api.twitter.com`) remain unchanged since the API still uses twitter.com

## Testing

- Existing twitter.com tests continue to pass
- New x.com URL tests have been added (tagged as flaky, matching existing test conventions)
- URL parsing and group numbering verified to work correctly with non-capturing groups

Addresses the x.com support request from issue #2068