### PR TITLE
Fix typos in log messages

### DIFF
--- a/src/main/java/com/rarchives/ripme/ripper/rippers/PhotobucketRipper.java
+++ b/src/main/java/com/rarchives/ripme/ripper/rippers/PhotobucketRipper.java
@@ -257,7 +257,7 @@ public class PhotobucketRipper extends AbstractHTMLRipper {
                 metadata.add(new AlbumMetadata(sub));
             }
         }
-        logger.info("Succesfully retrieved and parsed metadata");
+        logger.info("Successfully retrieved and parsed metadata");
         return metadata;
     }
 

--- a/src/main/java/com/rarchives/ripme/utils/Utils.java
+++ b/src/main/java/com/rarchives/ripme/utils/Utils.java
@@ -742,7 +742,7 @@ public class Utils {
             }
         } else {
             String[] langCode = langSelect.split("-");
-            LOGGER.info("set locale, langcoe: {}, selected langauge: {}, locale: {}", langCode, langSelect, Locale.forLanguageTag(langSelect));
+            LOGGER.info("set locale, langCode: {}, selected language: {}, locale: {}", langCode, langSelect, Locale.forLanguageTag(langSelect));
             return ResourceBundle.getBundle("LabelsBundle", Locale.forLanguageTag(langSelect), new UTF8Control());
         }
         try {


### PR DESCRIPTION
Fixes small typos in user-visible log output: `langcoe`→`langCode`, `langauge`→`language` in Utils.java, and `Succesfully`→`Successfully` in PhotobucketRipper.java.